### PR TITLE
use average species omega in collisions

### DIFF
--- a/src/collide_vss.cpp
+++ b/src/collide_vss.cpp
@@ -442,6 +442,9 @@ void CollideVSS::EEXCHANGE_NonReactingEDisposal(Particle::OnePart *ip,
   } else {
     E_Dispose = precoln.etrans;
 
+    double aveomega = 0.5*(params[ip->ispecies].omega + 
+                           params[jp->ispecies].omega); 
+
     for (i = 0; i < 2; i++) {
       if (i == 0) p = ip; 
       else p = jp;
@@ -458,7 +461,7 @@ void CollideVSS::EEXCHANGE_NonReactingEDisposal(Particle::OnePart *ip,
           } else if (rotstyle != NONE && rotdof == 2) {
             E_Dispose += p->erot;
             Fraction_Rot = 
-              1- pow(random->uniform(),(1/(2.5-params[sp].omega)));
+              1- pow(random->uniform(),(1/(2.5-aveomega)));
             p->erot = Fraction_Rot * E_Dispose;
             E_Dispose -= p->erot;
           } else {
@@ -485,7 +488,7 @@ void CollideVSS::EEXCHANGE_NonReactingEDisposal(Particle::OnePart *ip,
             if (vibstyle == SMOOTH) {
               E_Dispose += p->evib;
               Fraction_Vib = 
-                1.0 - pow(random->uniform(),(1.0/(2.5-params[sp].omega)));
+                1.0 - pow(random->uniform(),(1.0/(2.5-aveomega)));
               p->evib= Fraction_Vib * E_Dispose;
               E_Dispose -= p->evib;
 
@@ -508,7 +511,7 @@ void CollideVSS::EEXCHANGE_NonReactingEDisposal(Particle::OnePart *ip,
               E_Dispose += p->evib;
               p->evib = E_Dispose * 
                 sample_bl(random,0.5*species[sp].vibdof-1.0,
-                          1.5-params[sp].omega);
+                          1.5-aveomega);
               E_Dispose -= p->evib;
               
             } else if (vibstyle == DISCRETE) {
@@ -531,7 +534,7 @@ void CollideVSS::EEXCHANGE_NonReactingEDisposal(Particle::OnePart *ip,
                     (random->uniform()*(max_level+AdjustFactor));
                   pevib = ivib * update->boltz * species[sp].vibtemp[imode];
                   State_prob = pow((1.0 - pevib / E_Dispose),
-                                   (1.5 - params[sp].omega));
+                                   (1.5 - aveomega));
                 } while (State_prob < random->uniform());
                 
                 vibmode[pindex][imode] = ivib;
@@ -627,7 +630,7 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
 {
   double State_prob,Fraction_Rot,Fraction_Vib;
   int i,numspecies,rotdof,vibdof,max_level,ivib,irot;
-  double pevib = 0.0;   
+  double aveomega,pevib;
 
   Particle::OnePart *p;
   Particle::Species *species = particle->species;
@@ -639,6 +642,7 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
     ip->evib = 0.0;
     jp->evib = 0.0;
     numspecies = 2;
+    aveomega = 0.5*(params[ip->ispecies].omega + params[jp->ispecies].omega); 
   } else {
     ip->erot = 0.0;
     jp->erot = 0.0;
@@ -647,6 +651,8 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
     jp->evib = 0.0;
     kp->evib = 0.0;
     numspecies = 3;
+    aveomega = (params[ip->ispecies].omega + params[jp->ispecies].omega + 
+                params[kp->ispecies].omega)/3;
   }
 
   // handle each kind of energy disposal for non-reacting reactants
@@ -667,14 +673,14 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
         p->erot = 0.0;
       } else if (rotdof == 2) {
         Fraction_Rot =
-          1- pow(random->uniform(),(1/(2.5-params[sp].omega)));
+          1- pow(random->uniform(),(1/(2.5-aveomega)));
         p->erot = Fraction_Rot * E_Dispose;
         E_Dispose -= p->erot;
         
       } else if (rotdof > 2) {
         p->erot = E_Dispose * 
           sample_bl(random,0.5*species[sp].rotdof-1.0,
-                    1.5-params[sp].omega);
+                    1.5-aveomega);
         E_Dispose -= p->erot;
       }
     }
@@ -693,20 +699,20 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
           p->evib = (double)
             (ivib * update->boltz * species[sp].vibtemp[0]);
           State_prob = pow((1.0 - p->evib / E_Dispose),
-                           (1.5 - params[sp].omega));
+                           (1.5 - aveomega));
         } while (State_prob < random->uniform());
         E_Dispose -= p->evib;
         
       } else if (vibdof == 2 && vibstyle == SMOOTH) {
         Fraction_Vib =
-          1.0 - pow(random->uniform(),(1.0 / (2.5-params[sp].omega)));
+          1.0 - pow(random->uniform(),(1.0 / (2.5-aveomega)));
         p->evib = Fraction_Vib * E_Dispose;
         E_Dispose -= p->evib;
 
       } else if (vibdof > 2 && vibstyle == SMOOTH) {
           p->evib = E_Dispose * 
           sample_bl(random,0.5*species[sp].vibdof-1.0,
-                   1.5-params[sp].omega);
+                   1.5-aveomega);
           E_Dispose -= p->evib;
       } else if (vibdof > 2 && vibstyle == DISCRETE) {
           p->evib = 0.0;
@@ -726,7 +732,7 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
               (random->uniform()*(max_level+AdjustFactor));
               pevib = ivib * update->boltz * species[sp].vibtemp[imode];
               State_prob = pow((1.0 - pevib / E_Dispose),
-                               (1.5 - params[sp].omega));
+                               (1.5 - aveomega));
             } while (State_prob < random->uniform());
 
             vibmode[pindex][imode] = ivib;

--- a/src/react.cpp
+++ b/src/react.cpp
@@ -34,7 +34,7 @@ React::React(SPARTA *sparta, int, char **arg) : Pointers(sparta)
 
   recombflag_user = 1;
   recomb_boost = 1000.0;
-  recomb_boost_inverse = 0.0001;
+  recomb_boost_inverse = 0.001;
 
   random = new RanPark(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();


### PR DESCRIPTION
## Purpose

Some reaction bug fixes, in particular to use the omega value averaged over species
in the reaction.

## Author(s)

Zhi-Hui Wang (University of Chinese Academy of Sciences (UCAS))
and Israel Borges Sebastiao (Purdue University) reported these bugs
and suggested changes.

## Backward Compatibility

Could change outputs for collisional flows.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


