### PR TITLE
bad indexing when some species have no Tvib

### DIFF
--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -662,7 +662,7 @@ template < int NEARCP > void Collide::collisions_group()
       for (jgroup = igroup; jgroup < ngroups; jgroup++) {
 	attempt = attempt_collision(icell,igroup,jgroup,volume);
 	nattempt = static_cast<int> (attempt);
-        
+
 	if (nattempt) {
 	  gpair[npair][0] = igroup;
 	  gpair[npair][1] = jgroup;

--- a/src/compute_tvib_grid.cpp
+++ b/src/compute_tvib_grid.cpp
@@ -401,23 +401,25 @@ double ComputeTvibGrid::post_process_grid(int index, int onecell, int nsample,
     for (int icell = lo; icell < hi; icell++) {
       evib = emap[0];
       count = evib+1;
-      
       for (isp = 0; isp < nsp; isp++) {
         ispecies = t2s[evib];
         theta = species[ispecies].vibtemp[0];
         if (theta == 0.0 || etally[icell][count] == 0.0) {
           tspecies[isp] = 0.0;
+          evib += 2;
+          count = evib+1;
           continue;
         }
         ibar = etally[icell][evib] / (etally[icell][count] * boltz * theta);
         if (ibar == 0.0) {
           tspecies[isp] = 0.0;
+          evib += 2;
+          count = evib+1;
           continue;
         }
         tspecies[isp] = theta / (log(1.0 + 1.0/ibar));
         //denom = boltz * etally[icell][count] * ibar * log(1.0 + 1.0/ibar);
         //tspecies[isp] = etally[icell][evib] / denom;
-        
         evib += 2;
         count = evib+1;
       }
@@ -457,17 +459,20 @@ double ComputeTvibGrid::post_process_grid(int index, int onecell, int nsample,
           theta = species[ispecies].vibtemp[imode];
           if (theta == 0.0 || etally[icell][count] == 0.0) {
             tspecies_mode[isp][imode] = 0.0;
+            evib += 2;
+            count = evib+1;
             continue;
           }
           ibar = etally[icell][evib] / etally[icell][count];
           if (ibar == 0.0) {
             tspecies_mode[isp][imode] = 0.0;
+            evib += 2;
+            count = evib+1;
             continue;
           }
           tspecies_mode[isp][imode] = theta / (log(1.0 + 1.0/ibar));
           //denom = boltz * etally[icell][count] * ibar * log(1.0 + 1.0/ibar);
           //tspecies_mode[isp][imode] = etally[icell][evib] / denom;
-        
           evib += 2;
           count = evib+1;
         }
@@ -511,17 +516,20 @@ double ComputeTvibGrid::post_process_grid(int index, int onecell, int nsample,
         theta = species[ispecies].vibtemp[imode];
         if (theta == 0.0 || etally[icell][count] == 0.0) {
           tspecies_mode[isp][imode] = 0.0;
+          evib += 2*maxmode;
+          count = evib+1;
           continue;
         }
         ibar = etally[icell][evib] / etally[icell][count];
         if (ibar == 0.0) {
           tspecies_mode[isp][imode] = 0.0;
+          evib += 2*maxmode;
+          count = evib+1;
           continue;
         }
         tspecies_mode[isp][imode] = theta / (log(1.0 + 1.0/ibar));
         //denom = boltz * etally[icell][count] * ibar * log(1.0 + 1.0/ibar);
         //tspecies_mode[isp][imode] = etally[icell][evib] / denom;
-        
         evib += 2*maxmode;
         count = evib+1;
       }


### PR DESCRIPTION
## Purpose

Fixed bug in compute tvib/grid with indexing into tally data structure.  Was giving invalid
temperatures with mutli-species groups when some species had no vibrational DOF.

## Author(s)

Steve

## Backward Compatibility

Will change answers for per-grid-cell Tvib values. 

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


