### PR TITLE
2 indexing typos in grid group definition

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1867,7 +1867,7 @@ void Grid::group(int narg, char **arg)
         x[0] = cells[i].lo[0];
         x[1] = cells[i].hi[1];
         if (!region->match(x)) flag = 0;
-        x[0] = cells[i].hi[1];
+        x[0] = cells[i].hi[0];
         x[1] = cells[i].hi[1];
         if (!region->match(x)) flag = 0;
 
@@ -1904,7 +1904,7 @@ void Grid::group(int narg, char **arg)
         x[0] = cells[i].lo[0];
         x[1] = cells[i].hi[1];
         if (region->match(x)) flag = 1;
-        x[0] = cells[i].hi[1];
+        x[0] = cells[i].hi[0];
         x[1] = cells[i].hi[1];
         if (region->match(x)) flag = 1;
 


### PR DESCRIPTION
## Purpose

Fix two small indexing bugs in defining a grid group.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


