### PR TITLE
Fix overflow issue with large grids

### DIFF
--- a/src/create_grid.cpp
+++ b/src/create_grid.cpp
@@ -180,7 +180,8 @@ void CreateGrid::command(int narg, char **arg)
   int nprocs = comm->nprocs;
   bigint count = 0;
 
-  int pnx,pny,pnz,ix,iy,iz,nbits,pflag,proc;
+  int pnx,pny,pnz,nbits,pflag,proc;
+  cellint ix,iy,iz;
   cellint m,nth,idgrandparent,idparent,idchild;
   double lo[3],hi[3];
   Grid::ParentCell *p;
@@ -534,9 +535,9 @@ void CreateGrid::procs2grid(int nx, int ny, int nz, int &px, int &py, int &pz)
   // area[0] = xy, area[1] = xz, area[2] = yz
 
   double area[3];
-  area[0] = nx*ny;
-  area[1] = nx*nz;
-  area[2] = ny*nz;
+  area[0] = (bigint) nx*ny;
+  area[1] = (bigint) nx*nz;
+  area[2] = (bigint) ny*nz;
 
   double bestsurf = 2.0 * (area[0]+area[1]+area[2]);
 

--- a/src/create_grid.cpp
+++ b/src/create_grid.cpp
@@ -277,13 +277,13 @@ void CreateGrid::command(int narg, char **arg)
           for (m = 0; m < ntotal; m++) {
             ix = m % nx;
             iy = (m / nx) % ny;
-            iz = m / (nx*ny);
-            if (order == XYZ) nth = (cellint) iz*nx*ny + iy*nx + ix;
-            else if (order == XZY) nth = (cellint) iy*nx*nz + iz*nx + ix;
-            else if (order == YXZ) nth = (cellint) iz*ny*nx + ix*ny + iy;
-            else if (order == YZX) nth = (cellint) ix*ny*nz + iz*ny + iy;
-            else if (order == ZXY) nth = (cellint) iy*nz*nx + ix*nz + iz;
-            else if (order == ZYX) nth = (cellint) ix*nz*ny + iy*nz + iz;
+            iz = m / ((cellint) nx*ny);
+            if (order == XYZ) nth = (cellint) iz*nx*ny + (cellint) iy*nx + ix;
+            else if (order == XZY) nth = (cellint) iy*nx*nz + (cellint) iz*nx + ix;
+            else if (order == YXZ) nth = (cellint) iz*ny*nx + (cellint) ix*ny + iy;
+            else if (order == YZX) nth = (cellint) ix*ny*nz + (cellint) iz*ny + iy;
+            else if (order == ZXY) nth = (cellint) iy*nz*nx + (cellint) ix*nz + iz;
+            else if (order == ZYX) nth = (cellint) ix*nz*ny + (cellint) iy*nz + iz;
             nth++;
             if (bstyle == STRIDE) proc = nth % nprocs;
             else proc = static_cast<int> (1.0*nth/ntotal * nprocs);
@@ -311,7 +311,7 @@ void CreateGrid::command(int narg, char **arg)
           for (iz = izstart; iz < izstop; iz++) {
             for (iy = iystart; iy < iystop; iy++) {
               for (ix = ixstart; ix < ixstop; ix++) {
-                m = (cellint) iz*nx*ny + iy*nx + ix;
+                m = (cellint) iz*nx*ny + (cellint) iy*nx + ix;
                 m++;
                 idchild = idparent | (m << nbits);
                 grid->id_child_lohi(iparent,m,lo,hi);

--- a/src/create_grid.cpp
+++ b/src/create_grid.cpp
@@ -180,8 +180,7 @@ void CreateGrid::command(int narg, char **arg)
   int nprocs = comm->nprocs;
   bigint count = 0;
 
-  int pnx,pny,pnz,nbits,pflag,proc;
-  cellint ix,iy,iz;
+  int pnx,pny,pnz,ix,iy,iz,nbits,pflag,proc;
   cellint m,nth,idgrandparent,idparent,idchild;
   double lo[3],hi[3];
   Grid::ParentCell *p;

--- a/src/grid_id.cpp
+++ b/src/grid_id.cpp
@@ -201,7 +201,7 @@ void Grid::id_child_lohi(int iparent, cellint ichild, double *lo, double *hi)
 
   int ix = ichild % nx;
   int iy = (ichild/nx) % ny;
-  int iz = ichild / (nx*ny);
+  int iz = ichild / ((bigint) nx*ny);
 
   double *plo = p->lo;
   double *phi = p->hi;


### PR DESCRIPTION
## Purpose

Fix overflow issue with large grids

## Author(s)

Stan Moore (Sandia)

## Backward Compatibility

No issues.

I tested this for a large 2D problem where `Nx_grid * Ny_grid` was larger than 2 billion.
