### PR TITLE
typo in clip3d triangle index, introduced recently

### DIFF
--- a/src/read_surf.cpp
+++ b/src/read_surf.cpp
@@ -1352,7 +1352,7 @@ void ReadSurf::clip3d()
     
     n = 0;
     for (i = 0; i < ntri; i++) {
-      if (!triflag[0]) {
+      if (!triflag[i]) {
 	memcpy(&tris[n],&tris[i],sizeof(Tri));
 	tris[n].p1 = ptflag[tris[n].p1];
 	tris[n].p2 = ptflag[tris[n].p2];


### PR DESCRIPTION
## Purpose

Introduce a typo bug into the clip3d operation of the read_surf command.   This fixes it.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


