### PR TITLE
Add duplicated memory option to KOKKOS package

### DIFF
--- a/doc/accelerate_kokkos.txt
+++ b/doc/accelerate_kokkos.txt
@@ -153,6 +153,11 @@ this manner no modification to the input script is
 needed. Alternatively, one can run with the KOKKOS package by editing
 the input script as described below.
 
+NOTE: When using a single OpenMP thread, the Kokkos Serial backend (i.e. 
+Makefile.kokkos_mpi_only) will give better performance than the OpenMP 
+backend (i.e. Makefile.kokkos_omp) because some of the overhead to make 
+the code thread-safe is removed.
+
 NOTE: The default for the "package kokkos"_package.html command is to
 use "threaded" communication. However, when running on CPUs, it will
 typically be faster to use "classic" non-threaded communication.  Use
@@ -162,6 +167,18 @@ page for details and default settings. Experimenting with its options
 can provide a speed-up for specific calculations. For example:
 
 mpirun -np 16 spa_kokkos_mpi_only -k on -sf kk -pk kokkos comm classic -in in.collide       # non-threaded comm :pre
+
+For OpenMP, the KOKKOS package uses data duplication (i.e. 
+thread-private arrays) by default to avoid thread-level write conflicts 
+in some compute styles. Data duplication is typically fastest for small 
+numbers of threads (i.e. 8 or less) but does increase memory footprint 
+and is not scalable to large numbers of threads. An alternative to data 
+duplication is to use thread-level atomics, which don't require 
+duplication. When using the Kokkos Serial backend or the OpenMP backend 
+with a single thread, no duplication or atomics are used. For CUDA, the 
+KOKKOS package always uses atomics in these computes when necessary. The 
+use of atomics instead of duplication can be forced by compiling with the 
+"-DSPARTA_KOKKOS_USE_ATOMICS" compile switch. 
 
 [Core and Thread Affinity:]
 

--- a/src/KOKKOS/compute_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_grid_kokkos.cpp
@@ -110,6 +110,12 @@ void ComputeGridKokkos::compute_per_grid_kokkos()
   // perform all tallies needed for each particle
   // depends on its species group and the user-requested values
 
+  need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (need_dup)
+    dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
+  else
+    ndup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterNonDuplicated>(d_tally);
+
   copymode = 1;
   if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_compute_per_grid>(0,nglocal),*this);
@@ -122,6 +128,11 @@ void ComputeGridKokkos::compute_per_grid_kokkos()
   DeviceType::fence();
   copymode = 0;
 
+  if (need_dup) {
+    Kokkos::Experimental::contribute(d_tally, dup_tally);
+    dup_tally = decltype(dup_tally)(); // free duplicated memory
+  }
+
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
   d_plist = DAT::t_int_2d(); // destroy reference to reduce memory use
 }
@@ -132,8 +143,10 @@ template<int NEED_ATOMICS>
 KOKKOS_INLINE_FUNCTION
 void ComputeGridKokkos::operator()(TagComputeGrid_compute_per_grid_atomic<NEED_ATOMICS>, const int &i) const {
 
-  // The tally array is atomic
-  Kokkos::View<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicView<NEED_ATOMICS>::value> > a_tally = d_tally;
+  // The tally array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+
+  auto v_tally = ScatterViewHelper<NeedDup<NEED_ATOMICS,DeviceType>::value,decltype(dup_tally),decltype(ndup_tally)>::get(dup_tally,ndup_tally);
+  auto a_tally = v_tally.template access<AtomicDup<NEED_ATOMICS,DeviceType>::value>();
 
   const int ispecies = d_particles[i].ispecies;
   const int igroup = d_s2g(imix,ispecies);
@@ -587,8 +600,8 @@ void ComputeGridKokkos::reallocate()
   memoryKK->destroy_kokkos(k_vector_grid,vector_grid);
   memoryKK->destroy_kokkos(k_tally,tally);
   nglocal = grid->nlocal;
-  memoryKK->create_kokkos(k_vector_grid,vector_grid,nglocal,"thermal/grid:vector_grid");
+  memoryKK->create_kokkos(k_vector_grid,vector_grid,nglocal,"compute_grid:vector_grid");
   d_vector = k_vector_grid.d_view;
-  memoryKK->create_kokkos(k_tally,tally,nglocal,ntotal,"thermal/grid:tally");
+  memoryKK->create_kokkos(k_tally,tally,nglocal,ntotal,"compute_grid:tally");
   d_tally = k_tally.d_view;
 }

--- a/src/KOKKOS/compute_grid_kokkos.h
+++ b/src/KOKKOS/compute_grid_kokkos.h
@@ -103,6 +103,9 @@ class ComputeGridKokkos : public ComputeGrid, public KokkosBase {
  private:
   DAT::tdual_float_2d_lr k_tally;
   DAT::t_float_2d_lr d_tally;
+  int need_dup;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_tally;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_tally;
 
   DAT::t_float_2d_lr d_etally;
   DAT::t_float_1d_strided d_vec;

--- a/src/KOKKOS/compute_thermal_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_thermal_grid_kokkos.cpp
@@ -95,6 +95,12 @@ void ComputeThermalGridKokkos::compute_per_grid_kokkos()
 
   // loop over all particles, skip species not in mixture group
 
+  need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (need_dup)
+    dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
+  else
+    ndup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterNonDuplicated>(d_tally);
+
   copymode = 1;
   if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeThermalGrid_compute_per_grid>(0,nglocal),*this);
@@ -107,6 +113,11 @@ void ComputeThermalGridKokkos::compute_per_grid_kokkos()
   DeviceType::fence();
   copymode = 0;
 
+  if (need_dup) {
+    Kokkos::Experimental::contribute(d_tally, dup_tally);
+    dup_tally = decltype(dup_tally)(); // free duplicated memory
+  }
+
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
   d_plist = DAT::t_int_2d(); // destroy reference to reduce memory use
 }
@@ -117,8 +128,10 @@ template<int NEED_ATOMICS>
 KOKKOS_INLINE_FUNCTION
 void ComputeThermalGridKokkos::operator()(TagComputeThermalGrid_compute_per_grid_atomic<NEED_ATOMICS>, const int &i) const {
 
-  // The tally array is atomic
-  Kokkos::View<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicView<NEED_ATOMICS>::value> > a_tally = d_tally;
+  // The tally array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+
+  auto v_tally = ScatterViewHelper<NeedDup<NEED_ATOMICS,DeviceType>::value,decltype(dup_tally),decltype(ndup_tally)>::get(dup_tally,ndup_tally);
+  auto a_tally = v_tally.template access<AtomicDup<NEED_ATOMICS,DeviceType>::value>();
 
   const int ispecies = d_particles[i].ispecies;
   const int igroup = d_s2g(imix,ispecies);

--- a/src/KOKKOS/compute_thermal_grid_kokkos.h
+++ b/src/KOKKOS/compute_thermal_grid_kokkos.h
@@ -60,6 +60,9 @@ class ComputeThermalGridKokkos : public ComputeThermalGrid, public KokkosBase {
  private:
   DAT::tdual_float_2d_lr k_tally;
   DAT::t_float_2d_lr d_tally;
+  int need_dup;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_tally;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_tally;
 
   DAT::t_float_2d_lr d_etally;
   DAT::t_float_1d_strided d_vec;

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -112,6 +112,13 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
     error->all(FLERR,"Kokkos has been compiled for CUDA but no GPUs are requested");
 #endif
 
+#ifndef KOKKOS_HAVE_SERIAL
+  if (nthreads == 1)
+    error->warning(FLERR,"When using a single thread, the Kokkos Serial backend "
+                         "(i.e. Makefile.kokkos_mpi_only) gives better performance "
+                         "than the OpenMP backend");
+#endif
+
   Kokkos::InitArguments args;
   args.num_threads = nthreads;
   args.num_numa = numa;

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -37,6 +37,15 @@ class KokkosSPARTA : protected Pointers {
   KokkosSPARTA(class SPARTA *, int, char **);
   ~KokkosSPARTA();
   void accelerator(int, char **);
+
+  template<class DeviceType>
+  int need_dup()
+  {
+    int value = 0;
+    if (need_atomics)
+      value = NeedDup<1,DeviceType>::value;
+    return value;
+  }
 };
 
 }


### PR DESCRIPTION
## Purpose

Add data duplication option to compute grid and compute thermal/grid in the KOKKOS package as an alternative to thread atomics. Can improve performance on hardware such as KNL.

## Author(s)

Stan Moore (Sandia)

## Backward Compatibility

No issues.
