### PR TITLE
 Use 1D views to allocate scalars in KOKKOS package

### DIFF
--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -58,6 +58,8 @@ CollideVSSKokkos::CollideVSSKokkos(SPARTA *sparta, int narg, char **arg) :
 {
   kokkos_flag = 1;
 
+  // use 1D view for scalars to reduce GPU memory operations
+
   d_scalars = t_int_10("collide:scalars");
   h_scalars = t_host_int_10("collide:scalars_mirror");
 

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -58,29 +58,30 @@ CollideVSSKokkos::CollideVSSKokkos(SPARTA *sparta, int narg, char **arg) :
 {
   kokkos_flag = 1;
 
-  k_nattempt_one = DAT::tdual_int_scalar("collide:nattempt_one");
-  d_nattempt_one = k_nattempt_one.view<DeviceType>();
-  h_nattempt_one = k_nattempt_one.h_view;
+  d_scalars = t_int_10("collide:scalars");
+  h_scalars = t_host_int_10("collide:scalars_mirror");
 
-  k_ncollide_one = DAT::tdual_int_scalar("collide:ncollide_one");
-  d_ncollide_one = k_ncollide_one.view<DeviceType>();
-  h_ncollide_one = k_ncollide_one.h_view;
+  d_nattempt_one = Kokkos::subview(d_scalars,0);
+  d_ncollide_one = Kokkos::subview(d_scalars,1);
+  d_nreact_one   = Kokkos::subview(d_scalars,2);
+  d_error_flag   = Kokkos::subview(d_scalars,3);
+  d_retry        = Kokkos::subview(d_scalars,4);
+  d_maxdelete    = Kokkos::subview(d_scalars,5);
+  d_maxcellcount = Kokkos::subview(d_scalars,6);
+  d_part_grow    = Kokkos::subview(d_scalars,7);
+  d_ndelete      = Kokkos::subview(d_scalars,8);
+  d_nlocal       = Kokkos::subview(d_scalars,9);
 
-  k_nreact_one = DAT::tdual_int_scalar("collide:nreact_one");
-  d_nreact_one = k_nreact_one.view<DeviceType>();
-  h_nreact_one = k_nreact_one.h_view;
-
-  k_error_flag = DAT::tdual_int_scalar("collide:error_flag");
-  d_error_flag = k_error_flag.view<DeviceType>();
-  h_error_flag = k_error_flag.h_view;
-
-  d_retry     = DAT::t_int_scalar("collide:retry");
-  d_maxdelete = DAT::t_int_scalar("collide:maxdelete");
-  d_maxcellcount = DAT::t_int_scalar("collide:maxcellcount");
-  d_part_grow = DAT::t_int_scalar("collide:part_grow");
-
-  d_ndelete = DAT::t_int_scalar("collide:ndelete");
-  d_nlocal  = DAT::t_int_scalar("collide:nlocal");
+  h_nattempt_one = Kokkos::subview(h_scalars,0);
+  h_ncollide_one = Kokkos::subview(h_scalars,1);
+  h_nreact_one   = Kokkos::subview(h_scalars,2);
+  h_error_flag   = Kokkos::subview(h_scalars,3);
+  h_retry        = Kokkos::subview(h_scalars,4);
+  h_maxdelete    = Kokkos::subview(h_scalars,5);
+  h_maxcellcount = Kokkos::subview(h_scalars,6);
+  h_part_grow    = Kokkos::subview(h_scalars,7);
+  h_ndelete      = Kokkos::subview(h_scalars,8);
+  h_nlocal       = Kokkos::subview(h_scalars,9);
 
   random_backup = NULL;
   react_random_backup = NULL;
@@ -323,20 +324,12 @@ void CollideVSSKokkos::collisions()
   // counters
 
   ncollide_one = nattempt_one = nreact_one = 0;
-  Kokkos::deep_copy(d_ndelete,0);
+  h_ndelete() = 0;
 
   if (sparta->kokkos->atomic_reduction) {
     h_nattempt_one() = 0;
-    k_nattempt_one.modify<SPAHostType>();
-    k_nattempt_one.sync<DeviceType>();
-
     h_ncollide_one() = 0;
-    k_ncollide_one.modify<SPAHostType>();
-    k_ncollide_one.sync<DeviceType>();
-
     h_nreact_one() = 0;
-    k_nreact_one.modify<SPAHostType>();
-    k_nreact_one.sync<DeviceType>();
   }
 
   dt = update->dt;
@@ -383,16 +376,8 @@ void CollideVSSKokkos::collisions()
   // accumulate running totals
 
   if (sparta->kokkos->atomic_reduction) {
-    k_nattempt_one.modify<DeviceType>();
-    k_nattempt_one.sync<SPAHostType>();
     nattempt_one = h_nattempt_one();
-
-    k_ncollide_one.modify<DeviceType>();
-    k_ncollide_one.sync<SPAHostType>();
     ncollide_one = h_ncollide_one();
-
-    k_nreact_one.modify<DeviceType>();
-    k_nreact_one.sync<SPAHostType>();
     nreact_one = h_nreact_one();
   } else {
     nattempt_one += reduce.nattempt_one;
@@ -457,10 +442,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
   //  reallocate on the host, and then repeat the parallel loop again.
   //  Unfortunately this leads to really messy code.
 
-  auto h_nlocal = Kokkos::create_mirror_view(d_nlocal);
-
-  auto h_retry = Kokkos::create_mirror_view(d_retry);
-  Kokkos::deep_copy(h_retry,1);
+  h_retry() = 1;
 
   if (react && !sparta->kokkos->collide_retry_flag)
   {
@@ -490,12 +472,14 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
     if (react && sparta->kokkos->collide_retry_flag)
       backup();
 
-    Kokkos::deep_copy(d_retry,0);
-    Kokkos::deep_copy(d_maxdelete,0);
-    Kokkos::deep_copy(d_maxcellcount,particle_kk->get_maxcellcount());
-    Kokkos::deep_copy(d_part_grow,0);
-    Kokkos::deep_copy(d_ndelete,0);
-    Kokkos::deep_copy(d_nlocal,particle->nlocal);
+    h_retry() = 0;
+    h_maxdelete() = 0;
+    h_maxcellcount() = particle_kk->get_maxcellcount();
+    h_part_grow() = 0;
+    h_ndelete() = 0;
+    h_nlocal() = particle->nlocal;
+
+    Kokkos::deep_copy(d_scalars,h_scalars);
 
     if (sparta->kokkos->atomic_reduction) {
       if (sparta->kokkos->need_atomics)
@@ -505,9 +489,8 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
     } else
       Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagCollideCollisionsOne<NEARCP,-1> >(0,nglocal),*this,reduce);
 
-    Kokkos::deep_copy(h_nlocal,d_nlocal);
+    Kokkos::deep_copy(h_scalars,d_scalars);
 
-    Kokkos::deep_copy(h_retry,d_retry);
     if (h_retry()) {
       //printf("Retrying !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n");
       if (!sparta->kokkos->collide_retry_flag) {
@@ -517,7 +500,6 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
         restore();
       reduce = COLLIDE_REDUCE();
 
-      auto h_maxdelete = Kokkos::create_mirror_view_and_copy(SPAHostType(),d_maxdelete);
       if (h_maxdelete()) {
         maxdelete = h_maxdelete();
         memoryKK->destroy_kokkos(k_dellist,dellist);
@@ -525,7 +507,6 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
         d_dellist = k_dellist.d_view;
       }
 
-      auto h_maxcellcount = Kokkos::create_mirror_view_and_copy(SPAHostType(),d_maxcellcount);
       if (h_maxcellcount() > particle_kk->get_maxcellcount()) {
         //printf("%i %i\n",h_maxcellcount(),particle_kk->get_maxcellcount());
         maxcellcount_kk = h_maxcellcount();
@@ -535,7 +516,6 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
         particle_kk->set_maxcellcount(maxcellcount_kk);
       }
 
-      auto h_part_grow = Kokkos::create_mirror_view_and_copy(SPAHostType(),d_part_grow);
       if (h_part_grow()) {
         //printf("%i %i\n",h_nlocal(),particle->nlocal);
         particle->grow(h_nlocal() - particle->nlocal);
@@ -546,7 +526,6 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
     }
   }
 
-  auto h_ndelete = Kokkos::create_mirror_view_and_copy(SPAHostType(),d_ndelete);
   ndelete = h_ndelete();
 
   particle->nlocal = h_nlocal();
@@ -554,8 +533,6 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
   DeviceType::fence();
   copymode = 0;
 
-  k_error_flag.modify<DeviceType>();
-  k_error_flag.sync<SPAHostType>();
   if (h_error_flag())
     error->one(FLERR,"Collision cell volume is zero");
 
@@ -1692,8 +1669,8 @@ void CollideVSSKokkos::restore()
 #endif
 
   if (sparta->kokkos->atomic_reduction) {
-    Kokkos::deep_copy(d_nattempt_one,0);
-    Kokkos::deep_copy(d_ncollide_one,0);
-    Kokkos::deep_copy(d_nreact_one,0);
+    h_nattempt_one() = 0;
+    h_ncollide_one() = 0;
+    h_nreact_one() = 0;
   }
 }

--- a/src/KOKKOS/collide_vss_kokkos.h
+++ b/src/KOKKOS/collide_vss_kokkos.h
@@ -135,29 +135,42 @@ class CollideVSSKokkos : public CollideVSS {
   DAT::tdual_float_3d k_remain;
   typename AT::t_float_3d d_remain;
 
-  DAT::tdual_int_scalar k_nattempt_one;
+  typedef Kokkos::DualView<int[10], SPADeviceType::array_layout, SPADeviceType> tdual_int_10;
+  typedef tdual_int_10::t_dev t_int_10;
+  typedef tdual_int_10::t_host t_host_int_10;
+  tdual_int_10 k_scalars;
+  t_int_10 d_scalars;
+  t_host_int_10 h_scalars;
+
   typename AT::t_int_scalar d_nattempt_one;
   HAT::t_int_scalar h_nattempt_one;
 
-  DAT::tdual_int_scalar k_ncollide_one;
   typename AT::t_int_scalar d_ncollide_one;
   HAT::t_int_scalar h_ncollide_one;
 
-  DAT::tdual_int_scalar k_nreact_one;
   typename AT::t_int_scalar d_nreact_one;
   HAT::t_int_scalar h_nreact_one;
 
-  DAT::tdual_int_scalar k_error_flag;
   typename AT::t_int_scalar d_error_flag;
   HAT::t_int_scalar h_error_flag;
 
-  DAT::t_int_scalar d_retry;
-  DAT::t_int_scalar d_maxdelete;
-  DAT::t_int_scalar d_maxcellcount;
-  DAT::t_int_scalar d_part_grow;
+  typename AT::t_int_scalar d_retry;
+  HAT::t_int_scalar h_retry;
 
-  DAT::t_int_scalar d_ndelete;
-  DAT::t_int_scalar d_nlocal;
+  typename AT::t_int_scalar d_maxdelete;
+  HAT::t_int_scalar h_maxdelete;
+
+  typename AT::t_int_scalar d_maxcellcount;
+  HAT::t_int_scalar h_maxcellcount;
+
+  typename AT::t_int_scalar d_part_grow;
+  HAT::t_int_scalar h_part_grow;
+
+  typename AT::t_int_scalar d_ndelete;
+  HAT::t_int_scalar h_ndelete;
+
+  typename AT::t_int_scalar d_nlocal;
+  HAT::t_int_scalar h_nlocal;
 
   DAT::tdual_int_1d k_dellist;
   DAT::t_int_1d d_dellist;

--- a/src/KOKKOS/collide_vss_kokkos.h
+++ b/src/KOKKOS/collide_vss_kokkos.h
@@ -138,7 +138,6 @@ class CollideVSSKokkos : public CollideVSS {
   typedef Kokkos::DualView<int[10], SPADeviceType::array_layout, SPADeviceType> tdual_int_10;
   typedef tdual_int_10::t_dev t_int_10;
   typedef tdual_int_10::t_host t_host_int_10;
-  tdual_int_10 k_scalars;
   t_int_10 d_scalars;
   t_host_int_10 h_scalars;
 

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -79,49 +79,35 @@ UpdateKokkos::UpdateKokkos(SPARTA *sparta) : Update(sparta),
   blist_active_copy{VAL_2(KKCopy<ComputeBoundaryKokkos>(sparta))},
   slist_active_copy{VAL_2(KKCopy<ComputeSurfKokkos>(sparta))}
 {
-  k_ncomm_one = DAT::tdual_int_scalar("UpdateKokkos:ncomm_one");
-  d_ncomm_one = k_ncomm_one.view<DeviceType>();
-  h_ncomm_one = k_ncomm_one.h_view;
 
-  k_nexit_one = DAT::tdual_int_scalar("UpdateKokkos:nexit_one");
-  d_nexit_one = k_nexit_one.view<DeviceType>();
-  h_nexit_one = k_nexit_one.h_view;
+  // use 1D view for scalars to reduce GPU memory operations
 
-  k_nboundary_one = DAT::tdual_int_scalar("UpdateKokkos:nboundary_one");
-  d_nboundary_one = k_nboundary_one.view<DeviceType>();
-  h_nboundary_one = k_nboundary_one.h_view;
+  d_scalars = t_int_11("collide:scalars");
+  h_scalars = t_host_int_11("collide:scalars_mirror");
 
-  k_nmigrate = DAT::tdual_int_scalar("UpdateKokkos:nmigrate");
-  d_nmigrate = k_nmigrate.view<DeviceType>();
-  h_nmigrate = k_nmigrate.h_view;
+  d_ncomm_one     = Kokkos::subview(d_scalars,0);
+  d_nexit_one     = Kokkos::subview(d_scalars,1);
+  d_nboundary_one = Kokkos::subview(d_scalars,2);
+  d_nmigrate      = Kokkos::subview(d_scalars,3);
+  d_entryexit     = Kokkos::subview(d_scalars,4);
+  d_ntouch_one    = Kokkos::subview(d_scalars,5);
+  d_nscheck_one   = Kokkos::subview(d_scalars,6);
+  d_nscollide_one = Kokkos::subview(d_scalars,7);
+  d_nreact_one    = Kokkos::subview(d_scalars,8);
+  d_nstuck        = Kokkos::subview(d_scalars,9);
+  d_error_flag    = Kokkos::subview(d_scalars,10);
 
-  k_entryexit = DAT::tdual_int_scalar("UpdateKokkos:entryexit");
-  d_entryexit = k_entryexit.view<DeviceType>();
-  h_entryexit = k_entryexit.h_view;
-
-  k_ntouch_one = DAT::tdual_int_scalar("UpdateKokkos:ntouch_one");
-  d_ntouch_one = k_ntouch_one.view<DeviceType>();
-  h_ntouch_one = k_ntouch_one.h_view;
-
-  k_nscheck_one = DAT::tdual_int_scalar("UpdateKokkos:nscheck_one");
-  d_nscheck_one = k_nscheck_one.view<DeviceType>();
-  h_nscheck_one = k_nscheck_one.h_view;
-
-  k_nscollide_one = DAT::tdual_int_scalar("UpdateKokkos:nscollide_one");
-  d_nscollide_one = k_nscollide_one.view<DeviceType>();
-  h_nscollide_one = k_nscollide_one.h_view;
-
-  k_nreact_one = DAT::tdual_int_scalar("UpdateKokkos:nreact_one");
-  d_nreact_one = k_nreact_one.view<DeviceType>();
-  h_nreact_one = k_nreact_one.h_view;
-
-  k_nstuck = DAT::tdual_int_scalar("UpdateKokkos:nstuck");
-  d_nstuck = k_nstuck.view<DeviceType>();
-  h_nstuck = k_nstuck.h_view;
-
-  k_error_flag = DAT::tdual_int_scalar("UpdateKokkos:error_flag");
-  d_error_flag = k_error_flag.view<DeviceType>();
-  h_error_flag = k_error_flag.h_view;
+  h_ncomm_one     = Kokkos::subview(h_scalars,0);
+  h_nexit_one     = Kokkos::subview(h_scalars,1);
+  h_nboundary_one = Kokkos::subview(h_scalars,2);
+  h_nmigrate      = Kokkos::subview(h_scalars,3);
+  h_entryexit     = Kokkos::subview(h_scalars,4);
+  h_ntouch_one    = Kokkos::subview(h_scalars,5);
+  h_nscheck_one   = Kokkos::subview(h_scalars,6);
+  h_nscollide_one = Kokkos::subview(h_scalars,7);
+  h_nreact_one    = Kokkos::subview(h_scalars,8);
+  h_nstuck        = Kokkos::subview(h_scalars,9);
+  h_error_flag    = Kokkos::subview(h_scalars,10);
 
   nboundary_tally = 0;
 }
@@ -382,37 +368,15 @@ template < int DIM, int SURF > void UpdateKokkos::move()
 
   if (sparta->kokkos->atomic_reduction) {
     h_ntouch_one() = 0;
-    k_ntouch_one.modify<SPAHostType>();
-    k_ntouch_one.sync<DeviceType>();
-
     h_nexit_one() = 0;
-    k_nexit_one.modify<SPAHostType>();
-    k_nexit_one.sync<DeviceType>();
-
     h_nboundary_one() = 0;
-    k_nboundary_one.modify<SPAHostType>();
-    k_nboundary_one.sync<DeviceType>();
-
     h_ncomm_one() = 0;
-    k_ncomm_one.modify<SPAHostType>();
-    k_ncomm_one.sync<DeviceType>();
-
     h_nscheck_one() = 0;
-    k_nscheck_one.modify<SPAHostType>();
-    k_nscheck_one.sync<DeviceType>();
-
     h_nscollide_one() = 0;
-    k_nscollide_one.modify<SPAHostType>();
-    k_nscollide_one.sync<DeviceType>();
-
     h_nreact_one() = 0;
-    k_nreact_one.modify<SPAHostType>();
-    k_nreact_one.sync<DeviceType>();
   }
 
   h_error_flag() = 0;
-  k_error_flag.modify<SPAHostType>();
-  k_error_flag.sync<DeviceType>();
 
   // move/migrate iterations
 
@@ -493,12 +457,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
       error->all(FLERR,"Cannot (yet) use surface reactions with Kokkos");
 
     h_nmigrate() = 0;
-    k_nmigrate.modify<SPAHostType>();
-    k_nmigrate.sync<DeviceType>();
-
     h_entryexit() = 0;
-    k_entryexit.modify<SPAHostType>();
-    k_entryexit.sync<DeviceType>();
 
     nmigrate = 0;
     entryexit = 0;
@@ -516,6 +475,8 @@ template < int DIM, int SURF > void UpdateKokkos::move()
                         -1 = use parallel_reduce
     */
 
+    Kokkos::deep_copy(d_scalars,h_scalars);
+
     k_mlist.sync<SPADeviceType>();
     copymode = 1;
     if (sparta->kokkos->atomic_reduction) {
@@ -529,13 +490,13 @@ template < int DIM, int SURF > void UpdateKokkos::move()
     }
     copymode = 0;
 
+    Kokkos::deep_copy(h_scalars,d_scalars);
+
     particle_kk->modify(Device,PARTICLE_MASK);
     d_particles = t_particle_1d(); // destroy reference to reduce memory use
 
     // END of pstart/pstop loop advecting all particles
 
-    k_nmigrate.modify<DeviceType>();
-    k_nmigrate.sync<SPAHostType>();
     nmigrate = h_nmigrate();
 
     DAT::t_int_1d d_mlist_small = Kokkos::subview(k_mlist.d_view,std::make_pair(0,nmigrate));
@@ -546,36 +507,13 @@ template < int DIM, int SURF > void UpdateKokkos::move()
     int error_flag;
 
     if (sparta->kokkos->atomic_reduction) {
-      k_ntouch_one.modify<DeviceType>();
-      k_ntouch_one.sync<SPAHostType>();
       ntouch_one = h_ntouch_one();
-
-      k_nexit_one.modify<DeviceType>();
-      k_nexit_one.sync<SPAHostType>();
       nexit_one = h_nexit_one();
-
-      k_nboundary_one.modify<DeviceType>();
-      k_nboundary_one.sync<SPAHostType>();
       nboundary_one = h_nboundary_one();
-
-      k_ncomm_one.modify<DeviceType>();
-      k_ncomm_one.sync<SPAHostType>();
       ncomm_one = h_ncomm_one();
-
-      k_nscheck_one.modify<DeviceType>();
-      k_nscheck_one.sync<SPAHostType>();
       nscheck_one = h_nscheck_one();
-
-      k_nscollide_one.modify<DeviceType>();
-      k_nscollide_one.sync<SPAHostType>();
       nscollide_one = h_nscollide_one();
-
-      k_nreact_one.modify<DeviceType>();
-      k_nreact_one.sync<SPAHostType>();
       surf->nreact_one = h_nreact_one();
-
-      k_nstuck.modify<DeviceType>();
-      k_nstuck.sync<SPAHostType>();
       nstuck = h_nstuck();
     } else {
       ntouch_one       += reduce.ntouch_one   ;
@@ -588,12 +526,8 @@ template < int DIM, int SURF > void UpdateKokkos::move()
       nstuck           += reduce.nstuck       ;
     }
 
-    k_entryexit.modify<DeviceType>();
-    k_entryexit.sync<SPAHostType>();
     entryexit = h_entryexit();
 
-    k_error_flag.modify<DeviceType>();
-    k_error_flag.sync<SPAHostType>();
     error_flag = h_error_flag();
 
     if (error_flag) {

--- a/src/KOKKOS/update_kokkos.h
+++ b/src/KOKKOS/update_kokkos.h
@@ -133,47 +133,43 @@ class UpdateKokkos : public Update {
   KKCopy<ComputeBoundaryKokkos> blist_active_copy[KOKKOS_MAX_BLIST];
   KKCopy<ComputeSurfKokkos> slist_active_copy[KOKKOS_MAX_SLIST];
 
-  DAT::tdual_int_scalar k_ntouch_one;
+
+  typedef Kokkos::DualView<int[11], SPADeviceType::array_layout, SPADeviceType> tdual_int_11;
+  typedef tdual_int_11::t_dev t_int_11;
+  typedef tdual_int_11::t_host t_host_int_11;
+  t_int_11 d_scalars;
+  t_host_int_11 h_scalars;
+
   typename AT::t_int_scalar d_ntouch_one;
   HAT::t_int_scalar h_ntouch_one;
 
-  DAT::tdual_int_scalar k_nexit_one;
   typename AT::t_int_scalar d_nexit_one;
   HAT::t_int_scalar h_nexit_one;
 
-  DAT::tdual_int_scalar k_nboundary_one;
   typename AT::t_int_scalar d_nboundary_one;
   HAT::t_int_scalar h_nboundary_one;
 
-  DAT::tdual_int_scalar k_nmigrate;
   typename AT::t_int_scalar d_nmigrate;
   HAT::t_int_scalar h_nmigrate;
 
-  DAT::tdual_int_scalar k_entryexit;
   typename AT::t_int_scalar d_entryexit;
   HAT::t_int_scalar h_entryexit;
 
-  DAT::tdual_int_scalar k_ncomm_one;
   typename AT::t_int_scalar d_ncomm_one;
   HAT::t_int_scalar h_ncomm_one;
 
-  DAT::tdual_int_scalar k_nscheck_one;
   typename AT::t_int_scalar d_nscheck_one;
   HAT::t_int_scalar h_nscheck_one;
 
-  DAT::tdual_int_scalar k_nscollide_one;
   typename AT::t_int_scalar d_nscollide_one;
   HAT::t_int_scalar h_nscollide_one;
 
-  DAT::tdual_int_scalar k_nreact_one;
   typename AT::t_int_scalar d_nreact_one;
   HAT::t_int_scalar h_nreact_one;
 
-  DAT::tdual_int_scalar k_nstuck;
   typename AT::t_int_scalar d_nstuck;
   HAT::t_int_scalar h_nstuck;
 
-  DAT::tdual_int_scalar k_error_flag;
   typename AT::t_int_scalar d_error_flag;
   HAT::t_int_scalar h_error_flag;
 


### PR DESCRIPTION
## Purpose

Use 1D view to allocate scalars in `collide_vss_kokkos` and `update_kokkos`. This reduces the number of small GPU memory operations, and improves performance on GPUs.

## Author(s)

Stan Moore (Sandia)

## Backward Compatibility

No issues.
