### PR TITLE
Add ScatterView changes from A. Stagg (KOKKOS package)

### DIFF
--- a/src/KOKKOS/compute_count_kokkos.h
+++ b/src/KOKKOS/compute_count_kokkos.h
@@ -47,6 +47,9 @@ class ComputeCountKokkos : public ComputeCount, public KokkosBase {
 
   DAT::tdual_int_1d k_count;
   DAT::t_int_1d d_count;
+  int need_dup;
+  Kokkos::Experimental::ScatterView<int*, typename DAT::t_int_1d::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_count;
+  Kokkos::Experimental::ScatterView<int*, typename DAT::t_int_1d::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_count;
 
   t_particle_1d d_particles;
 

--- a/src/KOKKOS/compute_eflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.cpp
@@ -111,6 +111,12 @@ void ComputeEFluxGridKokkos::compute_per_grid_kokkos()
 
   // loop over all particles, skip species not in mixture group
 
+  need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (need_dup)
+    dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
+  else
+    ndup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterNonDuplicated>(d_tally);
+
   copymode = 1;
   if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeEFluxGrid_compute_per_grid>(0,nglocal),*this);
@@ -123,6 +129,11 @@ void ComputeEFluxGridKokkos::compute_per_grid_kokkos()
   DeviceType::fence();
   copymode = 0;
 
+  if (need_dup) {
+    Kokkos::Experimental::contribute(d_tally, dup_tally);
+    dup_tally = decltype(dup_tally)(); // free duplicated memory
+  }
+
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
   d_plist = DAT::t_int_2d(); // destroy reference to reduce memory use
 }
@@ -133,8 +144,10 @@ template<int NEED_ATOMICS>
 KOKKOS_INLINE_FUNCTION
 void ComputeEFluxGridKokkos::operator()(TagComputeEFluxGrid_compute_per_grid_atomic<NEED_ATOMICS>, const int &i) const {
 
-  // The tally array is atomic
-  Kokkos::View<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicView<NEED_ATOMICS>::value> > a_tally = d_tally;
+  // The tally array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+
+  auto v_tally = ScatterViewHelper<NeedDup<NEED_ATOMICS,DeviceType>::value,decltype(dup_tally),decltype(ndup_tally)>::get(dup_tally,ndup_tally);
+  auto a_tally = v_tally.template access<AtomicDup<NEED_ATOMICS,DeviceType>::value>();
 
   const int ispecies = d_particles[i].ispecies;
   const int igroup = d_s2g(imix,ispecies);

--- a/src/KOKKOS/compute_eflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.cpp
@@ -112,6 +112,9 @@ void ComputeEFluxGridKokkos::compute_per_grid_kokkos()
   // loop over all particles, skip species not in mixture group
 
   need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
+    need_dup = 0;
+
   if (need_dup)
     dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
   else

--- a/src/KOKKOS/compute_eflux_grid_kokkos.h
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.h
@@ -60,6 +60,9 @@ class ComputeEFluxGridKokkos : public ComputeEFluxGrid, public KokkosBase {
  private:
   DAT::tdual_float_2d_lr k_tally;
   DAT::t_float_2d_lr d_tally;
+  int need_dup;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_tally;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_tally;
 
   DAT::t_float_2d_lr d_etally;
   DAT::t_float_1d_strided d_vec;

--- a/src/KOKKOS/compute_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_grid_kokkos.cpp
@@ -111,6 +111,9 @@ void ComputeGridKokkos::compute_per_grid_kokkos()
   // depends on its species group and the user-requested values
 
   need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
+    need_dup = 0;
+
   if (need_dup)
     dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
   else

--- a/src/KOKKOS/compute_pflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.cpp
@@ -109,6 +109,9 @@ void ComputePFluxGridKokkos::compute_per_grid_kokkos()
   // loop over all particles, skip species not in mixture group
 
   need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
+    need_dup = 0;
+
   if (need_dup)
     dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
   else

--- a/src/KOKKOS/compute_pflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.cpp
@@ -108,6 +108,12 @@ void ComputePFluxGridKokkos::compute_per_grid_kokkos()
 
   // loop over all particles, skip species not in mixture group
 
+  need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (need_dup)
+    dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
+  else
+    ndup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterNonDuplicated>(d_tally);
+
   copymode = 1;
   if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputePFluxGrid_compute_per_grid>(0,nglocal),*this);
@@ -120,6 +126,11 @@ void ComputePFluxGridKokkos::compute_per_grid_kokkos()
   DeviceType::fence();
   copymode = 0;
 
+  if (need_dup) {
+    Kokkos::Experimental::contribute(d_tally, dup_tally);
+    dup_tally = decltype(dup_tally)(); // free duplicated memory
+  }
+
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
   d_plist = DAT::t_int_2d(); // destroy reference to reduce memory use
 }
@@ -130,8 +141,10 @@ template<int NEED_ATOMICS>
 KOKKOS_INLINE_FUNCTION
 void ComputePFluxGridKokkos::operator()(TagComputePFluxGrid_compute_per_grid_atomic<NEED_ATOMICS>, const int &i) const {
 
-  // The tally array is atomic
-  Kokkos::View<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicView<NEED_ATOMICS>::value> > a_tally = d_tally;
+  // The tally array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+
+  auto v_tally = ScatterViewHelper<NeedDup<NEED_ATOMICS,DeviceType>::value,decltype(dup_tally),decltype(ndup_tally)>::get(dup_tally,ndup_tally);
+  auto a_tally = v_tally.template access<AtomicDup<NEED_ATOMICS,DeviceType>::value>();
 
   const int ispecies = d_particles[i].ispecies;
   const int igroup = d_s2g(imix,ispecies);

--- a/src/KOKKOS/compute_pflux_grid_kokkos.h
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.h
@@ -64,6 +64,9 @@ class ComputePFluxGridKokkos : public ComputePFluxGrid, public KokkosBase {
  private:
   DAT::tdual_float_2d_lr k_tally;
   DAT::t_float_2d_lr d_tally;
+  int need_dup;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_tally;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_tally;
 
   DAT::t_float_2d_lr d_etally;
   DAT::t_float_1d_strided d_vec;

--- a/src/KOKKOS/compute_sonine_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.cpp
@@ -100,6 +100,8 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
   d_species = particle_kk->k_species.d_view;
 
   GridKokkos* grid_kk = (GridKokkos*) grid;
+  d_cellcount = grid_kk->d_cellcount;
+  d_plist = grid_kk->d_plist;
   grid_kk->sync(Device,CINFO_MASK);
   d_cinfo = grid_kk->k_cinfo.d_view;
   d_s2g = particle_kk->k_species2group.view<DeviceType>();

--- a/src/KOKKOS/compute_sonine_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.cpp
@@ -109,6 +109,16 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
   Kokkos::deep_copy(d_tally,0.0);
   Kokkos::deep_copy(d_vcom,0.0);
 
+  need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (need_dup) {
+    dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
+    dup_vcom_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_vcom);
+  }
+  else {
+    ndup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterNonDuplicated>(d_tally);
+    ndup_vcom_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterNonDuplicated>(d_vcom);
+  }
+
   // calculate center of mass velocity for each cell and group
   copymode = 1;
   if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
@@ -123,6 +133,11 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
   }
   DeviceType::fence();
 
+  if (need_dup) {
+    Kokkos::Experimental::contribute(d_vcom, dup_vcom_tally);
+    dup_vcom_tally = decltype(dup_vcom_tally)(); // free duplicated memory
+  }
+
   // tally sonine moments
   if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSonineGrid_compute_per_grid>(0,nglocal),*this);
@@ -134,6 +149,11 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
   }
   DeviceType::fence();
   copymode = 0;
+
+  if (need_dup) {
+    Kokkos::Experimental::contribute(d_tally, dup_tally);
+    dup_tally = decltype(dup_tally)(); // free duplicated memory
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -143,8 +163,9 @@ KOKKOS_INLINE_FUNCTION
 void ComputeSonineGridKokkos::operator()(TagComputeSonineGrid_compute_vcom_init_atomic<NEED_ATOMICS>, const int &i) const {
   // compute COM velocity on this timestep for each cell and group
 
-  // The tally array for center of mass velocity is atomic
-  Kokkos::View<F_FLOAT***, typename DAT::t_float_3d::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicView<NEED_ATOMICS>::value> > a_vcom = d_vcom;
+  // The tally array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+  auto v_com_tally = ScatterViewHelper<NeedDup<NEED_ATOMICS,DeviceType>::value,decltype(dup_vcom_tally),decltype(ndup_vcom_tally)>::get(dup_vcom_tally,ndup_vcom_tally);
+  auto a_vcom_tally = v_com_tally.template access<AtomicDup<NEED_ATOMICS,DeviceType>::value>();
 
   const int ispecies = d_particles[i].ispecies;
   const int igroup = d_s2g(imix,ispecies);
@@ -155,10 +176,10 @@ void ComputeSonineGridKokkos::operator()(TagComputeSonineGrid_compute_vcom_init_
   const double mass = d_species[ispecies].mass;
   double *v = d_particles[i].v;
 
-  a_vcom(icell,igroup,0) += mass * v[0];
-  a_vcom(icell,igroup,1) += mass * v[1];
-  a_vcom(icell,igroup,2) += mass * v[2];
-  a_vcom(icell,igroup,3) += mass;
+  a_vcom_tally(icell,igroup,0) += mass * v[0];
+  a_vcom_tally(icell,igroup,1) += mass * v[1];
+  a_vcom_tally(icell,igroup,2) += mass * v[2];
+  a_vcom_tally(icell,igroup,3) += mass;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -219,8 +240,10 @@ template<int NEED_ATOMICS>
 KOKKOS_INLINE_FUNCTION
 void ComputeSonineGridKokkos::operator()(TagComputeSonineGrid_compute_per_grid_atomic<NEED_ATOMICS>, const int &i) const {
 
-  // The tally array is atomic
-  Kokkos::View<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::MemoryTraits<AtomicView<NEED_ATOMICS>::value> > a_tally = d_tally;
+  // The tally array is duplicated for OpenMP, atomic for CUDA, and neither for Serial
+
+  auto v_tally = ScatterViewHelper<NeedDup<NEED_ATOMICS,DeviceType>::value,decltype(dup_tally),decltype(ndup_tally)>::get(dup_tally,ndup_tally);
+  auto a_tally = v_tally.template access<AtomicDup<NEED_ATOMICS,DeviceType>::value>();
 
   const int ispecies = d_particles[i].ispecies;
   const int igroup = d_s2g(imix,ispecies);

--- a/src/KOKKOS/compute_sonine_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.cpp
@@ -110,6 +110,9 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
   Kokkos::deep_copy(d_vcom,0.0);
 
   need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
+    need_dup = 0;
+
   if (need_dup) {
     dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
     dup_vcom_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_vcom);

--- a/src/KOKKOS/compute_sonine_grid_kokkos.h
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.h
@@ -74,8 +74,14 @@ class ComputeSonineGridKokkos : public ComputeSonineGrid, public KokkosBase {
 
  private:
   DAT::t_float_3d d_vcom;
+  Kokkos::Experimental::ScatterView<F_FLOAT***, typename DAT::t_float_3d::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_vcom_tally;
+  Kokkos::Experimental::ScatterView<F_FLOAT***, typename DAT::t_float_3d::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_vcom_tally;
+
   DAT::tdual_float_2d_lr k_tally;
   DAT::t_float_2d_lr d_tally;
+  int need_dup;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_tally;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_tally;
 
   DAT::t_float_2d_lr d_etally;
   DAT::t_float_1d_strided d_vec;

--- a/src/KOKKOS/compute_thermal_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_thermal_grid_kokkos.cpp
@@ -96,6 +96,9 @@ void ComputeThermalGridKokkos::compute_per_grid_kokkos()
   // loop over all particles, skip species not in mixture group
 
   need_dup = sparta->kokkos->need_dup<DeviceType>();
+  if (particle_kk->sorted_kk && sparta->kokkos->need_atomics && !sparta->kokkos->atomic_reduction)
+    need_dup = 0;
+
   if (need_dup)
     dup_tally = Kokkos::Experimental::create_scatter_view<Kokkos::Experimental::ScatterSum, Kokkos::Experimental::ScatterDuplicated>(d_tally);
   else


### PR DESCRIPTION
## Purpose

Add ScatterView changes from A. Stagg to use duplicated memory for KOKKOS package versions of `compute/count`, `compute/eflux/grid`, `compute/pflux/grid`, and `compute/sonine`.

## Author(s)

Alan Stagg (Sandia)

## Backward Compatibility

No issues.