### PR TITLE
Added pvtu file write

### DIFF
--- a/tools/paraview/README
+++ b/tools/paraview/README
@@ -40,7 +40,7 @@ pvpython is in /Applications/paraview.app/Contents/bin/.
 
   On Windows:
 
-pvpython is in C:\Program Files (x86)\ParaView 4.1.0\bin. 
+pvpython is in C:\Program Files (x86)\ParaView 5.6.0\bin. 
 
 -------------------------------
 
@@ -188,3 +188,66 @@ NOTE: On Windows platforms, the grid blocking will always be executed
 serially.  This is due to how the multiprocessing module is
 implemented on Windows, which prohibits multiple instances of pvpython
 from starting independently.
+
+IV. PVBATCH FOR LARGE SPARTA GRIDS
+
+When Sparta grid output becomes large, the processing time required for
+grid2paraview.py can be long on a single node even with multi-processing.
+If more than one compute node is available (HPC environment), grid2paraview.py
+can be run with MPI using ParaView's pvbatch program. The pvbatch program
+is normally located in the same directory as pvpython, along with the mpiexec
+program that works with ParaView. In some environments, ParaView may have
+been compiled from source with a particular version of MPI, in which case 
+the appropriate mpiexec program will need to be used.
+
+From the mir.txt example in section III, to run grid2paraview.py using
+pvbatch, use the following command line.
+
+% mpiexec -np 256 pvbatch -sym grid2paraview.py mir.txt mir_grid -r \
+    ../parent/mir/tmp_flow.*
+
+This command will run grid2paraview.py on 256 MPI ranks and produce the same
+outputs as the pvpython version. Using 256 MPI ranks will be faster than
+multi-processing with threads on a single compute node. Notice the "-sym"
+argument to pvbatch, which tells pvbatch to run in symmetric MPI mode.
+This argument is required.
+
+V. CATALYST FOR LARGE SPARTA GRIDS
+
+There is an option in grid2paraview.py to execute a ParaView Catalyst Python
+script that has been exported from the ParaView GUI. For more details on
+Catalyst, please see the Catalyst user guide, located here.
+
+https://www.paraview.org/in-situ/
+
+The Catalyst script will generate images or data extracts for each time-step.
+This will avoid having to run ParaView as a separate step to generate
+visualizations. The ideal work-flow is to run the ParaView GUI on a much smaller
+grid version to setup the visualization and export the Catalyst script.
+Then, run grid2paraview.py on the larger Sparta grid output to generate
+images. From the mir.txt example, to run grid2paraview.py using pvbatch and
+catalyst, use the following command line (catalyst.py was exported from
+the ParaView GUI).
+
+% mpiexec -np 32 pvbatch -sym grid2paraview.py mir.txt mir_grid -r \
+    -c catalyst.py ../parent/mir/tmp_flow.*
+
+This will generate images or data extracts, depending on how catalyst.py was
+setup in the ParaView GUI. The grid2paraview.py script will not generate
+ParaView grid geometry when the "-c" option is used. Note that grid2paraview.py
+will assume that the grid input name is "mir_grid.pvd" in catalyst.py, since
+"mir_grid" is given as the output directory.  If these two names do not match,
+either edit your catalyst script or change the output directory name on the
+command line to match what your script expects. The output directory is not 
+created when "-c" option is used.
+
+VI. INTEGRATION TEST SCRIPT
+
+There is a bash script, runIntegrationTests.sh, located in this directory.
+This script will run 2D and 3D tests using the circle and sphere Sparta
+examples, and will create an output directory called 
+"integration_test_scratch_directory". There will be two subdirectories,
+circle and sphere, that contain the output of running surf2paraview.py,
+and grid2paraview.py using pvpython, pvbatch, and catalyst. Edit the top
+portion of runIntegrationTests.sh to point to your installed Sparta and
+ParaView before running.

--- a/tools/paraview/README
+++ b/tools/paraview/README
@@ -107,9 +107,9 @@ The first argument is a text file containing a description of the
 SPARTA grid.  The description uses commands found in the SPARTA input
 deck.  These commands are dimension, create_box, and create_grid or
 read_grid.  The file can also contain "slice" commands which will
-define slice planes through the 3d grid and output 2d data for each
-slice plane.  The file can also contain comment lines with start
-with a "#" character.
+define slice planes through the 3d grid and output 3d data for each
+slice plane (crinkle cut).  The file can also contain comment lines
+with start with a "#" character.
 
 The dimension and create_box command have exactly the same syntax as
 corresponding SPARTA input script commands.  Both of these commands

--- a/tools/paraview/coprocessor.py
+++ b/tools/paraview/coprocessor.py
@@ -1,0 +1,90 @@
+coProcessor = None
+usecp = True
+
+def initialize():
+    global coProcessor, usecp
+    if usecp:
+        import paraview
+        import vtkParallelCorePython
+        import vtk
+        from mpi4py import MPI
+        import os, sys
+
+        paraview.options.batch = True
+        paraview.options.symmetric = True
+        import vtkPVClientServerCoreCorePython as CorePython
+        try:
+            import vtkPVServerManagerApplicationPython as ApplicationPython
+        except:
+            paraview.print_error("Error: Cannot import vtkPVServerManagerApplicationPython")
+
+        if not CorePython.vtkProcessModule.GetProcessModule():
+            pvoptions = None
+            if paraview.options.batch:
+                pvoptions = CorePython.vtkPVOptions();
+                pvoptions.SetProcessType(CorePython.vtkPVOptions.PVBATCH)
+                if paraview.options.symmetric:
+                    pvoptions.SetSymmetricMPIMode(True)
+            ApplicationPython.vtkInitializationHelper.Initialize(sys.executable, CorePython.vtkProcessModule.PROCESS_BATCH, pvoptions)
+
+        import paraview.servermanager as pvsm
+        # we need ParaView 4.2 since ParaView 4.1 doesn't properly wrap
+        # vtkPVPythonCatalystPython
+        if pvsm.vtkSMProxyManager.GetVersionMajor() != 4 or \
+           pvsm.vtkSMProxyManager.GetVersionMinor() < 2:
+            print 'Must use ParaView v4.2 or greater'
+            sys.exit(0)
+
+        import numpy
+        import vtkPVCatalystPython as catalyst
+        import vtkPVPythonCatalystPython as pythoncatalyst
+        import paraview.simple
+        import paraview.vtk as vtk
+        from paraview import numpy_support
+        paraview.options.batch = True
+        paraview.options.symmetric = True
+
+        coProcessor = catalyst.vtkCPProcessor()
+        pm = paraview.servermanager.vtkProcessModule.GetProcessModule()
+        from mpi4py import MPI
+
+def finalize():
+    global coProcessor, usecp
+    if usecp:
+        coProcessor.Finalize()
+        import vtkPVServerManagerApplicationPython as ApplicationPython
+        ApplicationPython.vtkInitializationHelper.Finalize()
+
+def addscript(name):
+    global coProcessor
+    import vtkPVPythonCatalystPython as pythoncatalyst
+    pipeline = pythoncatalyst.vtkCPPythonScriptPipeline()
+    pipeline.Initialize(name)
+    coProcessor.AddPipeline(pipeline)
+
+def coprocess(time, timeStep, grid, attributes):
+    global coProcessor
+    import vtk
+    import vtkPVCatalystPython as catalyst
+    import paraview
+    from paraview import numpy_support
+    dataDescription = catalyst.vtkCPDataDescription()
+    dataDescription.SetTimeData(time, timeStep)
+    dataDescription.AddInput("input")
+
+    if coProcessor.RequestDataDescription(dataDescription):
+        import fedatastructures
+        imageData = vtk.vtkImageData()
+        imageData.SetExtent(grid.XStartPoint, grid.XEndPoint, 0, grid.NumberOfYPoints-1, 0, grid.NumberOfZPoints-1)
+        imageData.SetSpacing(grid.Spacing)
+
+        velocity = paraview.numpy_support.numpy_to_vtk(attributes.Velocity)
+        velocity.SetName("velocity")
+        imageData.GetPointData().AddArray(velocity)
+
+        pressure = numpy_support.numpy_to_vtk(attributes.Pressure)
+        pressure.SetName("pressure")
+        imageData.GetCellData().AddArray(pressure)
+        dataDescription.GetInputDescriptionByName("input").SetGrid(imageData)
+        dataDescription.GetInputDescriptionByName("input").SetWholeExtent(0, grid.NumberOfGlobalXPoints-1, 0, grid.NumberOfYPoints-1, 0, grid.NumberOfZPoints-1)
+coProcessor.CoProcess(dataDescription)

--- a/tools/paraview/coprocessor.py
+++ b/tools/paraview/coprocessor.py
@@ -1,90 +1,31 @@
 coProcessor = None
-usecp = True
 
 def initialize():
-    global coProcessor, usecp
-    if usecp:
-        import paraview
-        import vtkParallelCorePython
-        import vtk
-        from mpi4py import MPI
-        import os, sys
-
-        paraview.options.batch = True
-        paraview.options.symmetric = True
-        import vtkPVClientServerCoreCorePython as CorePython
-        try:
-            import vtkPVServerManagerApplicationPython as ApplicationPython
-        except:
-            paraview.print_error("Error: Cannot import vtkPVServerManagerApplicationPython")
-
-        if not CorePython.vtkProcessModule.GetProcessModule():
-            pvoptions = None
-            if paraview.options.batch:
-                pvoptions = CorePython.vtkPVOptions();
-                pvoptions.SetProcessType(CorePython.vtkPVOptions.PVBATCH)
-                if paraview.options.symmetric:
-                    pvoptions.SetSymmetricMPIMode(True)
-            ApplicationPython.vtkInitializationHelper.Initialize(sys.executable, CorePython.vtkProcessModule.PROCESS_BATCH, pvoptions)
-
-        import paraview.servermanager as pvsm
-        # we need ParaView 4.2 since ParaView 4.1 doesn't properly wrap
-        # vtkPVPythonCatalystPython
-        if pvsm.vtkSMProxyManager.GetVersionMajor() != 4 or \
-           pvsm.vtkSMProxyManager.GetVersionMinor() < 2:
-            print 'Must use ParaView v4.2 or greater'
-            sys.exit(0)
-
-        import numpy
-        import vtkPVCatalystPython as catalyst
-        import vtkPVPythonCatalystPython as pythoncatalyst
-        import paraview.simple
-        import paraview.vtk as vtk
-        from paraview import numpy_support
-        paraview.options.batch = True
-        paraview.options.symmetric = True
-
-        coProcessor = catalyst.vtkCPProcessor()
-        pm = paraview.servermanager.vtkProcessModule.GetProcessModule()
-        from mpi4py import MPI
+    global coProcessor
+    import paraview
+    paraview.options.batch = True
+    paraview.options.symmetric = True
+    from paraview.vtk import vtkPVCatalyst as catalyst
+    coProcessor = catalyst.vtkCPProcessor()
 
 def finalize():
-    global coProcessor, usecp
-    if usecp:
-        coProcessor.Finalize()
-        import vtkPVServerManagerApplicationPython as ApplicationPython
-        ApplicationPython.vtkInitializationHelper.Finalize()
+    global coProcessor
+    coProcessor.Finalize()
 
 def addscript(name):
     global coProcessor
-    import vtkPVPythonCatalystPython as pythoncatalyst
+    from paraview.vtk import vtkPVPythonCatalystPython as pythoncatalyst
     pipeline = pythoncatalyst.vtkCPPythonScriptPipeline()
     pipeline.Initialize(name)
     coProcessor.AddPipeline(pipeline)
 
-def coprocess(time, timeStep, grid, attributes):
+def coprocess(time, timeStep, grid, inputName):
     global coProcessor
-    import vtk
-    import vtkPVCatalystPython as catalyst
-    import paraview
-    from paraview import numpy_support
+    from paraview.vtk import vtkPVCatalyst as catalyst
     dataDescription = catalyst.vtkCPDataDescription()
     dataDescription.SetTimeData(time, timeStep)
-    dataDescription.AddInput("input")
+    dataDescription.AddInput(inputName)
 
     if coProcessor.RequestDataDescription(dataDescription):
-        import fedatastructures
-        imageData = vtk.vtkImageData()
-        imageData.SetExtent(grid.XStartPoint, grid.XEndPoint, 0, grid.NumberOfYPoints-1, 0, grid.NumberOfZPoints-1)
-        imageData.SetSpacing(grid.Spacing)
-
-        velocity = paraview.numpy_support.numpy_to_vtk(attributes.Velocity)
-        velocity.SetName("velocity")
-        imageData.GetPointData().AddArray(velocity)
-
-        pressure = numpy_support.numpy_to_vtk(attributes.Pressure)
-        pressure.SetName("pressure")
-        imageData.GetCellData().AddArray(pressure)
-        dataDescription.GetInputDescriptionByName("input").SetGrid(imageData)
-        dataDescription.GetInputDescriptionByName("input").SetWholeExtent(0, grid.NumberOfGlobalXPoints-1, 0, grid.NumberOfYPoints-1, 0, grid.NumberOfZPoints-1)
-coProcessor.CoProcess(dataDescription)
+        dataDescription.GetInputDescriptionByName(inputName).SetGrid(grid)
+        coProcessor.CoProcess(dataDescription)

--- a/tools/paraview/coprocessor.py
+++ b/tools/paraview/coprocessor.py
@@ -1,3 +1,17 @@
+
+#   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+#   http://sparta.sandia.gov
+#   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov,
+#   Thomas Otahal, tjotaha@sandia.gov
+#   Sandia National Laboratories
+
+#   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+#   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+#   certain rights in this software.  This software is distributed under 
+#   the GNU General Public License.
+
+#   See the README file in the top-level SPARTA directory.
+
 coProcessor = None
 
 def initialize():

--- a/tools/paraview/grid2paraview.py
+++ b/tools/paraview/grid2paraview.py
@@ -1098,7 +1098,7 @@ def run_pvbatch_output(params_dict):
     id_map = create_cell_global_id_to_local_id_map(ug)
     for idx, time in enumerate(sorted(time_steps_dict.keys())):
       read_time_step_data(time_steps_dict[time], ug, id_map)
-      coprocessor.coprocess(time, idx, ug)
+      coprocessor.coprocess(time, idx, ug, paraview_output_file + '.pvd')
     coprocessor.finalize()
   else:
     if rank == 0:

--- a/tools/paraview/runIntegrationTests.sh
+++ b/tools/paraview/runIntegrationTests.sh
@@ -56,6 +56,7 @@ test_circle() {
     cp $CIRCLE_EXAMPLE_DIR/data.circle .
     cp $INPUT_FILE_DIR/in.circle .
     cp $INPUT_FILE_DIR/circle.txt .
+    cp $INPUT_FILE_DIR/circle_slice.txt .
     cp $INPUT_FILE_DIR/circle_read_grid.txt .
     cp $INPUT_FILE_DIR/circle_catalyst_script.py .
 
@@ -89,7 +90,8 @@ test_circle() {
     CURRENT_TEST="grid2paraview pvpython circle"
     echo ""
     echo "Checking $CURRENT_TEST output"
-    $PARAVIEW_PVPYTHON $GRID2PARAVIEW circle.txt circle_grid_pvpython -xc 10 -yc 10 -r tmp_flow.*
+    $PARAVIEW_PVPYTHON $GRID2PARAVIEW circle.txt circle_grid_pvpython \
+        -xc 10 -yc 10 -r tmp_flow.*
     echo ""
     echo "Checking $CURRENT_TEST output"
     check_file "circle_grid_pvpython.pvd" 
@@ -105,9 +107,43 @@ test_circle() {
     echo ""
     echo "$CURRENT_TEST test passed"
 
+    CURRENT_TEST="grid2paraview pvpython slice circle"
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    $PARAVIEW_PVPYTHON $GRID2PARAVIEW circle_slice.txt \
+        circle_slice_grid_pvpython -xc 10 -yc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_slice_grid_pvpython.pvd" 
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_0.pvtu"
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_500.pvtu"
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_0_400.vtu"
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_1_400.vtu"
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_2_400.vtu"
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_3_400.vtu"
+    check_file "circle_slice_grid_pvpython/circle_slice_grid_pvpython_1000.pvtu"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvbatch slice circle"
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW circle_slice.txt \
+        circle_slice_grid_pvbatch -xc 10 -yc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_slice_grid_pvbatch.pvd" 
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_0.pvtu"
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_500.pvtu"
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_0_600.vtu"
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_1_600.vtu"
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_2_600.vtu"
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_3_600.vtu"
+    check_file "circle_slice_grid_pvbatch/circle_slice_grid_pvbatch_1000.pvtu"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
     CURRENT_TEST="grid2paraview pvbatch circle"
-    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW circle.txt circle_grid_pvbatch \
-        -xc 10 -yc 10 -r tmp_flow.*
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW circle.txt \
+        circle_grid_pvbatch -xc 10 -yc 10 -r tmp_flow.*
     echo ""
     echo "Checking $CURRENT_TEST output"
     check_file "circle_grid_pvbatch.pvd"
@@ -124,8 +160,9 @@ test_circle() {
     echo "$CURRENT_TEST test passed"
 
     CURRENT_TEST="grid2paraview catalyst circle"
-    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW circle_read_grid.txt circle_grid_pvbatch \
-        -xc 10 -yc 10 -c circle_catalyst_script.py -r tmp_flow.*
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW \
+        circle_read_grid.txt circle_grid_pvbatch -xc 10 -yc 10 \
+        -c circle_catalyst_script.py -r tmp_flow.*
     echo ""
     echo "Checking $CURRENT_TEST output"
     check_file "RenderView1_0.png"
@@ -157,6 +194,7 @@ test_sphere() {
     cp $INPUT_FILE_DIR/in.sphere .
     cp $INPUT_FILE_DIR/sphere.txt .
     cp $INPUT_FILE_DIR/sphere_read_grid.txt .
+    cp $INPUT_FILE_DIR/sphere_slice.txt .
     cp $INPUT_FILE_DIR/sphere_catalyst_script.py .
 
     CURRENT_TEST="surf2paraview sphere"
@@ -205,6 +243,42 @@ test_sphere() {
     check_file "sphere_grid_pvpython/sphere_grid_pvpython_6_500.vtu" 
     check_file "sphere_grid_pvpython/sphere_grid_pvpython_7_500.vtu" 
     check_file "sphere_grid_pvpython/sphere_grid_pvpython_1000.pvtu" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvpython slice sphere"
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    $PARAVIEW_PVPYTHON $GRID2PARAVIEW sphere_slice.txt \
+        sphere_slice_grid_pvpython -xc 5 -yc 5 -zc 5 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "sphere_slice_grid_pvpython.pvd" 
+    check_file "sphere_slice_grid_pvpython/sphere_slice_grid_pvpython_0.pvtu"
+    check_file "sphere_slice_grid_pvpython/sphere_slice_grid_pvpython_500.pvtu"
+    check_file "sphere_slice_grid_pvpython/sphere_slice_grid_pvpython_33_100.vtu"
+    check_file "sphere_slice_grid_pvpython/sphere_slice_grid_pvpython_50_100.vtu"
+    check_file "sphere_slice_grid_pvpython/sphere_slice_grid_pvpython_27_100.vtu"
+    check_file "sphere_slice_grid_pvpython/sphere_slice_grid_pvpython_1000.pvtu"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvbatch slice sphere"
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW \
+        sphere_slice.txt sphere_slice_grid_pvbatch -xc 10 -yc 10 -zc 10 \
+        -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "sphere_slice_grid_pvbatch.pvd"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_0.pvtu"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_500.pvtu"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_0_200.vtu"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_1_200.vtu"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_2_200.vtu"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_3_200.vtu"
+    check_file "sphere_slice_grid_pvbatch/sphere_slice_grid_pvbatch_1000.pvtu"
+    echo ""
+    echo "Checking $CURRENT_TEST output"
     echo ""
     echo "$CURRENT_TEST test passed"
 

--- a/tools/paraview/runIntegrationTests.sh
+++ b/tools/paraview/runIntegrationTests.sh
@@ -1,0 +1,270 @@
+#!/bin/bash
+
+# To run the ParaView tests, uncomment and set the following shell
+# variables to your installed ParaView and Sparta
+#
+# SPARTA_EXECUTABLE=<PATH TO SPARTA EXECUTABLE>
+# SPARTA_MPI_EXEC=<PATH TO MPI LAUNCH EXECUTABLE FOR SPARTA>
+#
+# PARAVIEW_PVPYTHON=<PATH TO PARAVIEW PVPYTHON EXECUTABLE>
+# PARAVIEW_PVBATCH=<PATH TO PARAVIEW PVBATCH EXECUTABLE>
+# PARAVIEW_MPI_EXEC=<PATH TO MPI LAUNCH EXECUTABLE FOR PARAVIEW>
+
+usage() {
+  echo ""
+  echo "Edit the top section of runIntegrationTests.sh to set installed Paraview"
+  echo "and Sparta executable paths for running tests."
+  echo ""
+}
+
+get_abs_filename() {
+    echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+check_variable() {
+    if [ $# = 1 ]; then
+        echo ""
+        echo $1 "is not set. Unable to run tests."
+        usage
+        exit 1
+    fi
+    
+    if [ ! -x "$1" ]; then
+        echo ""
+        echo $2 "=" $1 "is not executable. Unable to run tests."
+        usage
+        exit 1
+    fi
+}
+
+check_file() {
+    if [ ! -s "$1" ]; then
+        echo "File $1 does not exist. Test $CURRENT_TEST failed."
+        echo "Exiting."
+        exit 1
+    fi
+}
+
+test_circle() {
+    if [ ! -d "/circle" ]; then
+        mkdir circle
+    fi
+
+    cd circle
+    cp $CIRCLE_EXAMPLE_DIR/air.species .
+    cp $CIRCLE_EXAMPLE_DIR/air.vss .
+    cp $CIRCLE_EXAMPLE_DIR/data.circle .
+    cp $INPUT_FILE_DIR/in.circle .
+    cp $INPUT_FILE_DIR/circle.txt .
+    cp $INPUT_FILE_DIR/circle_read_grid.txt .
+    cp $INPUT_FILE_DIR/circle_catalyst_script.py .
+
+    CURRENT_TEST="surf2paraview circle"
+    echo ""
+    echo "Running Sparta circle example"
+    echo ""
+    $SPARTA_MPI_EXEC -np 1 $SPARTA_EXECUTABLE < in.circle
+    echo ""
+    echo "Finished"
+    echo ""
+    echo "Running surf2paraview"
+    $PARAVIEW_PVPYTHON $SURF2PARAVIEW data.circle circle_surf -r tmp_surf.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_surf.pvd" 
+    check_file "circle_surf/circle_surf_0.vtu" 
+    check_file "circle_surf/circle_surf_100.vtu" 
+    check_file "circle_surf/circle_surf_200.vtu" 
+    check_file "circle_surf/circle_surf_300.vtu" 
+    check_file "circle_surf/circle_surf_400.vtu" 
+    check_file "circle_surf/circle_surf_500.vtu" 
+    check_file "circle_surf/circle_surf_600.vtu" 
+    check_file "circle_surf/circle_surf_700.vtu" 
+    check_file "circle_surf/circle_surf_800.vtu" 
+    check_file "circle_surf/circle_surf_900.vtu" 
+    check_file "circle_surf/circle_surf_1000.vtu" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvpython circle"
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    $PARAVIEW_PVPYTHON $GRID2PARAVIEW circle.txt circle_grid_pvpython -xc 10 -yc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_grid_pvpython.pvd" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_0.pvtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_1_0.vtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_2_0.vtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_500.pvtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_1_500.vtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_2_500.vtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_1000.pvtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_1_1000.vtu" 
+    check_file "circle_grid_pvpython/circle_grid_pvpython_2_1000.vtu" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvbatch circle"
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW circle.txt circle_grid_pvbatch \
+        -xc 10 -yc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_grid_pvbatch.pvd"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_0.pvtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_1_0.vtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_2_0.vtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_500.pvtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_1_500.vtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_2_500.vtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_1000.pvtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_1_1000.vtu"
+    check_file "circle_grid_pvbatch/circle_grid_pvbatch_2_1000.vtu"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview catalyst circle"
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW circle_read_grid.txt circle_grid_pvbatch \
+        -xc 10 -yc 10 -c circle_catalyst_script.py -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "RenderView1_0.png"
+    check_file "RenderView1_1.png"
+    check_file "RenderView1_2.png"
+    check_file "RenderView1_3.png"
+    check_file "RenderView1_4.png"
+    check_file "RenderView1_5.png"
+    check_file "RenderView1_6.png"
+    check_file "RenderView1_7.png"
+    check_file "RenderView1_8.png"
+    check_file "RenderView1_9.png"
+    check_file "RenderView1_10.png"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    cd ../
+}
+
+test_sphere() {
+    if [ ! -d "/sphere" ]; then
+        mkdir sphere
+    fi
+
+    cd sphere
+    cp $SPHERE_EXAMPLE_DIR/air.species .
+    cp $SPHERE_EXAMPLE_DIR/air.vss .
+    cp $SPHERE_EXAMPLE_DIR/data.sphere .
+    cp $INPUT_FILE_DIR/in.sphere .
+    cp $INPUT_FILE_DIR/sphere.txt .
+    cp $INPUT_FILE_DIR/sphere_read_grid.txt .
+    cp $INPUT_FILE_DIR/sphere_catalyst_script.py .
+
+    CURRENT_TEST="surf2paraview sphere"
+    echo ""
+    echo "Running Sparta sphere example"
+    echo ""
+    $SPARTA_MPI_EXEC -np 1 $SPARTA_EXECUTABLE < in.sphere
+    echo ""
+    echo "Finished"
+    echo ""
+    echo "Running surf2paraview"
+    $PARAVIEW_PVPYTHON $SURF2PARAVIEW data.sphere sphere_surf -r tmp_surf.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "sphere_surf.pvd" 
+    check_file "sphere_surf/sphere_surf_0.vtu" 
+    check_file "sphere_surf/sphere_surf_100.vtu" 
+    check_file "sphere_surf/sphere_surf_200.vtu" 
+    check_file "sphere_surf/sphere_surf_300.vtu" 
+    check_file "sphere_surf/sphere_surf_400.vtu" 
+    check_file "sphere_surf/sphere_surf_500.vtu" 
+    check_file "sphere_surf/sphere_surf_600.vtu" 
+    check_file "sphere_surf/sphere_surf_700.vtu" 
+    check_file "sphere_surf/sphere_surf_800.vtu" 
+    check_file "sphere_surf/sphere_surf_900.vtu" 
+    check_file "sphere_surf/sphere_surf_1000.vtu" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvpython sphere"
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    $PARAVIEW_PVPYTHON $GRID2PARAVIEW sphere.txt sphere_grid_pvpython \
+        -xc 10 -yc 10 -zc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "sphere_grid_pvpython.pvd" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_0.pvtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_500.pvtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_0_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_1_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_2_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_3_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_4_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_5_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_6_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_7_500.vtu" 
+    check_file "sphere_grid_pvpython/sphere_grid_pvpython_1000.pvtu" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview pvbatch sphere"
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW sphere.txt sphere_grid_pvbatch \
+        -xc 10 -yc 10 -zc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "sphere_grid_pvbatch.pvd"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_0.pvtu"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_500.pvtu"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_0_500.vtu"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_1_500.vtu"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_2_500.vtu"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_3_500.vtu"
+    check_file "sphere_grid_pvbatch/sphere_grid_pvbatch_1000.pvtu"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="grid2paraview catalyst sphere"
+    $PARAVIEW_MPI_EXEC -np 4 $PARAVIEW_PVBATCH -sym $GRID2PARAVIEW sphere_read_grid.txt sphere_grid_pvbatch \
+        -xc 10 -yc 10 -zc 10 -c sphere_catalyst_script.py -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "RenderView1_0.png"
+    check_file "RenderView1_1.png"
+    check_file "RenderView1_2.png"
+    check_file "RenderView1_3.png"
+    check_file "RenderView1_4.png"
+    check_file "RenderView1_5.png"
+    check_file "RenderView1_6.png"
+    check_file "RenderView1_7.png"
+    check_file "RenderView1_8.png"
+    check_file "RenderView1_9.png"
+    check_file "RenderView1_10.png"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    cd ../
+}
+
+check_variable $SPARTA_EXECUTABLE "SPARTA_EXECUTABLE"
+check_variable $SPARTA_MPI_EXEC "SPARTA_MPI_EXEC"
+check_variable $PARAVIEW_PVPYTHON "PARAVIEW_PVPYTHON"
+check_variable $PARAVIEW_PVBATCH "PARAVIEW_PVBATCH"
+check_variable $PARAVIEW_MPI_EXEC "PARAVIEW_MPI_EXEC"
+
+GRID2PARAVIEW=$(get_abs_filename "grid2paraview.py")
+SURF2PARAVIEW=$(get_abs_filename "surf2paraview.py")
+CIRCLE_EXAMPLE_DIR=$(get_abs_filename "../../examples/circle/")
+SPHERE_EXAMPLE_DIR=$(get_abs_filename "../../examples/sphere/")
+INPUT_FILE_DIR=$(get_abs_filename "tests/input_files/")
+TEST_DIR="integration_test_scratch_directory"
+if [ ! -d "${TEST_DIR}" ]; then
+    mkdir ${TEST_DIR}
+fi
+cd ${TEST_DIR}
+
+test_circle
+test_sphere
+
+echo ""
+echo "All Sparta/Paraview integration tests passed"

--- a/tools/paraview/tests/input_files/circle.txt
+++ b/tools/paraview/tests/input_files/circle.txt
@@ -1,0 +1,3 @@
+dimension   	    2
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    20 20 1 

--- a/tools/paraview/tests/input_files/circle_catalyst_script.py
+++ b/tools/paraview/tests/input_files/circle_catalyst_script.py
@@ -1,0 +1,231 @@
+
+#--------------------------------------------------------------
+
+# Global timestep output options
+timeStepToStartOutputAt=0
+forceOutputAtFirstCall=False
+
+# Global screenshot output options
+imageFileNamePadding=0
+rescale_lookuptable=False
+
+# Whether or not to request specific arrays from the adaptor.
+requestSpecificArrays=False
+
+# a root directory under which all Catalyst output goes
+rootDirectory=''
+
+# makes a cinema D index table
+make_cinema_table=False
+
+#--------------------------------------------------------------
+# Code generated from cpstate.py to create the CoProcessor.
+# paraview version 5.6.0
+#--------------------------------------------------------------
+
+from paraview.simple import *
+from paraview import coprocessing
+
+# ----------------------- CoProcessor definition -----------------------
+
+def CreateCoProcessor():
+  def _CreatePipeline(coprocessor, datadescription):
+    class Pipeline:
+      # state file generated using paraview version 5.6.0
+
+      # ----------------------------------------------------------------
+      # setup views used in the visualization
+      # ----------------------------------------------------------------
+
+      # trace generated using paraview version 5.6.0
+      #
+      # To ensure correct image size when batch processing, please search 
+      # for and uncomment the line `# renderView*.ViewSize = [*,*]`
+
+      #### disable automatic camera reset on 'Show'
+      paraview.simple._DisableFirstRenderCameraReset()
+
+      # get the material library
+      materialLibrary1 = GetMaterialLibrary()
+
+      # Create a new 'Render View'
+      renderView1 = CreateView('RenderView')
+      renderView1.ViewSize = [1512, 1568]
+      renderView1.InteractionMode = '2D'
+      renderView1.AxesGrid = 'GridAxes3DActor'
+      renderView1.CenterOfRotation = [5.0, 5.0, 0.0]
+      renderView1.StereoType = 0
+      renderView1.CameraPosition = [5.0, 5.0, 10000.0]
+      renderView1.CameraFocalPoint = [5.0, 5.0, 0.0]
+      renderView1.CameraParallelScale = 7.332959212304938
+      renderView1.Background = [0.32, 0.34, 0.43]
+      renderView1.OSPRayMaterialLibrary = materialLibrary1
+
+      # init the 'GridAxes3DActor' selected for 'AxesGrid'
+      renderView1.AxesGrid.XTitleFontFile = ''
+      renderView1.AxesGrid.YTitleFontFile = ''
+      renderView1.AxesGrid.ZTitleFontFile = ''
+      renderView1.AxesGrid.XLabelFontFile = ''
+      renderView1.AxesGrid.YLabelFontFile = ''
+      renderView1.AxesGrid.ZLabelFontFile = ''
+
+      # register the view with coprocessor
+      # and provide it with information such as the filename to use,
+      # how frequently to write the images, etc.
+      coprocessor.RegisterView(renderView1,
+          filename='RenderView1_%t.png', freq=1, fittoscreen=0, magnification=1, width=1512, height=1568, cinema={})
+      renderView1.ViewTime = datadescription.GetTime()
+
+      # ----------------------------------------------------------------
+      # restore active view
+      SetActiveView(renderView1)
+      # ----------------------------------------------------------------
+
+      # ----------------------------------------------------------------
+      # setup the data processing pipelines
+      # ----------------------------------------------------------------
+
+      # create a new 'PVD Reader'
+      # create a producer from a simulation input
+      circle_grid_pvbatchpvd = coprocessor.CreateProducer(datadescription, 'circle_grid_pvbatch.pvd')
+
+      # ----------------------------------------------------------------
+      # setup the visualization in view 'renderView1'
+      # ----------------------------------------------------------------
+
+      # show data from circle_grid_pvbatchpvd
+      circle_grid_pvbatchpvdDisplay = Show(circle_grid_pvbatchpvd, renderView1)
+
+      # get color transfer function/color map for 'f_12'
+      f_12LUT = GetColorTransferFunction('f_12')
+      f_12LUT.RGBPoints = [-27.991, 0.231373, 0.298039, 0.752941, 263.7225, 0.865003, 0.865003, 0.865003, 555.436, 0.705882, 0.0156863, 0.14902]
+      f_12LUT.ScalarRangeInitialized = 1.0
+
+      # get opacity transfer function/opacity map for 'f_12'
+      f_12PWF = GetOpacityTransferFunction('f_12')
+      f_12PWF.Points = [-27.991, 0.0, 0.5, 0.0, 555.436, 1.0, 0.5, 0.0]
+      f_12PWF.ScalarRangeInitialized = 1
+
+      # trace defaults for the display properties.
+      circle_grid_pvbatchpvdDisplay.Representation = 'Surface With Edges'
+      circle_grid_pvbatchpvdDisplay.ColorArrayName = ['CELLS', 'f_1[2]']
+      circle_grid_pvbatchpvdDisplay.LookupTable = f_12LUT
+      circle_grid_pvbatchpvdDisplay.OSPRayScaleFunction = 'PiecewiseFunction'
+      circle_grid_pvbatchpvdDisplay.SelectOrientationVectors = 'None'
+      circle_grid_pvbatchpvdDisplay.SelectScaleArray = 'None'
+      circle_grid_pvbatchpvdDisplay.GlyphType = 'Arrow'
+      circle_grid_pvbatchpvdDisplay.GlyphTableIndexArray = 'None'
+      circle_grid_pvbatchpvdDisplay.GaussianRadius = 0.05
+      circle_grid_pvbatchpvdDisplay.SetScaleArray = [None, '']
+      circle_grid_pvbatchpvdDisplay.ScaleTransferFunction = 'PiecewiseFunction'
+      circle_grid_pvbatchpvdDisplay.OpacityArray = [None, '']
+      circle_grid_pvbatchpvdDisplay.OpacityTransferFunction = 'PiecewiseFunction'
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid = 'GridAxesRepresentation'
+      circle_grid_pvbatchpvdDisplay.SelectionCellLabelFontFile = ''
+      circle_grid_pvbatchpvdDisplay.SelectionPointLabelFontFile = ''
+      circle_grid_pvbatchpvdDisplay.PolarAxes = 'PolarAxesRepresentation'
+      circle_grid_pvbatchpvdDisplay.ScalarOpacityFunction = f_12PWF
+      circle_grid_pvbatchpvdDisplay.ScalarOpacityUnitDistance = 1.9193831036664846
+
+      # init the 'GridAxesRepresentation' selected for 'DataAxesGrid'
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid.XTitleFontFile = ''
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid.YTitleFontFile = ''
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid.ZTitleFontFile = ''
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid.XLabelFontFile = ''
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid.YLabelFontFile = ''
+      circle_grid_pvbatchpvdDisplay.DataAxesGrid.ZLabelFontFile = ''
+
+      # init the 'PolarAxesRepresentation' selected for 'PolarAxes'
+      circle_grid_pvbatchpvdDisplay.PolarAxes.PolarAxisTitleFontFile = ''
+      circle_grid_pvbatchpvdDisplay.PolarAxes.PolarAxisLabelFontFile = ''
+      circle_grid_pvbatchpvdDisplay.PolarAxes.LastRadialAxisTextFontFile = ''
+      circle_grid_pvbatchpvdDisplay.PolarAxes.SecondaryRadialAxesTextFontFile = ''
+
+      # setup the color legend parameters for each legend in this view
+
+      # get color legend/bar for f_12LUT in view renderView1
+      f_12LUTColorBar = GetScalarBar(f_12LUT, renderView1)
+      f_12LUTColorBar.Title = 'f_1[2]'
+      f_12LUTColorBar.ComponentTitle = ''
+      f_12LUTColorBar.TitleFontFile = ''
+      f_12LUTColorBar.LabelFontFile = ''
+
+      # set color bar visibility
+      f_12LUTColorBar.Visibility = 1
+
+      # show color legend
+      circle_grid_pvbatchpvdDisplay.SetScalarBarVisibility(renderView1, True)
+
+      # ----------------------------------------------------------------
+      # setup color maps and opacity mapes used in the visualization
+      # note: the Get..() functions create a new object, if needed
+      # ----------------------------------------------------------------
+
+      # ----------------------------------------------------------------
+      # finally, restore active source
+      SetActiveSource(circle_grid_pvbatchpvd)
+      # ----------------------------------------------------------------
+    return Pipeline()
+
+  class CoProcessor(coprocessing.CoProcessor):
+    def CreatePipeline(self, datadescription):
+      self.Pipeline = _CreatePipeline(self, datadescription)
+
+  coprocessor = CoProcessor()
+  # these are the frequencies at which the coprocessor updates.
+  freqs = {'circle_grid_pvbatch.pvd': [1]}
+  coprocessor.SetUpdateFrequencies(freqs)
+  if requestSpecificArrays:
+    arrays = [['f_1[10]', 1], ['f_1[11]', 1], ['f_1[12]', 1], ['f_1[13]', 1], ['f_1[14]', 1], ['f_1[1]', 1], ['f_1[2]', 1], ['f_1[3]', 1], ['f_1[4]', 1], ['f_1[5]', 1], ['f_1[6]', 1], ['f_1[7]', 1], ['f_1[8]', 1], ['f_1[9]', 1], ['id', 1]]
+    coprocessor.SetRequestedArrays('circle_grid_pvbatch.pvd', arrays)
+  coprocessor.SetInitialOutputOptions(timeStepToStartOutputAt,forceOutputAtFirstCall)
+
+  if rootDirectory:
+      coprocessor.SetRootDirectory(rootDirectory)
+
+  if make_cinema_table:
+      coprocessor.EnableCinemaDTable()
+
+  return coprocessor
+
+
+#--------------------------------------------------------------
+# Global variable that will hold the pipeline for each timestep
+# Creating the CoProcessor object, doesn't actually create the ParaView pipeline.
+# It will be automatically setup when coprocessor.UpdateProducers() is called the
+# first time.
+coprocessor = CreateCoProcessor()
+
+#--------------------------------------------------------------
+# Enable Live-Visualizaton with ParaView and the update frequency
+coprocessor.EnableLiveVisualization(False, 1)
+
+# ---------------------- Data Selection method ----------------------
+
+def RequestDataDescription(datadescription):
+    "Callback to populate the request for current timestep"
+    global coprocessor
+
+    # setup requests for all inputs based on the requirements of the
+    # pipeline.
+    coprocessor.LoadRequestedData(datadescription)
+
+# ------------------------ Processing method ------------------------
+
+def DoCoProcessing(datadescription):
+    "Callback to do co-processing for current timestep"
+    global coprocessor
+
+    # Update the coprocessor by providing it the newly generated simulation data.
+    # If the pipeline hasn't been setup yet, this will setup the pipeline.
+    coprocessor.UpdateProducers(datadescription)
+
+    # Write output data, if appropriate.
+    coprocessor.WriteData(datadescription);
+
+    # Write image capture (Last arg: rescale lookup table), if appropriate.
+    coprocessor.WriteImages(datadescription, rescale_lookuptable=rescale_lookuptable,
+        image_quality=0, padding_amount=imageFileNamePadding)
+
+    # Live Visualization, if enabled.
+    coprocessor.DoLiveVisualization(datadescription, "localhost", 22222)

--- a/tools/paraview/tests/input_files/circle_read_grid.txt
+++ b/tools/paraview/tests/input_files/circle_read_grid.txt
@@ -1,0 +1,3 @@
+dimension   	    2
+create_box  	    0 10 0 10 -0.5 0.5
+read_grid           data.grid

--- a/tools/paraview/tests/input_files/circle_slice.txt
+++ b/tools/paraview/tests/input_files/circle_slice.txt
@@ -1,0 +1,6 @@
+dimension   	    2
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    20 20 1 
+slice               1 0 0 5 5 0.0
+slice               0 1 0 5 5 0.0
+slice               1 1 0 5 5 0.0

--- a/tools/paraview/tests/input_files/in.circle
+++ b/tools/paraview/tests/input_files/in.circle
@@ -1,0 +1,44 @@
+# 2d flow around a circle
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    20 20 1 
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0 
+
+read_surf           data.circle
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+compute             1 grid all species n u v w usq vsq wsq
+compute             2 surf all species n nwt mflux fx fx fz press ke
+fix                 1 ave/grid all 1 100 100 c_1[*]
+fix                 2 ave/surf all 1 100 100 c_2[*]
+dump                1 grid all 100 tmp_flow.* id f_1[*]
+dump                2 surf all 100 tmp_surf.* id f_2[*]
+
+fix		    in emit/face air xlo # subsonic 0.1 NULL
+
+write_grid          parent data.grid
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 &
+#                    surf proc 0.01 size 512 512 zoom 1.75 &
+#                    gline yes 0.005 
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000

--- a/tools/paraview/tests/input_files/in.sphere
+++ b/tools/paraview/tests/input_files/in.sphere
@@ -1,0 +1,51 @@
+# 3d flow around a sphere
+
+seed	    	    12345
+dimension   	    3
+
+global              gridcut 0.1 comm/sort yes
+
+boundary	    o r r
+
+create_box  	    -2 2 -2 2 -2 2
+
+create_grid         20 20 20
+
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.0005
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0 
+
+read_surf           data.sphere
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide		    vss air air.vss
+
+fix		    in emit/face air xlo 
+
+compute             1 grid all species n u v w usq vsq wsq
+compute             2 surf all species n nwt mflux fx fx fz press ke
+fix                 1 ave/grid all 1 100 100 c_1[*]
+fix                 2 ave/surf all 1 100 100 c_2[*]
+dump                1 grid all 100 tmp_flow.* id f_1[*]
+dump                2 surf all 100 tmp_surf.* id f_2[*]
+write_grid          parent data.grid
+
+timestep 	    0.0001
+
+#compute             2 surf all all n press ke
+#fix                 save ave/surf all 1 50 50 c_2[*] ave running
+#region              slab block INF INF INF INF -0.1 0.1
+#dump                2 image all 50 image.*.ppm type type pdiam 0.03 &
+#		    view 70 120 size 512 512 axes yes 0.9 0.02 &
+#                    gridz -0.8 proc gline yes 0.005 &
+#                    surf f_save[2] 0.0
+#dump_modify	    2 pad 4 region slab
+#dump_modify         2 cmap surf min max cf 0.0 2 min orange max green
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000

--- a/tools/paraview/tests/input_files/sphere.txt
+++ b/tools/paraview/tests/input_files/sphere.txt
@@ -1,0 +1,3 @@
+dimension           3
+create_box          -2 2 -2 2 -2 2
+create_grid         20 20 20

--- a/tools/paraview/tests/input_files/sphere_catalyst_script.py
+++ b/tools/paraview/tests/input_files/sphere_catalyst_script.py
@@ -1,0 +1,235 @@
+
+#--------------------------------------------------------------
+
+# Global timestep output options
+timeStepToStartOutputAt=0
+forceOutputAtFirstCall=False
+
+# Global screenshot output options
+imageFileNamePadding=0
+rescale_lookuptable=False
+
+# Whether or not to request specific arrays from the adaptor.
+requestSpecificArrays=False
+
+# a root directory under which all Catalyst output goes
+rootDirectory=''
+
+# makes a cinema D index table
+make_cinema_table=False
+
+#--------------------------------------------------------------
+# Code generated from cpstate.py to create the CoProcessor.
+# paraview version 5.6.0
+#--------------------------------------------------------------
+
+from paraview.simple import *
+from paraview import coprocessing
+
+# ----------------------- CoProcessor definition -----------------------
+
+def CreateCoProcessor():
+  def _CreatePipeline(coprocessor, datadescription):
+    class Pipeline:
+      # state file generated using paraview version 5.6.0
+
+      # ----------------------------------------------------------------
+      # setup views used in the visualization
+      # ----------------------------------------------------------------
+
+      # trace generated using paraview version 5.6.0
+      #
+      # To ensure correct image size when batch processing, please search 
+      # for and uncomment the line `# renderView*.ViewSize = [*,*]`
+
+      #### disable automatic camera reset on 'Show'
+      paraview.simple._DisableFirstRenderCameraReset()
+
+      # get the material library
+      materialLibrary1 = GetMaterialLibrary()
+
+      # Create a new 'Render View'
+      renderView1 = CreateView('RenderView')
+      renderView1.ViewSize = [1512, 1568]
+      renderView1.AxesGrid = 'GridAxes3DActor'
+      renderView1.StereoType = 0
+      renderView1.CameraPosition = [11.693224453960685, 0.24893581001714482, 7.413155031681012]
+      renderView1.CameraViewUp = [0.019443143110028937, 0.9977493262176635, -0.06417356323441484]
+      renderView1.CameraParallelScale = 3.5924016749576713
+      renderView1.Background = [0.32, 0.34, 0.43]
+      renderView1.OSPRayMaterialLibrary = materialLibrary1
+
+      # init the 'GridAxes3DActor' selected for 'AxesGrid'
+      renderView1.AxesGrid.XTitleFontFile = ''
+      renderView1.AxesGrid.YTitleFontFile = ''
+      renderView1.AxesGrid.ZTitleFontFile = ''
+      renderView1.AxesGrid.XLabelFontFile = ''
+      renderView1.AxesGrid.YLabelFontFile = ''
+      renderView1.AxesGrid.ZLabelFontFile = ''
+
+      # register the view with coprocessor
+      # and provide it with information such as the filename to use,
+      # how frequently to write the images, etc.
+      coprocessor.RegisterView(renderView1,
+          filename='RenderView1_%t.png', freq=1, fittoscreen=0, magnification=1, width=1512, height=1568, cinema={})
+      renderView1.ViewTime = datadescription.GetTime()
+
+      # ----------------------------------------------------------------
+      # restore active view
+      SetActiveView(renderView1)
+      # ----------------------------------------------------------------
+
+      # ----------------------------------------------------------------
+      # setup the data processing pipelines
+      # ----------------------------------------------------------------
+
+      # create a new 'PVD Reader'
+      # create a producer from a simulation input
+      sphere_grid_pvbatchpvd = coprocessor.CreateProducer(datadescription, 'sphere_grid_pvbatch.pvd')
+
+      # create a new 'Clip'
+      clip1 = Clip(Input=sphere_grid_pvbatchpvd)
+      clip1.ClipType = 'Plane'
+      clip1.Scalars = ['CELLS', 'f_1[10]']
+
+      # ----------------------------------------------------------------
+      # setup the visualization in view 'renderView1'
+      # ----------------------------------------------------------------
+
+      # show data from clip1
+      clip1Display = Show(clip1, renderView1)
+
+      # get color transfer function/color map for 'f_11'
+      f_11LUT = GetColorTransferFunction('f_11')
+      f_11LUT.RGBPoints = [0.0, 0.231373, 0.298039, 0.752941, 4.555, 0.865003, 0.865003, 0.865003, 9.11, 0.705882, 0.0156863, 0.14902]
+      f_11LUT.ScalarRangeInitialized = 1.0
+
+      # get opacity transfer function/opacity map for 'f_11'
+      f_11PWF = GetOpacityTransferFunction('f_11')
+      f_11PWF.Points = [0.0, 0.0, 0.5, 0.0, 9.11, 1.0, 0.5, 0.0]
+      f_11PWF.ScalarRangeInitialized = 1
+
+      # trace defaults for the display properties.
+      clip1Display.Representation = 'Surface With Edges'
+      clip1Display.ColorArrayName = ['CELLS', 'f_1[1]']
+      clip1Display.LookupTable = f_11LUT
+      clip1Display.OSPRayScaleFunction = 'PiecewiseFunction'
+      clip1Display.SelectOrientationVectors = 'None'
+      clip1Display.ScaleFactor = 0.4
+      clip1Display.SelectScaleArray = 'None'
+      clip1Display.GlyphType = 'Arrow'
+      clip1Display.GlyphTableIndexArray = 'None'
+      clip1Display.GaussianRadius = 0.02
+      clip1Display.SetScaleArray = [None, '']
+      clip1Display.ScaleTransferFunction = 'PiecewiseFunction'
+      clip1Display.OpacityArray = [None, '']
+      clip1Display.OpacityTransferFunction = 'PiecewiseFunction'
+      clip1Display.DataAxesGrid = 'GridAxesRepresentation'
+      clip1Display.SelectionCellLabelFontFile = ''
+      clip1Display.SelectionPointLabelFontFile = ''
+      clip1Display.PolarAxes = 'PolarAxesRepresentation'
+      clip1Display.ScalarOpacityFunction = f_11PWF
+      clip1Display.ScalarOpacityUnitDistance = 0.377976314968462
+
+      # init the 'GridAxesRepresentation' selected for 'DataAxesGrid'
+      clip1Display.DataAxesGrid.XTitleFontFile = ''
+      clip1Display.DataAxesGrid.YTitleFontFile = ''
+      clip1Display.DataAxesGrid.ZTitleFontFile = ''
+      clip1Display.DataAxesGrid.XLabelFontFile = ''
+      clip1Display.DataAxesGrid.YLabelFontFile = ''
+      clip1Display.DataAxesGrid.ZLabelFontFile = ''
+
+      # init the 'PolarAxesRepresentation' selected for 'PolarAxes'
+      clip1Display.PolarAxes.PolarAxisTitleFontFile = ''
+      clip1Display.PolarAxes.PolarAxisLabelFontFile = ''
+      clip1Display.PolarAxes.LastRadialAxisTextFontFile = ''
+      clip1Display.PolarAxes.SecondaryRadialAxesTextFontFile = ''
+
+      # setup the color legend parameters for each legend in this view
+
+      # get color legend/bar for f_11LUT in view renderView1
+      f_11LUTColorBar = GetScalarBar(f_11LUT, renderView1)
+      f_11LUTColorBar.Title = 'f_1[1]'
+      f_11LUTColorBar.ComponentTitle = ''
+      f_11LUTColorBar.TitleFontFile = ''
+      f_11LUTColorBar.LabelFontFile = ''
+
+      # set color bar visibility
+      f_11LUTColorBar.Visibility = 1
+
+      # show color legend
+      clip1Display.SetScalarBarVisibility(renderView1, True)
+
+      # ----------------------------------------------------------------
+      # setup color maps and opacity mapes used in the visualization
+      # note: the Get..() functions create a new object, if needed
+      # ----------------------------------------------------------------
+
+      # ----------------------------------------------------------------
+      # finally, restore active source
+      SetActiveSource(clip1)
+      # ----------------------------------------------------------------
+    return Pipeline()
+
+  class CoProcessor(coprocessing.CoProcessor):
+    def CreatePipeline(self, datadescription):
+      self.Pipeline = _CreatePipeline(self, datadescription)
+
+  coprocessor = CoProcessor()
+  # these are the frequencies at which the coprocessor updates.
+  freqs = {'sphere_grid_pvbatch.pvd': [1, 1]}
+  coprocessor.SetUpdateFrequencies(freqs)
+  if requestSpecificArrays:
+    arrays = [['f_1[10]', 1], ['f_1[11]', 1], ['f_1[12]', 1], ['f_1[13]', 1], ['f_1[14]', 1], ['f_1[1]', 1], ['f_1[2]', 1], ['f_1[3]', 1], ['f_1[4]', 1], ['f_1[5]', 1], ['f_1[6]', 1], ['f_1[7]', 1], ['f_1[8]', 1], ['f_1[9]', 1], ['id', 1]]
+    coprocessor.SetRequestedArrays('sphere_grid_pvbatch.pvd', arrays)
+  coprocessor.SetInitialOutputOptions(timeStepToStartOutputAt,forceOutputAtFirstCall)
+
+  if rootDirectory:
+      coprocessor.SetRootDirectory(rootDirectory)
+
+  if make_cinema_table:
+      coprocessor.EnableCinemaDTable()
+
+  return coprocessor
+
+
+#--------------------------------------------------------------
+# Global variable that will hold the pipeline for each timestep
+# Creating the CoProcessor object, doesn't actually create the ParaView pipeline.
+# It will be automatically setup when coprocessor.UpdateProducers() is called the
+# first time.
+coprocessor = CreateCoProcessor()
+
+#--------------------------------------------------------------
+# Enable Live-Visualizaton with ParaView and the update frequency
+coprocessor.EnableLiveVisualization(False, 1)
+
+# ---------------------- Data Selection method ----------------------
+
+def RequestDataDescription(datadescription):
+    "Callback to populate the request for current timestep"
+    global coprocessor
+
+    # setup requests for all inputs based on the requirements of the
+    # pipeline.
+    coprocessor.LoadRequestedData(datadescription)
+
+# ------------------------ Processing method ------------------------
+
+def DoCoProcessing(datadescription):
+    "Callback to do co-processing for current timestep"
+    global coprocessor
+
+    # Update the coprocessor by providing it the newly generated simulation data.
+    # If the pipeline hasn't been setup yet, this will setup the pipeline.
+    coprocessor.UpdateProducers(datadescription)
+
+    # Write output data, if appropriate.
+    coprocessor.WriteData(datadescription);
+
+    # Write image capture (Last arg: rescale lookup table), if appropriate.
+    coprocessor.WriteImages(datadescription, rescale_lookuptable=rescale_lookuptable,
+        image_quality=0, padding_amount=imageFileNamePadding)
+
+    # Live Visualization, if enabled.
+    coprocessor.DoLiveVisualization(datadescription, "localhost", 22222)

--- a/tools/paraview/tests/input_files/sphere_read_grid.txt
+++ b/tools/paraview/tests/input_files/sphere_read_grid.txt
@@ -1,0 +1,3 @@
+dimension           3
+create_box          -2 2 -2 2 -2 2
+read_grid           data.grid

--- a/tools/paraview/tests/input_files/sphere_slice.txt
+++ b/tools/paraview/tests/input_files/sphere_slice.txt
@@ -1,0 +1,7 @@
+dimension           3
+create_box          -2 2 -2 2 -2 2
+create_grid         20 20 20
+slice               1 0 0 0.0 0.0 0.0
+slice               0 1 0 0.0 0.0 0.0
+slice               1 1 1 0.0 0.0 0.0
+slice               1 0 1 0.0 0.0 0.0


### PR DESCRIPTION
Modified grid2paraview.py to output a pvtu file
per timestep, and reference these pvtu files in
the pvd file. This will allow the individual vtu
files to be distributed accross multiple MPI ranks
when ParaView is run in parallel client/server
mode.

## Purpose

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request. If this addresses an open GitHub Issue, mention the issue number, e.g. with `fixes #221` or `closes #135`, so that issue will be automatically closed when the pull request is merged_

## Author(s)

_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


