### PR TITLE
bug fix when new surf alg is used in a restart

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -178,11 +178,11 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
     t1 = MPI_Wtime();
   }
 
-  // if subflag, reset hash for parent/child IDs
+  // if no hash or subflag, reset hash for parent/child IDs
   // needed b/c callers called clear_surf before surf2grid
   //   to wipe out split cells and compress local cell list
 
-  if (subflag) rehash();
+  if (!hashfilled || subflag) rehash();
 
   // assign every Pth surf to me
   // nsurf = # of surfs I own for finding overlaps with cells


### PR DESCRIPTION
## Purpose

Fix a one-line bug with the new surf to cell mapping algorithm when reading a restart file.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


