### PR TITLE
add rendezvous method for summing surface tallies

### DIFF
--- a/doc/global.txt
+++ b/doc/global.txt
@@ -13,7 +13,7 @@ global command :h3
 global keyword values ... :pre
 
 one or more keyword/value pairs :ulb,l
-keyword = {fnum} or {nrho} or {vstream} or {temp} or {gravity} or {surfs} or {surfgrid} or {surfmax} or {cellmax} or {splitmax} or {surfpush} or {gridcut} or {comm/sort} or {comm/style} or {weight} or {particle/reorder} or {mem/limit} :l
+keyword = {fnum} or {nrho} or {vstream} or {temp} or {gravity} or {surfs} or {surfgrid} or {surfmax} or {cellmax} or {splitmax} or {surftally} or {surfpush} or {gridcut} or {comm/sort} or {comm/style} or {weight} or {particle/reorder} or {mem/limit} :l
   {fnum} value = ratio
     ratio = Fnum ratio of physical particles to simulation particles
   {nrho} value = density
@@ -31,16 +31,20 @@ keyword = {fnum} or {nrho} or {vstream} or {temp} or {gravity} or {surfs} or {su
                            only the surfs for its owned_ghost grid cells
     implicit = surfs defined in read_isurf file, each proc owns
                            only the surfs for its owned+ghost grid cells
-  {surfgrid} value = combo or percell or persurf
+  {surfgrid} value = {percell} or {persurf} or {auto}
     percell = loop over my cells and check every surf
     persurf = loop over my surfs and cells they overlap
-    combo = choose percell or persurf based on surface element and proc count
+    auto = choose percell or persurf based on surface element and proc count
   {surfmax} value = Nsurf
     Nsurf = max # of surface elements allowed in single grid cell
   {cellmax} value = Ncell
     Ncell = max # of grid cells a single surf can overlap
   {splitmax} value = Nsplit
     Nsplit = max # of sub-cells one grid cell can be split into by surface elements
+  {surftally} value = {reduce} or {rvous} or {auto}
+    reduce = tally surf collision info via MPI_Allreduce operations
+    rvous = tally via a rendezvous algorithm
+    auto = choose reduce or rvous based on surface element and proc count
   {surfpush} value(s) = no/yes or slo shi svalue
     no = do not push surface element points near cell surface
     yes = push surface element points near cell surface if necessary
@@ -122,7 +126,7 @@ MBytes.
 The {surfgrid} keyword determines what algorithm is used to enumerate
 the overlaps (intersections) between grid cells and surface elements
 (lines in 2d, triangles in 3d).  The possible settings are {percell},
-{persurf}, and {combo}.  The {combo} setting is the default and will
+{persurf}, and {auto}.  The {auto} setting is the default and will
 choose between a {percell} or {persurf} algorithm based on the number
 of surface elements and processor count.  If there are more processors
 than surface elements, the {percell} algorithm is used.  Otherwise the
@@ -154,6 +158,24 @@ with multiple surface elements (lines in 2d, triangles in 3d).  The
 default is 10, which should be large enough for any simulation, unless
 you embed a complex-shaped surface object into one or a very few grid
 cells.
+
+The {surftally} keyword determines what algorithm is used to combine
+tallies of surface collisions across processors that own portions of
+the same surface element.  The possible settings are {reduce},
+{rvous}, and {auto}.  The {auto} setting is the default and will
+choose between a {reduce} or {rvous} algorithm based on the number of
+surface elements and processor count.  If there are more processors
+than surface elements, the {reduce} algorithm is used.  Otherwise the
+{rvous} algorithm is used.  The {reduce} algorithm is suitable for
+relatively small surface elememt counts.  It creates a copy of a
+vector or array of length the global number of surface elements.  Each
+processor sums its tally contributions into the vector or array.  An
+MPI_Allreduce() is performed to sum it across all processors.  Each
+processor than extracts values for the N/P surfaces it owns.  The
+{rvous} algorithm is faster for large surface element counts.  A
+rendezvous style of communication is performed where every processor
+sends its tally contributions directly to the processor which owns the
+element as one of its N/P elements.
 
 :line
 
@@ -375,6 +397,7 @@ defined, e.g. via the "read_surf"_read_surf.html command.
 
 The keyword defaults are fnum = 1.0, nrho = 1.0, vstream = 0.0 0.0
 0.0, temp = 273.15, gravity = 0.0 0.0 0.0 0.0, surfs = explicit,
-surfgrid = combo, surfmax = 100, cellmax = 100, splitmax = 10,
-surfpush = yes, gridcut = -1.0, comm/sort = no, comm/style = neigh,
-weight = cell none, particle/reorder = 0, mem/limit = 0.
+surfgrid = auto, surfmax = 100, cellmax = 100, splitmax = 10,
+surftally = auto, surfpush = yes, gridcut = -1.0, comm/sort = no,
+comm/style = neigh, weight = cell none, particle/reorder = 0,
+mem/limit = 0.

--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -45,6 +45,7 @@ ComputeSurfKokkos::ComputeSurfKokkos(SPARTA *sparta) :
   surf2tally = NULL;
   tally2surf = NULL;
   array_surf_tally = NULL;
+  vector_surf = NULL;
   normflux = NULL;
   id = NULL;
   style = NULL;

--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -35,15 +35,15 @@ ComputeSurfKokkos::ComputeSurfKokkos(SPARTA *sparta, int narg, char **arg) :
   kokkos_flag = 1;
   d_which = DAT::t_int_1d("surf:which",nvalue);
 
-  d_nlocal = DAT::t_int_scalar("surf:nlocal");
+  d_ntally = DAT::t_int_scalar("surf:ntally");
 }
 
 ComputeSurfKokkos::ComputeSurfKokkos(SPARTA *sparta) :
   ComputeSurf(sparta)
 {
   which = NULL;
-  glob2loc = NULL;
-  loc2glob = NULL;
+  surf2tally = NULL;
+  tally2surf = NULL;
   array_surf_tally = NULL;
   normflux = NULL;
   id = NULL;
@@ -57,7 +57,7 @@ ComputeSurfKokkos::~ComputeSurfKokkos()
 {
   if (copy || copymode) return;
 
-  memoryKK->destroy_kokkos(k_loc2glob,loc2glob);
+  memoryKK->destroy_kokkos(k_tally2surf,tally2surf);
   memoryKK->destroy_kokkos(k_array_surf_tally,array_surf_tally);
 }
 
@@ -72,8 +72,8 @@ void ComputeSurfKokkos::init()
     h_which(n) = which[n];
   Kokkos::deep_copy(d_which,h_which);
 
-  d_glob2loc = DAT::t_int_1d("surf:glob2loc",nsurf);
-  Kokkos::deep_copy(d_glob2loc,-1);
+  d_surf2tally = DAT::t_int_1d("surf:surf2tally",nsurf);
+  Kokkos::deep_copy(d_surf2tally,-1);
 
   d_normflux = DAT::t_float_1d("surf:normflux",nsurf);
   auto h_normflux = Kokkos::create_mirror_view(d_normflux);
@@ -81,12 +81,12 @@ void ComputeSurfKokkos::init()
     h_normflux(n) = normflux[n];
   Kokkos::deep_copy(d_normflux,h_normflux);
 
-  // Cannot realloc inside a Kokkos parallel region, so size loc2glob the 
-  //  same as glob2loc 
+  // Cannot realloc inside a Kokkos parallel region, so size tally2surf the 
+  //  same as surf2tally 
 
-  memoryKK->destroy_kokkos(k_loc2glob,loc2glob);
-  memoryKK->create_kokkos(k_loc2glob,loc2glob,nsurf,"surf:loc2glob");
-  d_loc2glob = k_loc2glob.d_view;
+  memoryKK->destroy_kokkos(k_tally2surf,tally2surf);
+  memoryKK->create_kokkos(k_tally2surf,tally2surf,nsurf,"surf:tally2surf");
+  d_tally2surf = k_tally2surf.d_view;
 
   memoryKK->destroy_kokkos(k_array_surf_tally,array_surf_tally);
   memoryKK->create_kokkos(k_array_surf_tally,array_surf_tally,nsurf,ntotal,"surf:array_surf_tally");
@@ -97,26 +97,26 @@ void ComputeSurfKokkos::init()
 
 void ComputeSurfKokkos::clear()
 {
-  // reset all set glob2loc values to -1
+  // reset all set surf2tally values to -1
   // called by Update at beginning of timesteps surf tallying is done
 
-  auto h_nlocal = Kokkos::create_mirror_view(d_nlocal);
-  Kokkos::deep_copy(h_nlocal,d_nlocal);
-  nlocal = h_nlocal();
+  auto h_ntally = Kokkos::create_mirror_view(d_ntally);
+  Kokkos::deep_copy(h_ntally,d_ntally);
+  ntally = h_ntally();
 
   copymode = 1;
-  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSurf_clear>(0,nlocal),*this);
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSurf_clear>(0,ntally),*this);
   DeviceType::fence();
   copymode = 0;
 
-  nlocal = 0;
-  Kokkos::deep_copy(d_nlocal,0);
+  ntally = 0;
+  Kokkos::deep_copy(d_ntally,0);
   Kokkos::deep_copy(d_array_surf_tally,0);
 }
 
 KOKKOS_INLINE_FUNCTION
 void ComputeSurfKokkos::operator()(TagComputeSurf_clear, const int &i) const {
-  d_glob2loc[d_loc2glob[i]] = -1;
+  d_surf2tally[d_tally2surf[i]] = -1;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -150,11 +150,11 @@ void ComputeSurfKokkos::post_surf_tally()
 
 int ComputeSurfKokkos::surfinfo(int *&locptr)
 {
-  k_loc2glob.modify<DeviceType>();
-  k_loc2glob.sync<SPAHostType>();
-  locptr = loc2glob;
+  k_tally2surf.modify<DeviceType>();
+  k_tally2surf.sync<SPAHostType>();
+  locptr = tally2surf;
 
-  auto h_nlocal = Kokkos::create_mirror_view(d_nlocal);
-  Kokkos::deep_copy(h_nlocal,d_nlocal);
-  return h_nlocal();
+  auto h_ntally = Kokkos::create_mirror_view(d_ntally);
+  Kokkos::deep_copy(h_ntally,d_ntally);
+  return h_ntally();
 }

--- a/src/KOKKOS/compute_surf_kokkos.h
+++ b/src/KOKKOS/compute_surf_kokkos.h
@@ -75,14 +75,14 @@ void surf_tally_kk(int isurf, Particle::OnePart *iorig,
   // if 1st particle hitting isurf, add isurf to local list
   // grow local list if needed
 
-  int ilocal = d_glob2loc(isurf);
+  int ilocal = d_surf2tally(isurf);
   if (ilocal < 0) {
     if (ATOMIC_REDUCTION != 0)
-      ilocal = Kokkos::atomic_fetch_add(&d_nlocal(),1);
+      ilocal = Kokkos::atomic_fetch_add(&d_ntally(),1);
     else
-      ilocal = d_nlocal()++;
-    d_loc2glob(ilocal) = isurf;
-    d_glob2loc(isurf) = ilocal;
+      ilocal = d_ntally()++;
+    d_tally2surf(ilocal) = isurf;
+    d_surf2tally(isurf) = ilocal;
   }
 
   double fluxscale = d_normflux(isurf);
@@ -273,14 +273,14 @@ void surf_tally_kk(int isurf, Particle::OnePart *iorig,
  private:
   int mvv2e;
 
-  DAT::t_int_scalar d_nlocal;
+  DAT::t_int_scalar d_ntally;
   DAT::t_int_1d d_which;
 
   DAT::t_float_2d d_array_surf_tally;  // tally values for local surfs
   DAT::tdual_float_2d k_array_surf_tally;
-  DAT::t_int_1d d_glob2loc;           // glob2loc[I] = local index of Ith global surf
-  DAT::t_int_1d d_loc2glob;           // loc2glob[I] = global index of Ith local surf
-  DAT::tdual_int_1d k_loc2glob;
+  DAT::t_int_1d d_surf2tally;           // surf2tally[I] = local index of Ith global surf
+  DAT::t_int_1d d_tally2surf;           // tally2surf[I] = global index of Ith local surf
+  DAT::tdual_int_1d k_tally2surf;
 
   DAT::t_float_1d d_normflux;         // normalization factor for each surf element
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -647,6 +647,7 @@ void Comm::ring(int n, int nper, void *inbuf, int messtag,
                 takes input datums, returns output datums
      outorder = same as inorder, but for datums returned by callback()
      ptr = pointer to caller class, passed to callback()
+     statflag = 1 for stats output, else 0
    outputs:
      nout = # of output datums (function return)
      outbuf = vector of output datums

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -50,7 +50,6 @@ Compute::Compute(SPARTA *sparta, int narg, char **arg) : Pointers(sparta)
   scalar_flag = vector_flag = array_flag = 0;
   per_particle_flag = per_grid_flag = per_surf_flag = 0;
   post_process_grid_flag = 0;
-  size_per_grid_extra_cols = 0;
   surf_tally_flag = boundary_tally_flag = 0;
 
   timeflag = 0;

--- a/src/compute.h
+++ b/src/compute.h
@@ -32,18 +32,13 @@ class Compute : protected Pointers {
   double *vector_grid;      // computed per-grid vector
   double **array_grid;      // computed per-grid array
 
-  // vec/array_surf are length nslocal = # of owned surf elements
-  // tally vec/array are length nlocal = # of unique surf elements tallied
-  // tally info is accessed by callers via surfinfo()
+  // vec/array surf are length = # of explicit surf elements owned
+  // vec/array tally are length = # of surf elements tallied
 
   double *vector_surf;        // computed per-surf vector
   double **array_surf;        // computed per-surf array
   double *vector_surf_tally;  // computed per-surf tally vector
   double **array_surf_tally;  // computed per-surf tally array
-
-  // NOTE: get rid of these fields?
-  double **array_grid_extra;   // extra per-grid array
-  double **norm_grid_extra;    // extra per-grid normalizations
 
   int scalar_flag;          // 0/1 if compute_scalar() function exists
   int vector_flag;          // 0/1 if compute_vector() function exists
@@ -59,9 +54,6 @@ class Compute : protected Pointers {
   int size_per_grid_cols;     // 0 = vector, N = columns in per-grid array
 
   int post_process_grid_flag;   // 1 if requires post_processing for output
-
-  // NOTE: get rid of this field?
-  int size_per_grid_extra_cols; // 0 = none, N = columns in extra per-grid array
 
   int per_surf_flag;          // 0/1 if compute_per_surf() function exists
   int size_per_surf_cols;     // 0 = vector, N = columns in per-surf array
@@ -103,25 +95,26 @@ class Compute : protected Pointers {
   virtual double post_process_grid(int, int, int, double **, int *, 
                                    double *, int) {return 0.0;}
 
-  // Kokkos methods
-
-  int kokkos_flag;          // 1 if Kokkos-enabled
-  int copy,copymode;        // 1 if copy of class (prevents deallocation of
-                            //  base class when child copy is destroyed)
-
-  // NOTE: get rid of these methods
+  // NOTE: get rid of this method at some point
   virtual void post_process_grid_old(void *, void *, int, int, double *, int) {}
-  virtual void normwhich(int, int &, int &) {}
-  virtual double *normptr(int) {return NULL;}
 
-  virtual int surfinfo(int *&) {return 0;}
+  virtual int tallyinfo(int *&) {return 0;}
+  virtual void tallysum(int) {}
+
+  virtual void reallocate() {}
+  virtual bigint memory_usage();
+
+  // methods in compute.cpp
 
   void addstep(bigint);
   int matchstep(bigint);
   void clearstep();
 
-  virtual void reallocate() {}
-  virtual bigint memory_usage();
+  // Kokkos methods
+
+  int kokkos_flag;          // 1 if Kokkos-enabled
+  int copy,copymode;        // 1 if copy of class (prevents deallocation of
+                            //  base class when child copy is destroyed)
 };
 
 }

--- a/src/compute_surf.h
+++ b/src/compute_surf.h
@@ -36,22 +36,23 @@ class ComputeSurf : public Compute {
   virtual void clear();
   virtual void surf_tally(int, Particle::OnePart *, 
                           Particle::OnePart *, Particle::OnePart *);
-  double *normptr(int);
-  virtual int surfinfo(int *&);
+  virtual int tallyinfo(int *&);
+  virtual void tallysum(int);
   bigint memory_usage();
 
  protected:
   int groupbit,imix,nvalue,ngroup,ntotal;
   int *which;
+  bigint last_tallysum;    // last timestep tallysum was called
 
   int nsurf;               // # of lines/tris I own
                            // surf->nlocal+nghost for explicit all or distributed
 
-  int nlocal;              // # of local surfs I have tallied for
-  int maxlocal;            // # of local surfs currently allocated
-  double **array;          // tally values for local surfs
-  int *glob2loc;           // glob2loc[I] = local index of Ith global surf
-  int *loc2glob;           // loc2glob[I] = global index of Ith local surf
+  int ntally;              // # of surfs I have tallied for
+  int maxtally;            // # of tallies currently allocated
+  int *surf2tally;         // surf2tally[I] = tally index of Ith surf
+  int *tally2surf;         // tally2surf[I] = surf index of Ith tally
+  double **array;          // tally values, maxtally in length
 
   int dimension;           // local copies
   Surf::Line *lines;
@@ -63,7 +64,7 @@ class ComputeSurf : public Compute {
   double nfactor_inverse;  // fnum/dt for normalization
   double *normflux;        // normalization factor for each surf element
   double nfactor_previous; // nfactor from previous run
-  void grow();
+  void grow_tally();
 };
 
 }

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -977,15 +977,13 @@ void DumpImage::write()
 
     for (int isurf = 0; isurf < nsurf; isurf++) {
       if (surfwhich == COMPUTE) {
-        // NOTE: accessing compute's tallied values, not collated values ??
-        // see dump_surf for needed logic
         Compute *compute = modify->compute[surfindex];
         if (!(compute->invoked_flag & INVOKED_PER_SURF)) {
           compute->compute_per_surf();
           compute->invoked_flag |= INVOKED_PER_SURF;
         }
-        if (surfcol == 0) value = compute->vector_surf[isurf];
-        else value = compute->array_surf[isurf][surfcol-1];
+        compute->tallysum(surfcol);
+        value = compute->vector_surf[isurf];
       } else if (surfwhich == FIX) {
         Fix *fix = modify->fix[surfindex];
         if (surfcol == 0) value = fix->vector_surf[isurf];
@@ -1473,15 +1471,13 @@ void DumpImage::create_image()
         color = scolorproc;
       } else if (scolor == ATTRIBUTE) {
         if (surfwhich == COMPUTE) {
-          // NOTE: accessing compute's tallied values, not collated values ??
-          // see dump_surf for needed logic
           Compute *compute = modify->compute[surfindex];
           if (!(compute->invoked_flag & INVOKED_PER_SURF)) {
             compute->compute_per_surf();
             compute->invoked_flag |= INVOKED_PER_SURF;
           }
-          if (surfcol == 0) value = compute->vector_surf[isurf];
-          else value = compute->array_surf[isurf][surfcol-1];
+          compute->tallysum(surfcol);
+          value = compute->vector_surf[isurf];
         } else if (surfwhich == FIX) {
           Fix *fix = modify->fix[surfindex];
           if (surfcol == 0) value = fix->vector_surf[isurf];

--- a/src/fix_ave_surf.cpp
+++ b/src/fix_ave_surf.cpp
@@ -177,6 +177,15 @@ FixAveSurf::FixAveSurf(SPARTA *sparta, int narg, char **arg) :
     }
   }
 
+  // if any input is a compute, all must be
+
+  int cflag = 0;
+  for (int i = 0; i < nvalues; i++)
+    if (which[i] == COMPUTE) cflag++;
+
+  if (cflag && cflag != nvalues)
+    error->all(FLERR,"Fix ave/surf inputs must be all computes or no computes");
+
   // this fix produces either a per-surf vector or array
 
   per_surf_flag = 1;
@@ -187,8 +196,14 @@ FixAveSurf::FixAveSurf(SPARTA *sparta, int narg, char **arg) :
   // if ave = RUNNING, allocate extra set of accvec/accarray
 
   nown = surf->nown;
-  memory->create(buflocal,nown,"ave/surf:buflocal");
   memory->create(masks,nown,"ave/surf:masks");
+
+  if (cflag) {
+    bufvec = NULL;
+    bufarray = NULL;
+    if (nvalues == 1) memory->create(bufvec,nown,"ave/surf:bufvec");
+    else memory->create(bufarray,nown,nvalues,"ave/surf:bufarray");
+  }
 
   if (nvalues == 1) memory->create(vector_surf,nown,"ave/surf:vector_surf");
   else memory->create(array_surf,nown,nvalues,"ave/surf:array_surf");
@@ -206,13 +221,13 @@ FixAveSurf::FixAveSurf(SPARTA *sparta, int narg, char **arg) :
 
   nsurf = surf->nlocal + surf->nghost;
 
-  memory->create(glob2loc,nsurf,"surf:glob2loc");
-  for (int i = 0; i < nsurf; i++) glob2loc[i] = -1;
+  memory->create(surf2tally,nsurf,"surf:surf2tally");
+  for (int i = 0; i < nsurf; i++) surf2tally[i] = -1;
 
-  nlocal = maxlocal = 0;
-  loc2glob = NULL;
-  vec_local = NULL;
-  array_local = NULL;
+  ntally = maxtally = 0;
+  tally2surf = NULL;
+  vec_tally = NULL;
+  array_tally = NULL;
 
   // zero accumulators one time if ave = RUNNING
 
@@ -290,7 +305,8 @@ FixAveSurf::~FixAveSurf()
   for (int i = 0; i < nvalues; i++) delete [] ids[i];
   delete [] ids;
 
-  memory->destroy(buflocal);
+  memory->destroy(bufvec);
+  memory->destroy(bufarray);
   memory->destroy(masks);
 
   if (nvalues == 1) memory->destroy(vector_surf);
@@ -300,10 +316,10 @@ FixAveSurf::~FixAveSurf()
     else memory->destroy(accarray);
   }
 
-  memory->destroy(glob2loc);
-  memory->destroy(loc2glob);
-  memory->destroy(vec_local);
-  memory->destroy(array_local);
+  memory->destroy(surf2tally);
+  memory->destroy(tally2surf);
+  memory->destroy(vec_tally);
+  memory->destroy(array_tally);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -360,7 +376,7 @@ void FixAveSurf::setup()
 
 void FixAveSurf::end_of_step()
 {
-  int i,j,k,m,n,isurf,ilocal;
+  int i,j,k,m,n,isurf,itally;
   double *vec;
 
   // skip if not step which requires doing something
@@ -368,7 +384,7 @@ void FixAveSurf::end_of_step()
   bigint ntimestep = update->ntimestep;
   if (ntimestep != nvalid) return;
 
-  // zero accumulators and norms if ave = ONE and first sample
+  // zero accumulators if ave = ONE and first sample
 
   if (ave == ONE && irepeat == 0) {
     if (nvalues == 1)
@@ -380,16 +396,15 @@ void FixAveSurf::end_of_step()
 	  accarray[i][m] = 0.0;
   }
 
-  // reset all set glob2loc values to -1 and nlocal to 0 if first sample
+  // reset all set surf2tally values to -1 and ntally to 0 if first sample
 
   if (irepeat == 0) {
-    for (i = 0; i < nlocal; i++) glob2loc[loc2glob[i]] = -1;
-    nlocal = 0;
+    for (i = 0; i < ntally; i++) surf2tally[tally2surf[i]] = -1;
+    ntally = 0;
   }
 
   // accumulate results of computes,fixes,variables
   // compute/fix/variable may invoke computes so wrap with clear/add
-  // NOTE: need to add logic for fixes and variables if enable them
 
   modify->clearstep_compute();
 
@@ -397,7 +412,7 @@ void FixAveSurf::end_of_step()
     n = value2index[m];
     j = argindex[m];
 
-    // invoke compute if not previously invoked
+    // do not invoke compute_per_surf(), just access tallies
     
     if (which[m] == COMPUTE) {
       Compute *compute = modify->compute[n];
@@ -405,68 +420,68 @@ void FixAveSurf::end_of_step()
         compute->compute_per_surf();
         compute->invoked_flag |= INVOKED_PER_SURF;
       }
-      int *loc2glob_compute;
-      int nlocal_compute = compute->surfinfo(loc2glob_compute);
+      int *tally2surf_compute;
+      int ntally_compute = compute->tallyinfo(tally2surf_compute);
       
       if (j == 0) {
         double *vector = compute->vector_surf_tally;
         if (nvalues == 1) {
-          for (i = 0; i < nlocal_compute; i++) {
-            isurf = loc2glob_compute[i];
-            ilocal = glob2loc[isurf];
-            if (ilocal < 0) {
-              if (nlocal == maxlocal) grow_local();
-              ilocal = nlocal++;
-              loc2glob[ilocal] = isurf;
-              glob2loc[isurf] = ilocal;
-              vec_local[ilocal] = 0.0;
+          for (i = 0; i < ntally_compute; i++) {
+            isurf = tally2surf_compute[i];
+            itally = surf2tally[isurf];
+            if (itally < 0) {
+              if (ntally == maxtally) grow_tally();
+              itally = ntally++;
+              tally2surf[itally] = isurf;
+              surf2tally[isurf] = itally;
+              vec_tally[itally] = 0.0;
             }
-            vec_local[ilocal] += vector[i];
+            vec_tally[itally] += vector[i];
           }
         } else {
-          for (i = 0; i < nlocal_compute; i++) {
-            isurf = loc2glob_compute[i];
-            ilocal = glob2loc[isurf];
-            if (ilocal < 0) {
-              if (nlocal == maxlocal) grow_local();
-              ilocal = nlocal++;
-              loc2glob[ilocal] = isurf;
-              glob2loc[isurf] = ilocal;
-              vec = array_local[ilocal];
+          for (i = 0; i < ntally_compute; i++) {
+            isurf = tally2surf_compute[i];
+            itally = surf2tally[isurf];
+            if (itally < 0) {
+              if (ntally == maxtally) grow_tally();
+              itally = ntally++;
+              tally2surf[itally] = isurf;
+              surf2tally[isurf] = itally;
+              vec = array_tally[itally];
               for (k = 0; k < nvalues; k++) vec[k] = 0.0;
             }
-            array_local[ilocal][m] += vector[i];
+            array_tally[itally][m] += vector[i];
           }
         }
       } else {
         int jm1 = j - 1;
         double **array = compute->array_surf_tally;
         if (nvalues == 1) {
-          for (i = 0; i < nlocal_compute; i++) {
-            isurf = loc2glob_compute[i];
-            ilocal = glob2loc[isurf];
-            if (ilocal < 0) {
-              if (nlocal == maxlocal) grow_local();
-              ilocal = nlocal++;
-              loc2glob[ilocal] = isurf;
-              glob2loc[isurf] = ilocal;
-              vec_local[ilocal] = 0.0;
+          for (i = 0; i < ntally_compute; i++) {
+            isurf = tally2surf_compute[i];
+            itally = surf2tally[isurf];
+            if (itally < 0) {
+              if (ntally == maxtally) grow_tally();
+              itally = ntally++;
+              tally2surf[itally] = isurf;
+              surf2tally[isurf] = itally;
+              vec_tally[itally] = 0.0;
             }
-            vec_local[ilocal] += array[i][jm1];
+            vec_tally[itally] += array[i][jm1];
           }
         } else {
-          for (i = 0; i < nlocal_compute; i++) {
-            isurf = loc2glob_compute[i];
-            ilocal = glob2loc[isurf];
-            if (ilocal < 0) {
-              if (nlocal == maxlocal) grow_local();
-              ilocal = nlocal++;
-              loc2glob[ilocal] = isurf;
-              glob2loc[isurf] = ilocal;
-              vec = array_local[ilocal];
+          for (i = 0; i < ntally_compute; i++) {
+            isurf = tally2surf_compute[i];
+            itally = surf2tally[isurf];
+            if (itally < 0) {
+              if (ntally == maxtally) grow_tally();
+              itally = ntally++;
+              tally2surf[itally] = isurf;
+              surf2tally[isurf] = itally;
+              vec = array_tally[itally];
               for (k = 0; k < nvalues; k++) vec[k] = 0.0;
             }
-            array_local[ilocal][m] += array[i][jm1];
+            array_tally[itally][m] += array[i][jm1];
           }
         }
       }
@@ -510,31 +525,24 @@ void FixAveSurf::end_of_step()
   nvalid = ntimestep+per_surf_freq - (nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
 
-  // for values from computes, merge local values across all procs
-  // returns surf element values I own in buflocal
-  // then sum buflocal into accvec and accarray
-  //   do not sum for surf elements not in surf group
-  //   so those values stay 0.0 even if compute's surf group is different
-  // NOTE: could test if all values are from COMPUTE and do collate_array()
-  //       there is no other per-surf fix or variable currently
+  // for values from computes, 
+  //   invoke surf->collate() on tallies this fix stores for multiple steps
+  //   this merges tallies to owned surf elements
 
-  for (m = 0; m < nvalues; m++) {
-    if (which[m] != COMPUTE) continue;
+  if (which[0] == COMPUTE) {
     if (nvalues == 1) {
-      surf->collate_vector(nlocal,loc2glob,vec_local,1,buflocal);
-      for (i = 0; i < nown; i++) accvec[i] += buflocal[i];
+      surf->collate_vector(ntally,tally2surf,vec_tally,1,bufvec);
+      for (i = 0; i < nown; i++) accvec[i] += bufvec[i];
     } else {
-      // array can be NULL if nlocal = 0, b/c this proc tallied no surfs
-      if (nlocal) surf->collate_vector(nlocal,loc2glob,&array_local[0][m],
-                                       nvalues,buflocal);
-      else surf->collate_vector(nlocal,loc2glob,NULL,nvalues,buflocal);
-      for (i = 0; i < nown; i++) accarray[i][m] += buflocal[i];
+      surf->collate_array(ntally,nvalues,tally2surf,array_tally,bufarray);
+      for (i = 0; i < nown; i++)
+        for (m = 0; m < nvalues; m++)
+          accarray[i][m] += bufarray[i][m];
     }
   }
 
   // normalize the accumulators for output on Nfreq timestep
-  // normindex < 0, just normalize by # of samples
-  // normindex >= 0, normalize by accumulated norm vector
+  // everything is just normalized by # of samples
 
   if (ave == ONE) {
     if (nvalues == 1)
@@ -596,14 +604,14 @@ void FixAveSurf::options(int iarg, int narg, char **arg)
 
 /* ---------------------------------------------------------------------- */
 
-void FixAveSurf::grow_local()
+void FixAveSurf::grow_tally()
 {
-  maxlocal += DELTA;
-  memory->grow(loc2glob,maxlocal,"ave/surf:loc2glob");
+  maxtally += DELTA;
+  memory->grow(tally2surf,maxtally,"ave/surf:tally2surf");
   if (nvalues == 1)
-    memory->grow(vec_local,maxlocal,"ave/surf:vec_local");
+    memory->grow(vec_tally,maxtally,"ave/surf:vec_tally");
   else
-    memory->grow(array_local,maxlocal,nvalues,"ave/surf:array_local");
+    memory->grow(array_tally,maxtally,nvalues,"ave/surf:array_tally");
 }
 
 /* ----------------------------------------------------------------------
@@ -615,7 +623,6 @@ double FixAveSurf::memory_usage()
   double bytes = 0.0;
   bytes += nown*nvalues * sizeof(double);
   if (ave == RUNNING) bytes += nown*nvalues * sizeof(double);
-  //bytes += nown*nnorm * sizeof(double);
   return bytes;
 }
 

--- a/src/fix_ave_surf.h
+++ b/src/fix_ave_surf.h
@@ -47,19 +47,19 @@ class FixAveSurf : public Fix {
   int nown;                // # of explicit surfs I own = surf->nown
   double *accvec;          // accumulation vector
   double **accarray;       // accumulation array
-  double *buflocal;        // surf collate vector for surfs I own
+  double *bufvec;          // surf collate vector for surfs I own
+  double **bufarray;       // surf collate array for surfs I own
   int *masks;              // surface element group masks for surfs I own
 
-  int nlocal;              // # of local surf tallies
-  int maxlocal;            // # of local surf tallies currently allocated
-  int *glob2loc;           // glob2loc[I] = local index of Ith global surf
-  int *loc2glob;           // loc2glob[I] = global index of Ith local surf
-
-  double *vec_local;
-  double **array_local;
+  int ntally;              // # of surfs I have tallies for
+  int maxtally;            // # of tallies currently allocated
+  int *surf2tally;         // surf2tally[I] = tally index of Ith surf
+  int *tally2surf;         // tally2surf[I] = surf index of Ith tally
+  double *vec_tally;       // tally values, maxtally in length
+  double **array_tally;
 
   void options(int, int, char **);
-  void grow_local();
+  void grow_tally();
   bigint nextvalid();
 };
 

--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -416,7 +416,7 @@ void FixAveTime::invoke_scalar(bigint ntimestep)
     
     if (which[i] == COMPUTE) {
       Compute *compute = modify->compute[m];
-      
+
       if (argindex[i] == 0) {
 	if (!(compute->invoked_flag & INVOKED_SCALAR)) {
 	  compute->compute_scalar();

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -40,7 +40,7 @@ using namespace MathConst;
 enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
 enum{PERIODIC,OUTFLOW,REFLECT,SURFACE,AXISYM};  // same as Domain
 enum{REGION_ALL,REGION_ONE,REGION_CENTER};      // same as Surf
-enum{COMBO,PERCELL,PERSURF};                    // several files
+enum{PERAUTO,PERCELL,PERSURF};                  // several files
 
 // cell type = OUTSIDE/INSIDE/OVERLAP if entirely outside/inside surfs
 //   or has any overlap with surfs including grazing or touching
@@ -96,7 +96,7 @@ Grid::Grid(SPARTA *sparta) : Pointers(sparta)
 
   maxbits = 8*sizeof(cellint)-1;
 
-  surfgrid_algorithm = COMBO;
+  surfgrid_algorithm = PERAUTO;
   maxsurfpercell = MAXSURFPERCELL;
   maxsplitpercell = MAXSPLITPERCELL;
   csurfs = NULL; csplits = NULL; csubs = NULL;

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -39,7 +39,7 @@ int compare_surfIDs(const void *, const void *);
 #define CHUNK 16
 
 enum{UNKNOWN,OUTSIDE,INSIDE,OVERLAP};   // several files
-enum{COMBO,PERCELL,PERSURF};            // several files
+enum{PERAUTO,PERCELL,PERSURF};          // several files
 
 // operations for surfaces in grid cells
 
@@ -50,7 +50,7 @@ enum{COMBO,PERCELL,PERSURF};            // several files
    surf_alg = Jan19, loop over N/P surfs, find small set of cells each overlaps,
               perform rendezvous comm to convert cells per surf to surfs per cell
    for distributed surfs, have to use surf_alg
-   COMBO option chooses based on total nsurfs vs nprocs
+   PERAUTO option chooses based on total nsurfs vs nprocs
    called from Readsurf, MoveSurf, RemoveSurf, ReadRestart, and FixMoveSurf
 ------------------------------------------------------------------------- */
 
@@ -58,7 +58,7 @@ void Grid::surf2grid(int subflag, int outflag)
 {
   if (surf->distributed)
     surf2grid_surf_algorithm(subflag,outflag);
-  else if (surfgrid_algorithm == COMBO) {
+  else if (surfgrid_algorithm == PERAUTO) {
     if (comm->nprocs > surf->nsurf) surf2grid_cell_algorithm(outflag);
     else surf2grid_surf_algorithm(subflag,outflag);
   } else if (surfgrid_algorithm == PERCELL) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -56,19 +56,17 @@ enum{COMBO,PERCELL,PERSURF};            // several files
 
 void Grid::surf2grid(int subflag, int outflag)
 {
-  int ntotal = surf->nsurf;
-
   if (surf->distributed)
     surf2grid_surf_algorithm(subflag,outflag);
   else if (surfgrid_algorithm == COMBO) {
-      if (comm->nprocs > ntotal) surf2grid_cell_algorithm(outflag);
-      else surf2grid_surf_algorithm(subflag,outflag);
-  } 
-  else if (surfgrid_algorithm == PERCELL) 
+    if (comm->nprocs > surf->nsurf) surf2grid_cell_algorithm(outflag);
+    else surf2grid_surf_algorithm(subflag,outflag);
+  } else if (surfgrid_algorithm == PERCELL) {
     surf2grid_cell_algorithm(outflag);
-  else if (surfgrid_algorithm == PERSURF) 
+  } else if (surfgrid_algorithm == PERSURF) {
     surf2grid_surf_algorithm(subflag,outflag);
-
+  }
+  
   // now have nsurf,csurfs list of local surfs that overlap each cell
   // compute cut volume and split info for each cell
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -135,6 +135,9 @@ void *sparta_extract_global(void *ptr, char *name)
    style = 0 for global data, 1 for per particle data,
      2 for per grid data, 3 for per surf data
    type = 0 for scalar, 1 for vector, 2 for array
+     for style = compute,
+     type = 0 if compute produces a vector
+     type = 1 to N if compute produces an array, type = which column of array
    for global data, returns a pointer to the
      compute's internal data structure for the entity
      caller should cast it to (double *) for a scalar or vector
@@ -210,16 +213,8 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
 
   if (style == 3) {
     if (!compute->per_surf_flag) return NULL;
-    if (type == 1) {
-      if (compute->invoked_per_surf != sparta->update->ntimestep)
-        compute->compute_per_surf();
-      return (void *) compute->vector_surf;
-    }
-    if (type == 2) {
-      if (compute->invoked_per_surf != sparta->update->ntimestep)
-        compute->compute_per_surf();
-      return (void *) compute->array_surf;
-    }
+    compute->tallysum(type);
+    return (void *) compute->vector_surf;
   }
 
   return NULL;

--- a/src/read_surf.cpp
+++ b/src/read_surf.cpp
@@ -413,7 +413,7 @@ void ReadSurf::header()
 
     if (strstr(line,"points")) {
       bigint bnpoint;
-      sscanf(line,"%ld",&bnpoint);
+      sscanf(line,BIGINT_FORMAT,&bnpoint);
       if (bnpoint > MAXSMALLINT) 
         error->all(FLERR,"Read surf npoint is too large");
       npoint = bnpoint;
@@ -421,7 +421,7 @@ void ReadSurf::header()
       if (dim == 3) 
 	error->all(FLERR,"Surf file cannot contain lines for 3d simulation");
       bigint bnline;
-      sscanf(line,"%ld",&bnline);
+      sscanf(line,BIGINT_FORMAT,&bnline);
       if (bnline > MAXSMALLINT) error->all(FLERR,"Read surf nline is too large");
       nline = bnline;
     } else if (strstr(line,"triangles")) {
@@ -429,7 +429,7 @@ void ReadSurf::header()
 	error->all(FLERR,
 		   "Surf file cannot contain triangles for 2d simulation");
       bigint bntri;
-      sscanf(line,"%ld",&bntri);
+      sscanf(line,BIGINT_FORMAT,&bntri);
       if (bntri > MAXSMALLINT) error->all(FLERR,"Read surf ntri is too large");
       ntri = bntri;
     } else break;

--- a/src/surf.h
+++ b/src/surf.h
@@ -183,12 +183,17 @@ class Surf : protected Pointers {
   void group(int, char **);
   int add_group(const char *);
   int find_group(const char *);
-
-  void collate_vector(int, int *, double *, int, double *);
-  void collate_array(int, int, int *, double **, double **);
   
   void compress_rebalance();
   void reset_csurfs_implicit();
+
+  void collate_vector(int, int *, double *, int, double *);
+  void collate_vector_reduce(int, int *, double *, int, double *);
+  void collate_vector_rendezvous(int, int *, double *, int, double *);
+
+  void collate_array(int, int, int *, double **, double **);
+  void collate_array_reduce(int, int, int *, double **, double **);
+  void collate_array_rendezvous(int, int, int *, double **, double **);
 
   void write_restart(FILE *);
   void read_restart(FILE *);
@@ -196,18 +201,49 @@ class Surf : protected Pointers {
   virtual void grow_own();
   bigint memory_usage();
 
- private:
+ protected:
   int maxsc;                // max # of models in sc
   int maxsr;                // max # of models in sr
+  
+  // collate rendezvous data
 
+  struct InRvousVec {
+    surfint id;             // surface ID
+    double value;           // compute value
+  };
+
+  double *out_rvous;
+  int ncol_rvous;
+
+  // union data struct for packing 32-bit and 64-bit ints into double bufs
+  // this avoids aliasing issues by having 2 pointers (double,int)
+  //   to same buf memory
+  // constructor for 32-bit int prevents compiler
+  //   from possibly calling the double constructor when passed an int
+  // copy to a double *buf:
+  //   buf[m++] = ubuf(foo).d, where foo is a 32-bit or 64-bit int
+  // copy from a double *buf:
+  //   foo = (int) ubuf(buf[m++]).i;, where (int) or (tagint) match foo
+  //   the cast prevents compiler warnings about possible truncation
+
+  union ubuf {
+    double d;
+    int64_t i;
+    ubuf(double arg) : d(arg) {}
+    ubuf(int64_t arg) : i(arg) {}
+    ubuf(int arg) : i(arg) {}
+  };
+
+  // private methods
+  
   void point_line_compare(double *, double *, double *, double, int &, int &);
   void point_tri_compare(double *, double *, double *, double *, double *,
                          double, int &, int &, int, int, int);
 
-  void collate_vector_allreduce(int, int *, double *, int, double *);
-  void collate_vector_irregular(int, int *, double *, int, double *);
-  void collate_array_allreduce(int, int, int *, double **, double **);
-  void collate_array_irregular(int, int, int *, double **, double **);
+  // callback functions for rendezvous communication
+
+  static int rendezvous_vector(int, char *, int &, int *&, char *&, void *);
+  static int rendezvous_array(int, char *, int &, int *&, char *&, void *);
 };
 
 }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -46,7 +46,7 @@ enum{PERIODIC,OUTFLOW,REFLECT,SURFACE,AXISYM};  // same as Domain
 enum{OUTSIDE,INSIDE,ONSURF2OUT,ONSURF2IN};      // several files
 enum{PKEEP,PINSERT,PDONE,PDISCARD,PENTRY,PEXIT,PSURF};   // several files
 enum{NCHILD,NPARENT,NUNKNOWN,NPBCHILD,NPBPARENT,NPBUNKNOWN,NBOUND};  // Grid
-enum{TALLYAUTO,TALLYREDUCE,TALLYLOCAL};         // same as Surf
+enum{TALLYAUTO,TALLYREDUCE,TALLYRVOUS};         // same as Surf
 enum{COMBO,PERCELL,PERSURF};            // several files
 
 #define MAXSTUCK 20
@@ -1485,8 +1485,8 @@ void Update::global(int narg, char **arg)
     } else if (strcmp(arg[iarg],"surf/comm") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal global command");
       if (strcmp(arg[iarg+1],"auto") == 0) surf->tally_comm = TALLYAUTO;
-      else if (strcmp(arg[iarg+1],"all") == 0) surf->tally_comm = TALLYREDUCE;
-      else if (strcmp(arg[iarg+1],"local") == 0) surf->tally_comm = TALLYLOCAL;
+      else if (strcmp(arg[iarg+1],"reduce") == 0) surf->tally_comm = TALLYREDUCE;
+      else if (strcmp(arg[iarg+1],"rvous") == 0) surf->tally_comm = TALLYRVOUS;
       else error->all(FLERR,"Illegal global command");
       iarg += 2;
 

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -47,7 +47,7 @@ enum{OUTSIDE,INSIDE,ONSURF2OUT,ONSURF2IN};      // several files
 enum{PKEEP,PINSERT,PDONE,PDISCARD,PENTRY,PEXIT,PSURF};   // several files
 enum{NCHILD,NPARENT,NUNKNOWN,NPBCHILD,NPBPARENT,NPBUNKNOWN,NBOUND};  // Grid
 enum{TALLYAUTO,TALLYREDUCE,TALLYRVOUS};         // same as Surf
-enum{COMBO,PERCELL,PERSURF};            // several files
+enum{PERAUTO,PERCELL,PERSURF};                  // several files
 
 #define MAXSTUCK 20
 #define EPSPARAM 1.0e-7
@@ -1405,7 +1405,7 @@ void Update::global(int narg, char **arg)
       if (surf->exist) 
         error->all(FLERR,
                    "Cannot set global surfgrid when surfaces already exist");
-      if (strcmp(arg[iarg+1],"combo") == 0) grid->surfgrid_algorithm = COMBO;
+      if (strcmp(arg[iarg+1],"auto") == 0) grid->surfgrid_algorithm = PERAUTO;
       else if (strcmp(arg[iarg+1],"percell") == 0) 
         grid->surfgrid_algorithm = PERCELL;
       else if (strcmp(arg[iarg+1],"persurf") == 0) 
@@ -1482,7 +1482,7 @@ void Update::global(int narg, char **arg)
       else if (strcmp(arg[iarg+1],"all") == 0) comm->commpartstyle = 0;
       else error->all(FLERR,"Illegal global command");
       iarg += 2;
-    } else if (strcmp(arg[iarg],"surf/comm") == 0) {
+    } else if (strcmp(arg[iarg],"surftally") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal global command");
       if (strcmp(arg[iarg+1],"auto") == 0) surf->tally_comm = TALLYAUTO;
       else if (strcmp(arg[iarg+1],"reduce") == 0) surf->tally_comm = TALLYREDUCE;

--- a/src/variable.h
+++ b/src/variable.h
@@ -40,7 +40,7 @@ class Variable : protected Pointers {
   double compute_equal(char *);
   void compute_particle(int, double *, int, int);
   void compute_grid(int, double *, int, int);
-  void compute_surf(int, double *, int, int) {}
+  void compute_surf(int, double *, int, int) {}  // not yet supported
   void internal_set(int, double);
 
   int int_between_brackets(char *&, int);


### PR DESCRIPTION
## Purpose

Add a new rendezvous-based collate option for summing surface tallies across processors,
for both distributed and duplicated explicit surfs.  New global surf/comm command to choose which method is used (old or new).

## Author(s)

Steve

## Backward Compatibility

Should not.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


