### PR TITLE
Fix broken virtual function in compute_surf_kokkos

### DIFF
--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -149,7 +149,7 @@ void ComputeSurfKokkos::post_surf_tally()
    return ptr to norm vector used by column N
 ------------------------------------------------------------------------- */
 
-int ComputeSurfKokkos::surfinfo(int *&locptr)
+int ComputeSurfKokkos::tallyinfo(int *&locptr)
 {
   k_tally2surf.modify<DeviceType>();
   k_tally2surf.sync<SPAHostType>();

--- a/src/KOKKOS/compute_surf_kokkos.h
+++ b/src/KOKKOS/compute_surf_kokkos.h
@@ -36,7 +36,7 @@ class ComputeSurfKokkos : public ComputeSurf {
   ~ComputeSurfKokkos();
   void init();
   void clear();
-  int surfinfo(int *&);
+  int tallyinfo(int *&);
   void pre_surf_tally();
   void post_surf_tally();
 


### PR DESCRIPTION
## Purpose

Fix broken virtual function in compute_surf_kokkos causing it to return all zeros. Broken in 0fa12577a62103882d8b85aba90b6e8d9a31a5b1.

## Author(s)

Stan Moore (Sandia)

## Backward Compatibility

No issues.