### PR TITLE
Fix 3 instances of incorrect type declaration in read_isurf.cpp

### DIFF
--- a/src/read_isurf.cpp
+++ b/src/read_isurf.cpp
@@ -807,11 +807,11 @@ void ReadISurf::marching_squares(int igroup)
 void ReadISurf::marching_cubes(int igroup)
 {
   int i,j,ipt,isurf,nsurf,icase,which;
-  int *ptr;
+  surfint *ptr;
     
   Grid::ChildCell *cells = grid->cells;
   Grid::ChildInfo *cinfo = grid->cinfo;
-  MyPage<int> *csurfs = grid->csurfs;
+  MyPage<surfint> *csurfs = grid->csurfs;
   int nglocal = grid->nlocal;
   int groupbit = grid->bitmask[igroup];
     
@@ -2090,7 +2090,7 @@ void ReadISurf::cleanup_MC()
 
   Surf::Tri *tris = surf->tris;
   Grid::ChildCell *cells = grid->cells;
-  MyPage<int> *csurfs = grid->csurfs;
+  MyPage<surfint> *csurfs = grid->csurfs;
   int nglocal = grid->nlocal;
 
   Surf::Tri *tlist = NULL;


### PR DESCRIPTION
## Purpose

Fix 3 instances of incorrect type declaration in read_isurf.cpp

## Author(s)

Arnaud Borner and Steve Plimpton
