### PR TITLE
Surfmap bug

### DIFF
--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -701,7 +701,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
                                                "rendezvous:inbuf");
   irregular->exchange_uniform(inbuf,insize,inbuf_rvous);
 
-  bigint irregular1_bytes = 0; //irregular->irregular_bytes;
+  bigint irregular1_bytes = 0;   // irregular->irregular_bytes;
   delete irregular;
 
   // peform rendezvous computation via callback()
@@ -730,7 +730,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
                                     "rendezvous:outbuf");
   irregular->exchange_uniform(outbuf_rvous,outsize,outbuf);
 
-  bigint irregular2_bytes = 0; //irregular->irregular_bytes;
+  bigint irregular2_bytes = 0;   // irregular->irregular_bytes;
   delete irregular;
 
   memory->destroy(procs_rvous);
@@ -740,76 +740,7 @@ rendezvous_irregular(int n, char *inbuf, int insize, int inorder, int *procs,
 
   if (!statflag) return nout;
 
-  // memory info for caller and rendezvous decompositions
-
-  bigint size_in_all,size_in_max,size_in_min;
-  bigint size_out_all,size_out_max,size_out_min;
-  bigint size_inrvous_all,size_inrvous_max,size_inrvous_min;
-  bigint size_outrvous_all,size_outrvous_max,size_outrvous_min;
-
-  bigint size = (bigint) n*insize;
-  MPI_Allreduce(&size,&size_in_all,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
-  MPI_Allreduce(&size,&size_in_max,1,MPI_SPARTA_BIGINT,MPI_MAX,world);
-  MPI_Allreduce(&size,&size_in_min,1,MPI_SPARTA_BIGINT,MPI_MIN,world);
-
-  size = (bigint) nout*outsize;
-  MPI_Allreduce(&size,&size_out_all,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
-  MPI_Allreduce(&size,&size_out_max,1,MPI_SPARTA_BIGINT,MPI_MAX,world);
-  MPI_Allreduce(&size,&size_out_min,1,MPI_SPARTA_BIGINT,MPI_MIN,world);
-
-  size = (bigint) nrvous*insize;
-  MPI_Allreduce(&size,&size_inrvous_all,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
-  MPI_Allreduce(&size,&size_inrvous_max,1,MPI_SPARTA_BIGINT,MPI_MAX,world);
-  MPI_Allreduce(&size,&size_inrvous_min,1,MPI_SPARTA_BIGINT,MPI_MIN,world);
-
-  size = (bigint) nrvous_out*insize;
-  MPI_Allreduce(&size,&size_outrvous_all,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
-  MPI_Allreduce(&size,&size_outrvous_max,1,MPI_SPARTA_BIGINT,MPI_MAX,world);
-  MPI_Allreduce(&size,&size_outrvous_min,1,MPI_SPARTA_BIGINT,MPI_MIN,world);
-
-  int mbytes = 1024*1024;
-
-  if (me == 0) {
-    if (screen) {
-      fprintf(screen,"Rendezvous balance and memory info:\n");
-      fprintf(screen,"  input datum count "
-              "(tot,ave,max,min): " BIGINT_FORMAT " %g "
-              BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-              size_in_all/insize,1.0*size_in_all/nprocs/insize,
-              size_in_max/insize,size_in_min/insize);
-      fprintf(screen,"  input data (MB) "
-              "(tot,ave,max,min): %g %g %g %g\n",
-              1.0*size_in_all/mbytes,1.0*size_in_all/nprocs/mbytes,
-              1.0*size_in_max/mbytes,1.0*size_in_min/mbytes);
-      fprintf(screen,"  output datum count "
-              "(tot,ave,max,min): " BIGINT_FORMAT " %g "
-              BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-              size_out_all/outsize,1.0*size_out_all/nprocs/outsize,
-              size_out_max/outsize,size_out_min/outsize);
-      fprintf(screen,"  output data (MB) "
-              "(tot,ave,max,min): %g %g %g %g\n",
-              1.0*size_out_all/mbytes,1.0*size_out_all/nprocs/mbytes,
-              1.0*size_out_max/mbytes,1.0*size_out_min/mbytes);
-      fprintf(screen,"  input rvous datum count "
-              "(tot,ave,max,min): " BIGINT_FORMAT " %g "
-              BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-              size_inrvous_all/insize,1.0*size_inrvous_all/nprocs/insize,
-              size_inrvous_max/insize,size_inrvous_min/insize);
-      fprintf(screen,"  input rvous data (MB) "
-              "(tot,ave,max,min): %g %g %g %g\n",
-              1.0*size_inrvous_all/mbytes,1.0*size_inrvous_all/nprocs/mbytes,
-              1.0*size_inrvous_max/mbytes,1.0*size_inrvous_min/mbytes);
-      fprintf(screen,"  output rvous datum count "
-              "(tot,ave,max,min): " BIGINT_FORMAT " %g "
-              BIGINT_FORMAT " " BIGINT_FORMAT "\n",
-              size_outrvous_all/outsize,1.0*size_outrvous_all/nprocs/outsize,
-              size_outrvous_max/outsize,size_outrvous_min/outsize);
-      fprintf(screen,"  output rvous data (MB) "
-              "(tot,ave,max,min): %g %g %g %g\n",
-              1.0*size_outrvous_all/mbytes,1.0*size_outrvous_all/nprocs/mbytes,
-              1.0*size_outrvous_max/mbytes,1.0*size_outrvous_min/mbytes);
-    }
-  }
+  rendezvous_stats(n,insize,nout,outsize,nrvous,nrvous_out);
 
   /*
   rvous_bytes = 0;
@@ -1027,8 +958,29 @@ rendezvous_all2all(int n, char *inbuf, int insize, int inorder, int *procs,
 
   if (!statflag) return nout;
 
-  // memory info for caller and rendezvous decompositions
+  rendezvous_stats(n,insize,nout,outsize,nrvous,nrvous_out);
 
+  /*
+  rvous_bytes = 0;
+  rvous_bytes += n*insize;                                // inbuf
+  rvous_bytes += nout*outsize;                            // outbuf
+  rvous_bytes += nrvous*insize;                           // inbuf_rvous
+  rvous_bytes += nrvous_out*outsize;                      // outbuf_rvous
+  rvous_bytes += nrvous_out*sizeof(int);                  // procs_rvous
+  rvous_bytes += 4*nprocs*sizeof(int);                    // all2all vectors
+  rvous_bytes += MAX(all2all1_bytes,all2all2_bytes);      // reorder ops
+  */
+
+  return nout;
+}
+
+/* ----------------------------------------------------------------------
+   memory info for caller and rendezvous decompositions
+------------------------------------------------------------------------- */
+
+void Comm::rendezvous_stats(int n, int insize, int nout, int outsize, 
+                            int nrvous, int nrvous_out)
+{
   bigint size_in_all,size_in_max,size_in_min;
   bigint size_out_all,size_out_max,size_out_min;
   bigint size_inrvous_all,size_inrvous_max,size_inrvous_min;
@@ -1097,17 +1049,4 @@ rendezvous_all2all(int n, char *inbuf, int insize, int inorder, int *procs,
               1.0*size_outrvous_max/mbytes,1.0*size_outrvous_min/mbytes);
     }
   }
-
-  /*
-  rvous_bytes = 0;
-  rvous_bytes += n*insize;                                // inbuf
-  rvous_bytes += nout*outsize;                            // outbuf
-  rvous_bytes += nrvous*insize;                           // inbuf_rvous
-  rvous_bytes += nrvous_out*outsize;                      // outbuf_rvous
-  rvous_bytes += nrvous_out*sizeof(int);                  // procs_rvous
-  rvous_bytes += 4*nprocs*sizeof(int);                    // all2all vectors
-  rvous_bytes += MAX(all2all1_bytes,all2all2_bytes);      // reorder ops
-  */
-
-  return nout;
 }

--- a/src/comm.h
+++ b/src/comm.h
@@ -66,7 +66,8 @@ class Comm : protected Pointers {
                            int, char *&, int, void *, int);
   int rendezvous_all2all(int, char *, int, int, int *, 
                          int (*)(int, char *, int &, int *&, char *&, void *), 
-                         int, char *&, int, void *, int);  
+                         int, char *&, int, void *, int);
+  void rendezvous_stats(int, int, int, int, int, int);
 };
 
 }

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1311,9 +1311,9 @@ void Grid::set_inout()
                 //setnew[nsetnew++] = jcell;
               } else {
                 if (jtype != marktype) {
-                  printf("ICELL1 %d id %d iface %d jcell %d id %d "
-                         "marktype %d jtype %d\n",
-                         icell,cells[icell].id,iface,jcell,cells[jcell].id,
+                  printf("CELL1 proc %d icell %d id " CELLINT_FORMAT " iface %d "
+                         "jcell %d id " CELLINT_FORMAT " marktype %d jtype %d\n",
+                         me,icell,cells[icell].id,iface,jcell,cells[jcell].id,
                          marktype,jtype);
                   error->one(FLERR,"Cell type mis-match when marking on self");
                 }
@@ -1392,9 +1392,11 @@ void Grid::set_inout()
                   //setnew[nsetnew++] = jcell;
                 } else {
                   if (jtype != marktype) {
-                    printf("ICELL2 %d id %d iface %d jcell %d id %d "
-                           "marktype %d jtype %d\n",
-                           icell,cells[icell].id,iface,jcell,cells[jcell].id,
+                    printf("CELL2 proc %d icell %d id " CELLINT_FORMAT 
+                           " iface %d "
+                           "jcell %d id " CELLINT_FORMAT " marktype %d "
+                           "jtype %d\n",
+                           me,icell,cells[icell].id,iface,jcell,cells[jcell].id,
                            marktype,jtype);
                     error->one(FLERR,
                                "Cell type mis-match when marking on self");
@@ -1488,8 +1490,9 @@ void Grid::set_inout()
         //set[nset++] = jcell;
       } else {
         if (marktype != jtype) {
-          printf("JCELL3 %d id %d marktype %d jtype %d\n",
-                 jcell,cells[jcell].id,marktype,jtype);
+          printf("CELL3 me %d jcell %d id " CELLINT_FORMAT 
+                 " marktype %d jtype %d\n",
+                 me,jcell,cells[jcell].id,marktype,jtype);
           error->one(FLERR,"Cell type mis-match when marking on neigh proc");
         }
       }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -274,7 +274,7 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
   memory->create(proclist,ncount,"surf2grid2:proclist");
   InRvous *inbuf = (InRvous *) memory->smalloc((bigint) ncount*sizeof(InRvous),
                                                "surf2grid:inbuf");
-    
+
   // setup input buf to rendezvous comm
   // input datums = pairs of surfIDs and cellIDs
   // owning proc for each datum = random hash of cellID
@@ -1330,8 +1330,8 @@ void Grid::recurse2d(int iline, double *slo, double *shi, int iparent,
 void Grid::recurse3d(int itri, double *slo, double *shi, int iparent, 
                      int &n, cellint *list)
 {
-  int ix,iy,iz,ichild,newparent,index,parentflag,overlap;
-  cellint idchild;
+  int ix,iy,iz,newparent,index,parentflag,overlap;
+  cellint ichild,idchild;
   double celledge;
   double newslo[3],newshi[3];
   double clo[3],chi[3];
@@ -1407,7 +1407,7 @@ void Grid::recurse3d(int itri, double *slo, double *shi, int iparent,
     for (iy = jlo; iy <= jhi; iy++) {
       for (ix = ilo; ix <= ihi; ix++) {
         ichild = (cellint) iz*nx*ny + (cellint) iy*nx + ix + 1;
-        idchild = p->id | ((cellint) ichild << p->nbits);
+        idchild = p->id | (ichild << p->nbits);
         grid->id_child_lohi(iparent,ichild,clo,chi);
 
         if (hash->find(idchild) == hash->end()) parentflag = 0;

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -1065,7 +1065,7 @@ void Surf::check_watertight_3d_all()
   for (it = phash.begin(); it != phash.end(); ++it) {
     if (it->second != 2) {
       pts = (double *) it->first.pts;
-      if (Geometry::edge_on_hex_face(&pts[0],&pts[3],boxlo,boxhi) >= 0) nbad++;
+      if (Geometry::edge_on_hex_face(&pts[0],&pts[3],boxlo,boxhi) < 0) nbad++;
     }
   }
 


### PR DESCRIPTION
## Purpose

Fix two bugs.  One with watertight checks of 3d models where triangle edges lie on faces
of simulation box.  This was introduced recently.  The second is when running problems with
explicit surface elements and more than 2B grid cells (requiring big ints).  This was an issue
for the new, more efficient surface mapping to cells algorithm added recently.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


