### PR TITLE
corner-case bug fix for Marching Cubes, also watertight distributed s…

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1011,7 +1011,7 @@ void Grid::allocate_surf_arrays()
 
   csurfs = new MyPage<surfint>(maxsurfpercell,MAX(100*maxsurfpercell,1024));
   csplits = new MyPage<int>(maxsurfpercell,MAX(100*maxsurfpercell,1024));
-  csubs = new MyPage<int>(maxsplitpercell,128);
+  csubs = new MyPage<int>(maxsplitpercell,MAX(100*maxsplitpercell,128));
 }
 
 void Grid::allocate_cell_arrays()

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -1236,7 +1236,7 @@ int Surf::rendezvous_watertight_3d(int n, char *inbuf, int &flag, int *&proclist
   if (alldup) {
     char str[128];
     sprintf(str,"Watertight check failed with %d duplicate edges",alldup);
-    //error->all(FLERR,str);
+    error->all(FLERR,str);
   }
 
   // check that each edge has an inverted match(value = 3)
@@ -1250,7 +1250,7 @@ int Surf::rendezvous_watertight_3d(int n, char *inbuf, int &flag, int *&proclist
   for (it = phash.begin(); it != phash.end(); ++it) {
     if (it->second != 3) {
       pts = (double *) it->first.pts;
-      if (Geometry::edge_on_hex_face(&pts[0],&pts[3],boxlo,boxhi) >= 0) nbad++;
+      if (Geometry::edge_on_hex_face(&pts[0],&pts[3],boxlo,boxhi) < 0) nbad++;
     }
   }
 
@@ -1260,7 +1260,7 @@ int Surf::rendezvous_watertight_3d(int n, char *inbuf, int &flag, int *&proclist
   if (nbad) {
     char str[128];
     sprintf(str,"Watertight check failed with %d unmatched edges",allbad);
-    //error->all(FLERR,str);
+    error->all(FLERR,str);
   }
 
   // flag = 0: no second comm needed in rendezvous


### PR DESCRIPTION
…urf check

## Purpose

Couple more small bug-fixes.  One for Marching Cubes cleanup of a corner case in parallel.  Another for watertight checks in 3d of distributed surfs on the simulation boundary.  Another for large values of the global splitmax param.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


