### PR TITLE
bug fix for cleanup_MC() in 3d implicit surfs

### DIFF
--- a/src/read_isurf.cpp
+++ b/src/read_isurf.cpp
@@ -2436,8 +2436,9 @@ void ReadISurf::cleanup_MC()
   memory->destroy(facetris);
 
   // compress Surf::tris list to remove deleted tris
-  // when 4 tris on same face, they were deleted, 2 from each adjacent cell
-  // must sort dellist, so compress tris in ascending index order
+  // must sort dellist, so as to compress tris in DESCENDING index order
+  // descending, not ascending, so that a surf is not moved from end-of-list
+  //   that is flagged for later deletion
   // must repoint one location in cells->csurfs to moved surf
 
   qsort(dellist,ndelete,sizeof(int),compare_indices);
@@ -2525,7 +2526,7 @@ void ReadISurf::cleanup_MC()
 
 /* ----------------------------------------------------------------------
    comparison function invoked by qsort() called by cleanup_MC()
-   used to sort the dellist of removed tris
+   used to sort the dellist of removed tris into DESCENDING order
    this is not a class method
 ------------------------------------------------------------------------- */
 
@@ -2533,8 +2534,8 @@ int compare_indices(const void *iptr, const void *jptr)
 {
   int i = *((int *) iptr);
   int j = *((int *) jptr);
-  if (i < j) return -1;
-  if (i > j) return 1;
+  if (i < j) return 1;
+  if (i > j) return -1;
   return 0;
 }
 


### PR DESCRIPTION
## Purpose

Fix a corner case issue with marching cubes cleanup to insure triangles on shared face between
two grid cells are properly deleted.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


