### PR TITLE
bug fix for reading restart files with surfs

### DIFF
--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -129,8 +129,8 @@ void ReadRestart::command(int narg, char **arg)
   int incompatible = version_numeric();
 
   // read header info which creates simulation box
-  // also defines particle params: species, mixture, custom attributes
-  // also defines grid, surfs
+  // also read particle params: species, mixture, custom attributes
+  // also read parent grid and surfs
 
   header(incompatible);
 
@@ -328,7 +328,8 @@ void ReadRestart::command(int narg, char **arg)
   // sends chunks round-robin to other procs in its cluster
   // each proc keeps all cells/particles in its perproc chunks in file
 
-  else if (update->global_mem_limit > 0 || (update->mem_limit_grid_flag && !grid->nlocal)) {
+  else if (update->global_mem_limit > 0 || 
+           (update->mem_limit_grid_flag && !grid->nlocal)) {
   
   // what to do if split particle??
 
@@ -419,9 +420,12 @@ void ReadRestart::command(int narg, char **arg)
         }
 
         // number of particles per pass
+
         step_size = update->global_mem_limit/sizeof(Particle::OnePartRestart);
 
-        npasses = ceil((double)particle_nlocal/step_size)+1; // extra pass for grid
+        // extra pass for grid
+
+        npasses = ceil((double)particle_nlocal/step_size)+1; 
 
         if (i % nclusterprocs) {
           iproc = me + (i % nclusterprocs);
@@ -651,11 +655,15 @@ void ReadRestart::command(int narg, char **arg)
 
   if (me == 0 && surf->exist) {
     if (domain->dimension == 2) {
-      if (screen) fprintf(screen,"  " BIGINT_FORMAT " surf lines\n",surf->nsurf);
-      if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " surf lines\n",surf->nsurf);
+      if (screen) fprintf(screen,"  " BIGINT_FORMAT " surf lines\n",
+                          surf->nsurf);
+      if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " surf lines\n",
+                           surf->nsurf);
     } else {
-      if (screen) fprintf(screen,"  " BIGINT_FORMAT " surf triangles\n",surf->nsurf);
-      if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " surf triangles\n",surf->nsurf);
+      if (screen) fprintf(screen,"  " BIGINT_FORMAT " surf triangles\n",
+                          surf->nsurf);
+      if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " surf triangles\n",
+                           surf->nsurf);
     }
   }
 


### PR DESCRIPTION
## Purpose

FIx bug with reading restart files with explicit surfaces.  Introduced by change to allow
distributed or implicit surfs.

## Author(s)

Steve

## Backward Compatibility

Format of restart files changed so that surf count is now stored as an 8-byte integer.
So cannot read older restart files.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


