### PR TITLE
Fix emit face file

### DIFF
--- a/src/fix_emit_face_file.cpp
+++ b/src/fix_emit_face_file.cpp
@@ -417,7 +417,7 @@ void FixEmitFaceFile::perform_task()
 	  
           v[ndim] = beta_un*vscale[isp]*normal[ndim] + vstream[ndim];
 
-          theta = MY_PI * random->uniform();
+          theta = MY_2PI * random->uniform();
           vr = vscale[isp] * sqrt(-log(random->uniform()));
           v[pdim] = vr * sin(theta) + vstream[pdim];
           v[qdim] = vr * cos(theta) + vstream[qdim];
@@ -536,12 +536,14 @@ void FixEmitFaceFile::read_file(char *file, char *section)
       nskip = atoi(word);
       word = strtok(NULL," \t\n\r");
       nskip *= atoi(word);
+      fgets(line,MAXLINE,fp);                         // NV line
       fgets(line,MAXLINE,fp);                         // values line
       fgets(line,MAXLINE,fp);                         // imesh line
       fgets(line,MAXLINE,fp);                         // jmesh line
     } else if (strcmp(word,"NI") == 0) {
       word = strtok(NULL," \t\n\r");
       nskip = atoi(word);
+      fgets(line,MAXLINE,fp);                         // NV line
       fgets(line,MAXLINE,fp);                         // values line
       fgets(line,MAXLINE,fp);                         // imesh line
     } else error->one(FLERR,"Misformatted section in inflow file");


### PR DESCRIPTION
## Purpose

2 small bug fixes to the fix emit/face/file command.  Thanks to Zhi-Hui Wang for identifying these.
One is with reading files with multiple sections.  The 2nd is with using PI instead of 2*PI to set the transverse thermal temperature of particles (components perpendicular to face).

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


