### PR TITLE
fix possible overflow for 2d grids when mapping surf elements

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1230,8 +1230,8 @@ int Grid::find_overlaps(int isurf, cellint *list)
 void Grid::recurse2d(int iline, double *slo, double *shi, int iparent, 
                      int &n, cellint *list)
 {
-  int ix,iy,ichild,newparent,index,parentflag,overlap;
-  cellint idchild;
+  int ix,iy,newparent,index,parentflag,overlap;
+  cellint ichild,idchild;
   double celledge;
   double newslo[2],newshi[2];
   double clo[3],chi[3];
@@ -1291,8 +1291,8 @@ void Grid::recurse2d(int iline, double *slo, double *shi, int iparent,
 
   for (iy = jlo; iy <= jhi; iy++) {
     for (ix = ilo; ix <= ihi; ix++) {
-      ichild = iy*nx + ix + 1;
-      idchild = p->id | ((cellint) ichild << p->nbits);
+      ichild = (cellint) iy*nx + ix + 1;
+      idchild = p->id | (ichild << p->nbits);
       grid->id_child_lohi(iparent,ichild,clo,chi);
 
       if (hash->find(idchild) == hash->end()) parentflag = 0;


### PR DESCRIPTION
## Purpose

Fix possible overflow with 2d grids when mapping surf elements to it.  Previously fixed this for 3d grids.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


