### PR TITLE
fix recent introduced bug with reading restart files with split cells

### DIFF
--- a/src/create_grid.cpp
+++ b/src/create_grid.cpp
@@ -277,12 +277,18 @@ void CreateGrid::command(int narg, char **arg)
             ix = m % nx;
             iy = (m / nx) % ny;
             iz = m / ((cellint) nx*ny);
-            if (order == XYZ) nth = (cellint) iz*nx*ny + (cellint) iy*nx + ix;
-            else if (order == XZY) nth = (cellint) iy*nx*nz + (cellint) iz*nx + ix;
-            else if (order == YXZ) nth = (cellint) iz*ny*nx + (cellint) ix*ny + iy;
-            else if (order == YZX) nth = (cellint) ix*ny*nz + (cellint) iz*ny + iy;
-            else if (order == ZXY) nth = (cellint) iy*nz*nx + (cellint) ix*nz + iz;
-            else if (order == ZYX) nth = (cellint) ix*nz*ny + (cellint) iy*nz + iz;
+            if (order == XYZ) 
+              nth = (cellint) iz*nx*ny + (cellint) iy*nx + ix;
+            else if (order == XZY) 
+              nth = (cellint) iy*nx*nz + (cellint) iz*nx + ix;
+            else if (order == YXZ) 
+              nth = (cellint) iz*ny*nx + (cellint) ix*ny + iy;
+            else if (order == YZX) 
+              nth = (cellint) ix*ny*nz + (cellint) iz*ny + iy;
+            else if (order == ZXY) 
+              nth = (cellint) iy*nz*nx + (cellint) ix*nz + iz;
+            else if (order == ZYX) 
+              nth = (cellint) ix*nz*ny + (cellint) iy*nz + iz;
             nth++;
             if (bstyle == STRIDE) proc = nth % nprocs;
             else proc = static_cast<int> (1.0*nth/ntotal * nprocs);

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -2268,7 +2268,7 @@ void Grid::read_restart(FILE *fp)
 
 /* ----------------------------------------------------------------------
    return size of child grid restart info for this proc
-   count of all owned cells
+   using count of all owned cells
   // NOTE: worry about N overflowing int, and in IROUNDUP ???
 ------------------------------------------------------------------------- */
 
@@ -2284,8 +2284,8 @@ int Grid::size_restart()
 }
 
 /* ----------------------------------------------------------------------
-   return size of child grid restart info using
-     arbitrary count of all owned cells
+   return size of child grid restart info
+   using nlocal_restart count of all owned cells
 ------------------------------------------------------------------------- */
 
 int Grid::size_restart(int nlocal_restart)

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1028,7 +1028,7 @@ void Grid::allocate_cell_arrays()
 int *Grid::csubs_request(int n)
 {
   int *ptr = csubs->vget();
-  cpsurf->vgot(n);
+  csubs->vgot(n);
   return ptr;
 }
 
@@ -1594,9 +1594,9 @@ void Grid::flow_stats()
 
 /* ----------------------------------------------------------------------
    compute flow volume for entire box, using list of surfs
-   volume for one surf is projection to lower z face
+   volume for one surf is projection to lower z face (3d) or y face (2d)
    NOTE: this does not work if any surfs are clipped to zlo or zhi faces in 3d
-         this does not work if any surfs are clipped to ylo or yhi faces in 3d
+         this does not work if any surfs are clipped to ylo or yhi faces in 2d
          need to add contribution due to closing surfs on those faces
          fairly easy to add in 2d, not so easy in 3d
 ------------------------------------------------------------------------- */

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -1053,9 +1053,10 @@ void ReadRestart::create_child_cells(int skipflag)
     id = ids[i];
     nsplit = nsplits[i];
 
-    // NOTE: need more doc of this method
-
     // unsplit or split cell
+    // for skipflag, add only if I own this cell
+    // add as child cell to grid->cells
+    // if split cell, also add split cell to sinfo
     // add unsplit/split cells (not sub cells) to Grid::hash as create them
 
     if (nsplit > 0) {
@@ -1077,6 +1078,8 @@ void ReadRestart::create_child_cells(int skipflag)
 
     // sub cell
     // for skipflag, add only if I also own the corresponding split cell
+    // add as sub cell to grid->cells
+    // set nsplit for new sub cell and csubs in owning cell's sinfo
 
     } else {
       if (skipflag && hash->find(id) == hash->end()) continue;

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -2720,8 +2720,8 @@ void Surf::write_restart(FILE *fp)
       fwrite(&lines[i].id,sizeof(surfint),1,fp);
       fwrite(&lines[i].type,sizeof(int),1,fp);
       fwrite(&lines[i].mask,sizeof(int),1,fp);
-      fwrite(&lines[i].p1,sizeof(double),3,fp);
-      fwrite(&lines[i].p2,sizeof(double),3,fp);
+      fwrite(lines[i].p1,sizeof(double),3,fp);
+      fwrite(lines[i].p2,sizeof(double),3,fp);
     }
   }
 
@@ -2731,9 +2731,9 @@ void Surf::write_restart(FILE *fp)
       fwrite(&tris[i].id,sizeof(surfint),1,fp);
       fwrite(&tris[i].type,sizeof(int),1,fp);
       fwrite(&tris[i].mask,sizeof(int),1,fp);
-      fwrite(&tris[i].p1,sizeof(double),3,fp);
-      fwrite(&tris[i].p2,sizeof(double),3,fp);
-      fwrite(&tris[i].p3,sizeof(double),3,fp);
+      fwrite(tris[i].p1,sizeof(double),3,fp);
+      fwrite(tris[i].p2,sizeof(double),3,fp);
+      fwrite(tris[i].p3,sizeof(double),3,fp);
     }
   }
 }
@@ -2793,7 +2793,7 @@ void Surf::read_restart(FILE *fp)
 
   if (domain->dimension == 3) {
     if (me == 0) fread(&nsurf,sizeof(bigint),1,fp);
-    MPI_Bcast(&nsurf,1,MPI_INT,0,world);
+    MPI_Bcast(&nsurf,1,MPI_SPARTA_BIGINT,0,world);
     tris = (Tri *) memory->smalloc(nsurf*sizeof(Tri),"surf:tris");
     // NOTE: need different logic for different surf styles
     nlocal = nsurf;


### PR DESCRIPTION
## Purpose

Fix bug with memory issue for reading restart files with grid cells split by surfs.
This was recently introduced when adding distributed surfs.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


