### PR TITLE
Flush output buffers before calling MPI_Abort

### DIFF
--- a/src/error.cpp
+++ b/src/error.cpp
@@ -58,9 +58,11 @@ void Error::universe_all(const char *file, int line, const char *str)
 
 void Error::universe_one(const char *file, int line, const char *str)
 {
-  if (universe->uscreen)
+  if (universe->uscreen) {
     fprintf(universe->uscreen,"ERROR on proc %d: %s (%s:%d)\n",
 	    universe->me,str,file,line);
+    fflush(universe->uscreen);
+  }
   MPI_Abort(universe->uworld,1);
 }
 
@@ -99,11 +101,16 @@ void Error::one(const char *file, int line, const char *str)
 {
   int me;
   MPI_Comm_rank(world,&me);
-  if (screen) fprintf(screen,"ERROR on proc %d: %s (%s:%d)\n",
-		      me,str,file,line);
-  if (universe->nworlds > 1)
+  if (screen) {
+    fprintf(screen,"ERROR on proc %d: %s (%s:%d)\n",
+            me,str,file,line);
+    fflush(screen);
+  }
+  if (universe->nworlds > 1) {
     fprintf(universe->uscreen,"ERROR on proc %d: %s (%s:%d)\n",
 	    universe->me,str,file,line);
+    fflush(universe->uscreen);
+  }
   MPI_Abort(world,1);
 }
 


### PR DESCRIPTION
## Purpose

Sometimes when a job is killed with `error->one`, the error messages don't get printed before the job ends. Flushing the output buffers before calling `MPI_Abort` helps with this issue. A similar change was already made in LAMMPS.

## Author(s)

Stan Moore(Sandia)

## Backward Compatibility

No issues.