### PR TITLE
add balancing RCB options for 2d and flip

### DIFF
--- a/doc/balance_grid.html
+++ b/doc/balance_grid.html
@@ -27,6 +27,14 @@
   <I>rcb</I> args = weight
     weight = <I>cell</I> or <I>part</I> or <I>time</I> 
 </PRE>
+<LI>zero or more keyword/value(s) pairs may be appended 
+
+<LI>keyword = <I>axes</I> or <I>flip</I> 
+
+<PRE>  <I>axes</I> value = dims
+    dims = string with any of "x", "y", or "z" characters in it
+  <I>flip</I> value = yes or no 
+</PRE>
 
 </UL>
 <P><B>Examples:</B>
@@ -35,7 +43,8 @@
 balance_grid block * 4 *
 balance_grid clump yxz
 balance_grid random
-balance_grid rcb part 
+balance_grid rcb part
+balance_grid rcb part axes xz 
 </PRE>
 <P><B>Description:</B>
 </P>
@@ -157,6 +166,29 @@ image.
 </P>
 <CENTER><A HREF = "JPG/partition.jpg"><IMG SRC = "JPG/partition_small.jpg"></A>
 </CENTER>
+<HR>
+
+<P>The optional keywords <I>axes</I> and <I>flip</I> only apply to the <I>rcb</I>
+style.  Otherwise they are ignored.
+</P>
+<P>The <I>axes</I> keyword allows limiting the partitioning created by the RCB
+algorithm to a subset of dimensions.  The default is to allow cuts in
+all dimension, e.g. x,y,z for 3d simulations.  The dims value is a
+string with 1, 2, or 3 characters.  The characters must be one of "x",
+"y", or "z".  They can be in any order and must be unique.  For
+example, in 3d, a dims = xz would only partition the 3d grid only in
+the x and z dimensions.
+</P>
+<P>The <I>flip</I> keyword is useful for debugging.  If it is set to <I>yes</I>
+then each time an RCB partitioning is done, the coordinates of grid
+cells will (internally only) undergo a sign flip to insure that the
+new owner of each grid cell is a different processor than the previous
+owner, at least when more than a few processors are used.  This will
+insure all particle and grid data moves to new processors, fully
+exercising the rebalancing code.
+</P>
+<HR>
+
 <P><B>Restrictions:</B>
 </P>
 <P>This command can only be used after the grid has been created by the
@@ -174,6 +206,9 @@ performed.
 </P>
 <P><A HREF = "fix_balance.html">fix balance</A>
 </P>
-<P><B>Default:</B> none
+<P><B>Default:</B>
+</P>
+<P>The default settings for the optional keywords are axes = xyz, flip =
+no.
 </P>
 </HTML>

--- a/doc/balance_grid.txt
+++ b/doc/balance_grid.txt
@@ -22,6 +22,11 @@ style = {none} or {stride} or {clump} or {block} or {random} or {proc} or {rcb} 
   {proc} args = none
   {rcb} args = weight
     weight = {cell} or {part} or {time} :pre
+zero or more keyword/value(s) pairs may be appended :l
+keyword = {axes} or {flip} :l
+  {axes} value = dims
+    dims = string with any of "x", "y", or "z" characters in it
+  {flip} value = yes or no :pre
 :ule
 
 [Examples:]
@@ -30,7 +35,8 @@ balance_grid block * * *
 balance_grid block * 4 *
 balance_grid clump yxz
 balance_grid random
-balance_grid rcb part :pre
+balance_grid rcb part
+balance_grid rcb part axes xz :pre
 
 [Description:]
 
@@ -152,6 +158,29 @@ image.
 
 :c,image(JPG/partition_small.jpg,JPG/partition.jpg)
 
+:line
+
+The optional keywords {axes} and {flip} only apply to the {rcb}
+style.  Otherwise they are ignored.
+
+The {axes} keyword allows limiting the partitioning created by the RCB
+algorithm to a subset of dimensions.  The default is to allow cuts in
+all dimension, e.g. x,y,z for 3d simulations.  The dims value is a
+string with 1, 2, or 3 characters.  The characters must be one of "x",
+"y", or "z".  They can be in any order and must be unique.  For
+example, in 3d, a dims = xz would only partition the 3d grid only in
+the x and z dimensions.
+
+The {flip} keyword is useful for debugging.  If it is set to {yes}
+then each time an RCB partitioning is done, the coordinates of grid
+cells will (internally only) undergo a sign flip to insure that the
+new owner of each grid cell is a different processor than the previous
+owner, at least when more than a few processors are used.  This will
+insure all particle and grid data moves to new processors, fully
+exercising the rebalancing code.
+
+:line
+
 [Restrictions:]
 
 This command can only be used after the grid has been created by the
@@ -169,4 +198,7 @@ performed.
 
 "fix balance"_fix_balance.html
 
-[Default:] none
+[Default:]
+
+The default settings for the optional keywords are axes = xyz, flip =
+no.

--- a/doc/fix_balance.html
+++ b/doc/fix_balance.html
@@ -32,6 +32,14 @@
   <I>rcb</I> args = weight
     weight = <I>cell</I> or <I>part</I> or <I>time</I> 
 </PRE>
+<LI>zero or more keyword/value(s) pairs may be appended 
+
+<LI>keyword = <I>axes</I> or <I>flip</I> 
+
+<PRE>  <I>axes</I> value = dims
+    dims = string with any of "x", "y", or "z" characters in it
+  <I>flip</I> value = yes or no 
+</PRE>
 
 </UL>
 <P><B>Examples:</B>
@@ -155,6 +163,27 @@ image.
 </P>
 <CENTER><A HREF = "JPG/partition.jpg"><IMG SRC = "JPG/partition_small.jpg"></A>
 </CENTER>
+<HR>
+
+<P>The optional keywords <I>axes</I> and <I>flip</I> only apply to the <I>rcb</I>
+style.  Otherwise they are ignored.
+</P>
+<P>The <I>axes</I> keyword allows limiting the partitioning created by the RCB
+algorithm to a subset of dimensions.  The default is to allow cuts in
+all dimension, e.g. x,y,z for 3d simulations.  The dims value is a
+string with 1, 2, or 3 characters.  The characters must be one of "x",
+"y", or "z".  They can be in any order and must be unique.  For
+example, in 3d, a dims = xz would only partition the 3d grid only in
+the x and z dimensions.
+</P>
+<P>The <I>flip</I> keyword is useful for debugging.  If it is set to <I>yes</I>
+then each time an RCB partitioning is done, the coordinates of grid
+cells will (internally only) undergo a sign flip to insure that the
+new owner of each grid cell is a different processor than the previous
+owner, at least when more than a few processors are used.  This will
+insure all particle and grid data moves to new processors, fully
+exercising the rebalancing code.
+</P>
 <HR>
 
 <P><B>Restart, output info:</B>

--- a/doc/fix_balance.txt
+++ b/doc/fix_balance.txt
@@ -22,6 +22,11 @@ bstyle = {random} or {proc} or {rcb} :l
   {proc} args = none 
   {rcb} args = weight
     weight = {cell} or {part} or {time} :pre
+zero or more keyword/value(s) pairs may be appended :l
+keyword = {axes} or {flip} :l
+  {axes} value = dims
+    dims = string with any of "x", "y", or "z" characters in it
+  {flip} value = yes or no :pre
 :ule
 
 [Examples:]
@@ -144,6 +149,27 @@ compactly bounded by a rectangle.  Click for a larger version of the
 image.
 
 :c,image(JPG/partition_small.jpg,JPG/partition.jpg)
+
+:line
+
+The optional keywords {axes} and {flip} only apply to the {rcb}
+style.  Otherwise they are ignored.
+
+The {axes} keyword allows limiting the partitioning created by the RCB
+algorithm to a subset of dimensions.  The default is to allow cuts in
+all dimension, e.g. x,y,z for 3d simulations.  The dims value is a
+string with 1, 2, or 3 characters.  The characters must be one of "x",
+"y", or "z".  They can be in any order and must be unique.  For
+example, in 3d, a dims = xz would only partition the 3d grid only in
+the x and z dimensions.
+
+The {flip} keyword is useful for debugging.  If it is set to {yes}
+then each time an RCB partitioning is done, the coordinates of grid
+cells will (internally only) undergo a sign flip to insure that the
+new owner of each grid cell is a different processor than the previous
+owner, at least when more than a few processors are used.  This will
+insure all particle and grid data moves to new processors, fully
+exercising the rebalancing code.
 
 :line
 

--- a/doc/fix_emit_face.html
+++ b/doc/fix_emit_face.html
@@ -29,14 +29,15 @@
 
 <LI>keyword = <I>n</I> or <I>nevery</I> or <I>perspecies</I> or <I>region</I> or <I>subsonic</I> or <I>twopass</I> 
 
-  <I>n</I> value = Np = number of particles to create
+<PRE>  <I>n</I> value = Np = number of particles to create
   <I>nevery</I> value = Nstep = add particles every this many timesteps
   <I>perspecies</I> value = <I>yes</I> or <I>no</I>
   <I>region</I> value = region-ID 
   <I>subsonic</I> values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
-  <I>twopass</I> values = none
+  <I>twopass</I> values = none 
+</PRE>
 
 </UL>
 <P><B>Examples:</B>

--- a/doc/fix_emit_face.txt
+++ b/doc/fix_emit_face.txt
@@ -26,7 +26,7 @@ keyword = {n} or {nevery} or {perspecies} or {region} or {subsonic} or {twopass}
   {subsonic} values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
-  {twopass} values = none
+  {twopass} values = none :pre
 :ule
 
 [Examples:]

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -57,14 +57,15 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
 
   int bstyle,order;
   int px,py,pz;
-  int rcbwt,rcbflip;
+  int rcbwt;
+  int iarg;
 
   if (strcmp(arg[0],"none") == 0) {
-    if (narg != 1) error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 1) error->all(FLERR,"Illegal balance_grid command");
     bstyle = NONE;
 
   } else if (strcmp(arg[0],"stride") == 0) {
-    if (narg != 2) error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 2) error->all(FLERR,"Illegal balance_grid command");
     bstyle = STRIDE;
     if (strcmp(arg[1],"xyz") == 0) order = XYZ;
     else if (strcmp(arg[1],"xzy") == 0) order = XZY;
@@ -73,9 +74,10 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
     else if (strcmp(arg[1],"zxy") == 0) order = ZXY;
     else if (strcmp(arg[1],"zyx") == 0) order = ZYX;
     else error->all(FLERR,"Illegal balance_grid command");
+    iarg = 1;
 
   } else if (strcmp(arg[0],"clump") == 0) {
-    if (narg != 2) error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 2) error->all(FLERR,"Illegal balance_grid command");
     bstyle = CLUMP;
     if (strcmp(arg[1],"xyz") == 0) order = XYZ;
     else if (strcmp(arg[1],"xzy") == 0) order = XZY;
@@ -84,9 +86,10 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
     else if (strcmp(arg[1],"zxy") == 0) order = ZXY;
     else if (strcmp(arg[1],"zyx") == 0) order = ZYX;
     else error->all(FLERR,"Illegal balance_grid command");
+    iarg = 2;
 
   } else if (strcmp(arg[0],"block") == 0) {
-    if (narg != 4) error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 4) error->all(FLERR,"Illegal balance_grid command");
     bstyle = BLOCK;
     if (strcmp(arg[1],"*") == 0) px = 0;
     else px = atoi(arg[1]);
@@ -94,32 +97,59 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
     else py = atoi(arg[2]);
     if (strcmp(arg[3],"*") == 0) pz = 0;
     else pz = atoi(arg[3]);
+    iarg = 4;
     
   } else if (strcmp(arg[0],"random") == 0) {
-    if (narg != 1) error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 1) error->all(FLERR,"Illegal balance_grid command");
     bstyle = RANDOM;
+    iarg = 0;
 
   } else if (strcmp(arg[0],"proc") == 0) {
-    if (narg != 1) error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 1) error->all(FLERR,"Illegal balance_grid command");
     bstyle = PROC;
+    iarg = 0;
 
   } else if (strcmp(arg[0],"rcb") == 0) {
-    if (narg != 2 && narg != 3) 
-      error->all(FLERR,"Illegal balance_grid command");
+    if (narg < 2) error->all(FLERR,"Illegal balance_grid command");
     bstyle = BISECTION;
     if (strcmp(arg[1],"cell") == 0) rcbwt = CELL;
     else if (strcmp(arg[1],"part") == 0) rcbwt = PARTICLE;
     else if (strcmp(arg[1],"time") == 0) rcbwt = TIME;
     else error->all(FLERR,"Illegal balance_grid command");
-    // undocumented optional 3rd arg
-    // rcbflip = 3rd arg = 1 forces rcb->compute() to flip sign
-    //           of all grid cell "dots" to force totally different
-    //           assignment of grid cells to procs and induce
-    //           complete rebalance data migration
-    rcbflip = 0;
-    if (narg == 3) rcbflip = atoi(arg[2]);
+    iarg = 2;
+  }
 
-  } else error->all(FLERR,"Illegal balance_grid command");
+  // optional args
+
+  char eligible[4];
+  strcpy(eligible,"xyz");
+  int rcbflip = 0;
+
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"axes") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal balance_grid command");
+      if (strlen(arg[iarg+1]) > 3)
+        error->all(FLERR,"Illegal balance_grid command");
+      strcpy(eligible,arg[iarg+1]);
+      int xdim = 0;
+      int ydim = 0;
+      int zdim = 0;
+      if (strchr(eligible,'x')) xdim = 1;
+      if (strchr(eligible,'y')) ydim = 1;
+      if (strchr(eligible,'z')) zdim = 1;
+      if (zdim && domain->dimension == 2)
+        error->all(FLERR,"Illegal balance_grid command");
+      if (xdim+ydim+zdim != strlen(eligible)) 
+        error->all(FLERR,"Illegal balance_grid command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"flip") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal balance_grid command");
+      if (strcmp(arg[iarg+1],"yes") == 0) rcbflip = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) rcbflip = 0;
+      else error->all(FLERR,"Illegal balance_grid command");
+      iarg += 2;
+    } else error->all(FLERR,"Illegal balance_grid command");
+  }
 
   // error check on methods only allowed for a uniform grid
 
@@ -298,7 +328,7 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
       timer_cell_weights(wt);
     }
 
-    rcb->compute(nbalance,x,wt,rcbflip);
+    rcb->compute(nbalance,x,wt,eligible,rcbflip);
 
     // DEBUG info for dump image
 

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -19,6 +19,7 @@
 #include "update.h"
 #include "grid.h"
 #include "particle.h"
+#include "domain.h"
 #include "comm.h"
 #include "rcb.h"
 #include "modify.h"
@@ -58,20 +59,53 @@ FixBalance::FixBalance(SPARTA *sparta, int narg, char **arg) :
   nevery = atoi(arg[2]);
   thresh = atof(arg[3]);
 
+  int iarg;
   if (strcmp(arg[4],"random") == 0) {
-    if (narg != 5) error->all(FLERR,"Illegal fix balance command");
     bstyle = RANDOM;
+    iarg = 5;
   } else if (strcmp(arg[4],"proc") == 0) {
-    if (narg != 5) error->all(FLERR,"Illegal fix balance command");
     bstyle = PROC;
+    iarg = 5;
   } else if (strcmp(arg[4],"rcb") == 0) {
-    if (narg != 6) error->all(FLERR,"Illegal fix balance command");
+    if (narg < 6) error->all(FLERR,"Illegal fix balance command");
     bstyle = BISECTION;
     if (strcmp(arg[5],"cell") == 0) rcbwt = CELL;
     else if (strcmp(arg[5],"part") == 0) rcbwt = PARTICLE;
     else if (strcmp(arg[5],"time") == 0) rcbwt = TIME;
     else error->all(FLERR,"Illegal fix balance command");
+    iarg = 6;
   } else error->all(FLERR,"Illegal fix balance command");
+
+  // optional args
+
+  strcpy(eligible,"xyz");
+  rcbflip = 0;
+
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"axes") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix balance command");
+      if (strlen(arg[iarg+1]) > 3)
+        error->all(FLERR,"Illegal fix balance command");
+      strcpy(eligible,arg[iarg+1]);
+      int xdim = 0;
+      int ydim = 0;
+      int zdim = 0;
+      if (strchr(eligible,'x')) xdim = 1;
+      if (strchr(eligible,'y')) ydim = 1;
+      if (strchr(eligible,'z')) zdim = 1;
+      if (zdim && domain->dimension == 2)
+        error->all(FLERR,"Illegal balance_grid command");
+      if (xdim+ydim+zdim != strlen(eligible)) 
+        error->all(FLERR,"Illegal fix balance command");
+      iarg += 2;
+    } else if (strcmp(arg[iarg],"flip") == 0) {
+      if (iarg+2 > narg) error->all(FLERR,"Illegal fix balance command");
+      if (strcmp(arg[iarg+1],"yes") == 0) rcbflip = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) rcbflip = 0;
+      else error->all(FLERR,"Illegal fix balance command");
+      iarg += 2;
+    } else error->all(FLERR,"Illegal fix balance command");
+  }
 
   // error check
 
@@ -206,7 +240,7 @@ void FixBalance::end_of_step()
       timer_cell_weights(wt);
     }
 
-    rcb->compute(nbalance,x,wt);
+    rcb->compute(nbalance,x,wt,eligible,rcbflip);
     rcb->invert();
 
     nbalance = 0;

--- a/src/fix_balance.h
+++ b/src/fix_balance.h
@@ -39,7 +39,8 @@ class FixBalance : public Fix {
  private:
   int me,nprocs;
   double thresh;
-  int bstyle,rcbwt;
+  int bstyle,rcbwt,rcbflip;
+  char eligible[4];
   double last,my_timer_cost;
 
   double imbnow;                // current imbalance factor

--- a/src/rcb.h
+++ b/src/rcb.h
@@ -40,7 +40,7 @@ class RCB : protected Pointers {
 
   RCB(class SPARTA *);
   ~RCB();
-  void compute(int, double **, double *, int flip=0);
+  void compute(int, double **, double *, char *, int flip=0);
   void invert();
   void check();
   void stats(int);


### PR DESCRIPTION
## Purpose

Added a couple options to RCB balancing in the balance_grid and fix balance commands.
One for limiting the partitioning dimensions. Another for forcing all grid cells to be
assigned to new procs.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


