### PR TITLE
Add Support for Builds on Astra (Arm ThunderX2)

### DIFF
--- a/src/MAKE/Makefile.astra
+++ b/src/MAKE/Makefile.astra
@@ -1,0 +1,104 @@
+# kokkos_omp = KOKKOS package with OpenMP backend, MPI compiler, default MPI
+
+SHELL = /bin/sh
+
+# ---------------------------------------------------------------------
+# compiler/linker settings
+# specify flags and libraries needed for your compiler
+
+CC =		mpicxx
+CCFLAGS =	-g -O3
+SHFLAGS =	-fPIC
+DEPFLAGS =	-M
+
+LINK =		mpicxx
+LINKFLAGS =	-g -O3
+LIB = 
+SIZE =		size
+
+ARCHIVE =	ar
+ARFLAGS =	-rc
+SHLIBFLAGS =	-shared
+KOKKOS_DEVICES = OpenMP
+KOKKOS_ARCH    = ARMv8-TX2
+
+# ---------------------------------------------------------------------
+# SPARTA-specific settings
+# specify settings for SPARTA features you will use
+# if you change any -D setting, do full re-compile after "make clean"
+
+# SPARTA ifdef settings, OPTIONAL
+# see possible settings in doc/Section_start.html#2_2 (step 4)
+
+SPARTA_INC =	-DSPARTA_GZIP
+
+# MPI library, REQUIRED
+# see discussion in doc/Section_start.html#2_2 (step 5)
+# can point to dummy MPI library in src/STUBS as in Makefile.serial
+# INC = path for mpi.h, MPI compiler settings
+# PATH = path for MPI library
+# LIB = name of MPI library
+
+MPI_INC =       -DMPICH_SKIP_MPICXX -DOMPI_SKIP_MPICXX=1
+MPI_PATH =      
+MPI_LIB =	
+
+# JPEG library, OPTIONAL
+# see discussion in doc/Section_start.html#2_2 (step 7)
+# only needed if -DSPARTA_JPEG listed with SPARTA_INC
+# INC = path for jpeglib.h
+# PATH = path for JPEG library
+# LIB = name of JPEG library
+
+JPG_INC =       
+JPG_PATH = 	
+JPG_LIB =	
+
+# ---------------------------------------------------------------------
+# build rules and dependencies
+# no need to edit this section
+
+include	Makefile.package.settings
+include	Makefile.package
+
+EXTRA_INC = $(SPARTA_INC) $(PKG_INC) $(MPI_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
+
+# Path to src files
+
+vpath %.cpp ..
+vpath %.h ..
+
+# Link target
+
+$(EXE):	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(LINK) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(EXTRA_LIB) $(LIB) -o $(EXE)
+	$(SIZE) $(EXE)
+
+# Library targets
+
+lib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(ARCHIVE) $(ARFLAGS) $(EXE) $(OBJ)
+
+shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o $(EXE) \
+        $(OBJ) $(EXTRA_LIB) $(LIB)
+
+# Compilation rules
+
+%.o:%.cpp $(EXTRA_CPP_DEPENDS)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+%.d:%.cpp $(EXTRA_CPP_DEPENDS)
+	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+
+%.o:%.cu $(EXTRA_CPP_DEPENDS)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+# Individual dependencies
+
+DEPENDS = $(OBJ:.o=.d)
+sinclude $(DEPENDS)

--- a/src/MAKE/Makefile.astra_kokkos
+++ b/src/MAKE/Makefile.astra_kokkos
@@ -1,4 +1,4 @@
-# kokkos_omp = KOKKOS package with OpenMP backend, MPI compiler, default MPI
+# astra_kokkos = KOKKOS package with OpenMP backend, MPI compiler, default MPI, ARMv8-TX2 architecture
 
 SHELL = /bin/sh
 

--- a/src/MAKE/Makefile.astra_kokkos
+++ b/src/MAKE/Makefile.astra_kokkos
@@ -1,4 +1,4 @@
-# astra_kokkos = KOKKOS package with OpenMP backend, MPI compiler, default MPI, ARMv8-TX2 architecture
+# astra_kokkos = Arm ThunderX2 architecture, KOKKOS package with OpenMP backend, MPI compiler, default MPI
 
 SHELL = /bin/sh
 


### PR DESCRIPTION
## Purpose

Adds a Makefile for builds on the Sandia Astra Arm ThunderX2 machine. Sets correct KOKKOS_ARCH flags for the machine

## Author(s)

@nmhamster (Si Hammond), Sandia National Laboratories, NM

## Backward Compatibility

Does not break backwards compatibility.
