### PR TITLE
Add support for HPE MPI to Kokkos package

### DIFF
--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -828,9 +828,10 @@ are intended for computational work like running SPARTA.  By default
 Ng = 1 and Ns is not set.
 
 Depending on which flavor of MPI you are running, SPARTA will look for
-one of these 3 environment variables
+one of these 4 environment variables
 
 SLURM_LOCALID (various MPI variants compiled with SLURM support)
+MPT_LRANK (HPE MPI)
 MV2_COMM_WORLD_LOCAL_RANK (Mvapich)
 OMPI_COMM_WORLD_LOCAL_RANK (OpenMPI) :pre
 

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -67,22 +67,36 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
       }
       iarg += 2;
 
+      int set_flag = 0;
       char *str;
       if ((str = getenv("SLURM_LOCALID"))) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
+        set_flag = 1;
+      }
+      if ((str = getenv("MPT_LRANK"))) {
+        int local_rank = atoi(str);
+        device = local_rank % ngpus;
+        if (device >= skip_gpu) device++;
+        set_flag = 1;
       }
       if ((str = getenv("MV2_COMM_WORLD_LOCAL_RANK"))) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
+        set_flag = 1;
       }
       if ((str = getenv("OMPI_COMM_WORLD_LOCAL_RANK"))) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
+        set_flag = 1;
       }
+
+      if (ngpus > 1 && !set_flag)
+        error->all(FLERR,"Could not determine local MPI rank for multiple "
+                           "GPUs with Kokkos CUDA because MPI library not recognized");
 
     } else if (strcmp(arg[iarg],"t") == 0 ||
                strcmp(arg[iarg],"threads") == 0) {

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -58,6 +58,10 @@ E: Invalid Kokkos command-line args
 
 Self-explanatory.  See Section ? of the manual for details.
 
+E: Could not determine local MPI rank for multiple GPUs with Kokkos CUDA because MPI library not recognized
+
+The local MPI rank was not found in one of four supported environment variables.
+
 E: GPUs are requested but Kokkos has not been compiled for CUDA
 
 Recompile Kokkos with CUDA support to use GPUs.


### PR DESCRIPTION
## Purpose

Add support for HPE MPI to Kokkos package for multiple GPU runs and add error check if MPI library not recognized.

## Author(s)

Gabriele Jost (NASA Ames Research Center), Stan Moore (SNL)

## Backward Compatibility

No issues.
