### PR TITLE
tweak to manual TOC to add a link

### DIFF
--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -159,7 +159,7 @@ it gives quick access to documentation for all SPARTA commands.
 <BR>
   6.12 <A HREF = "Section_howto.html#howto_12">Using multiple vibrational energy levels</A> 
 <BR>
-  6.13 <A HREF = "howto_13">Surface elements: explicit, implicit, distributed</A> 
+  6.13 <A HREF = "Section_howto.html#howto_13">Surface elements: explicit, implicit, distributed</A> 
 <BR></UL>
 <LI><A HREF = "Section_example.html">Example problems</A> 
 
@@ -217,6 +217,8 @@ it gives quick access to documentation for all SPARTA commands.
 <BR></UL>
 
 </OL>
+
+
 
 
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -182,6 +182,7 @@ it gives quick access to documentation for all SPARTA commands.
 :link(howto_10,Section_howto.html#howto_10)
 :link(howto_11,Section_howto.html#howto_11)
 :link(howto_12,Section_howto.html#howto_12)
+:link(howto_13,Section_howto.html#howto_13)
 
 :link(mod_1,Section_python.html#mod_1)
 :link(mod_2,Section_python.html#mod_2)

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -833,9 +833,10 @@ are intended for computational work like running SPARTA.  By default
 Ng = 1 and Ns is not set.
 </P>
 <P>Depending on which flavor of MPI you are running, SPARTA will look for
-one of these 3 environment variables
+one of these 4 environment variables
 </P>
 <PRE>SLURM_LOCALID (various MPI variants compiled with SLURM support)
+MPT_LRANK (HPE MPI)
 MV2_COMM_WORLD_LOCAL_RANK (Mvapich)
 OMPI_COMM_WORLD_LOCAL_RANK (OpenMPI) 
 </PRE>


### PR DESCRIPTION
## Purpose

Add a link to Manual table of contents.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


