### PR TITLE
enabled dynamic reset of surf_collide diffuse temperature via a variable

### DIFF
--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -79,6 +79,7 @@ SurfCollideDiffuseKokkos::SurfCollideDiffuseKokkos(SPARTA *sparta) :
       error->all(FLERR,"Surf_collide ID must be alphanumeric or "
                  "underscore characters");
 
+  dynamicflag = 1;
   n = strlen(arg[1]) + 1;
   style = new char[n];
   strcpy(style,arg[1]);

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -248,7 +248,6 @@ void UpdateKokkos::run(int nsteps)
 
   int n_start_of_step = modify->n_start_of_step;
   int n_end_of_step = modify->n_end_of_step;
-  //int dynamic = 0;
 
   // cellweightflag = 1 if grid-based particle weighting is ON
 
@@ -265,15 +264,16 @@ void UpdateKokkos::run(int nsteps)
 
     timer->stamp();
 
+    // dynamic parameter updates
+
+    if (dynamic) dynamic_update();
+
     // start of step fixes
 
     if (n_start_of_step) {
       modify->start_of_step();
       timer->stamp(TIME_MODIFY);
     }
-
-
-    //if (dynamic) domain->dynamic();
 
     // move particles
 

--- a/src/surf_collide.cpp
+++ b/src/surf_collide.cpp
@@ -41,6 +41,7 @@ SurfCollide::SurfCollide(SPARTA *sparta, int, char **arg) :
   style = new char[n];
   strcpy(style,arg[1]);
 
+  dynamicflag = 0;
   allowreact = 0;
   vector_flag = 1;
   size_vector = 2;

--- a/src/surf_collide.h
+++ b/src/surf_collide.h
@@ -25,6 +25,7 @@ class SurfCollide : protected Pointers {
   char *id;
   char *style;
  
+  int dynamicflag;          // 1 if any param is dynamically updated
   int allowreact;           // 1 if allows for surface reactions
   int vector_flag;          // 0/1 if compute_vector() function exists
   int size_vector;          // length of global vector

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -46,6 +46,7 @@ SurfCollideDiffuse::SurfCollideDiffuse(SPARTA *sparta, int narg, char **arg) :
   tstr = NULL;
 
   if (strstr(arg[2],"v_") == arg[2]) {
+    dynamicflag = 1;
     int n = strlen(&arg[2][2]) + 1;
     tstr = new char[n];
     strcpy(tstr,&arg[2][2]);

--- a/src/update.h
+++ b/src/update.h
@@ -116,6 +116,14 @@ class Update : protected Pointers {
 
   int bounce_setup();
   virtual void bounce_set(bigint);
+
+  int nulist_surfcollide;
+  SurfCollide **ulist_surfcollide;
+
+  int dynamic;              // 1 if any classes do dynamic updates of params
+  void dynamic_setup();
+  void dynamic_update();
+
   void reset_timestep(bigint);
 
   //int axi_vertical_line(double, double *, double *, double, double, double,


### PR DESCRIPTION
## Purpose

Documented option to set a dynamic temperature for surf_collide diffuse, reset each
timestep by a variable, was not actually implemented.  This PR adds the functionality.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


