### PR TITLE
Remove Kokkos hash in compute_surf_kokkos

### DIFF
--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -99,12 +99,11 @@ void ComputeSurfKokkos::init_normflux()
   memoryKK->destroy_kokkos(k_tally2surf,tally2surf);
   memoryKK->create_kokkos(k_tally2surf,tally2surf,nsurf,"surf:tally2surf");
   d_tally2surf = k_tally2surf.d_view;
+  d_surf2tally = DAT::t_int_1d("surf:surf2tally",nsurf);
 
   memoryKK->destroy_kokkos(k_array_surf_tally,array_surf_tally);
   memoryKK->create_kokkos(k_array_surf_tally,array_surf_tally,nsurf,ntotal,"surf:array_surf_tally");
   d_array_surf_tally = k_array_surf_tally.d_view;
-
-  hash_kk = hash_type(2*nsurf);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -118,7 +117,7 @@ void ComputeSurfKokkos::clear()
   Kokkos::deep_copy(d_ntally,0);
   Kokkos::deep_copy(d_array_surf_tally,0);
 
-  hash_kk.clear();
+  Kokkos::deep_copy(d_surf2tally,-1);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/compute_surf_kokkos.h
+++ b/src/KOKKOS/compute_surf_kokkos.h
@@ -83,13 +83,13 @@ void surf_tally_kk(int isurf, Particle::OnePart *iorig,
   if (dim == 2) surfID = d_lines[isurf].id;
   else surfID = d_tris[isurf].id;
 
-  int h_index = d_surf2tally(surfID);
-  if (h_index != -1)
-    itally = h_index;
+  int index = d_surf2tally(isurf);
+  if (index != -1)
+    itally = index;
   else {
     itally = d_ntally();
 
-    d_surf2tally(surfID) = itally;
+    d_surf2tally(isurf) = itally;
 
     d_tally2surf[itally] = surfID;
     if (ATOMIC_REDUCTION != 0)


### PR DESCRIPTION
## Purpose

Remove Kokkos hash in compute_surf_kokkos because it uses too many registers on GPUs and slows down performance.

## Author(s)

Stan Moore (SNL), issue reported by Gabriele Jost (NASA Ames Research Center)

## Backward Compatibility

No issues