### PR TITLE
fix a bug with Cut3d encountering surf-to-grid error when adapting

### DIFF
--- a/src/adapt_grid.cpp
+++ b/src/adapt_grid.cpp
@@ -901,7 +901,7 @@ void AdaptGrid::refine_value()
       }
     }
 
-    //printf("AAA %d %d: %g %g\n",
+    //printf("REF VALUE %d %d: %g %g\n",
     //       icell,cells[icell].id,value,rvalue);
 
     if (rdecide == LESS) {

--- a/src/cut2d.cpp
+++ b/src/cut2d.cpp
@@ -18,6 +18,7 @@
 #include "surf.h"
 #include "domain.h"
 #include "grid.h"
+#include "comm.h"
 #include "math_extra.h"
 #include "math_const.h"
 #include "error.h"
@@ -1208,7 +1209,7 @@ int Cut2d::whichside(double *pt)
 
 void Cut2d::failed_cell()
 {
-  printf("Cut2d failed in cell ID: " CELLINT_FORMAT "\n",id);
+  printf("Cut2d failed on proc %d in cell ID: " CELLINT_FORMAT "\n",comm->me,id);
 
   cellint ichild;
   int iparent = grid->id_find_parent(id,ichild);

--- a/src/cut3d.cpp
+++ b/src/cut3d.cpp
@@ -19,6 +19,7 @@
 #include "surf.h"
 #include "domain.h"
 #include "grid.h"
+#include "comm.h"
 #include "math_extra.h"
 #include "memory.h"
 #include "error.h"
@@ -2153,7 +2154,7 @@ void Cut3d::push(double *pt)
 
 void Cut3d::failed_cell()
 {
-  printf("Cut3d failed in cell ID: " CELLINT_FORMAT "\n",id);
+  printf("Cut3d failed on proc %d in cell ID: " CELLINT_FORMAT "\n",comm->me,id);
 
   Surf::Tri *tris = surf->tris;
   

--- a/src/grid_adapt.cpp
+++ b/src/grid_adapt.cpp
@@ -45,9 +45,9 @@ void Grid::refine_cell(int icell, int iparent,
   ncorner = 8;
   if (dim == 2) ncorner = 4;
 
-  // remove icell from grid hash
+  // convert cell ID stored by grid hash from child to parent
 
-  hash->erase(cells[icell].id);
+  (*hash)[pcells[iparent].id] = -(iparent+1);
 
   // loop over creation of new child cells
 

--- a/src/grid_id.cpp
+++ b/src/grid_id.cpp
@@ -14,6 +14,7 @@
 
 #include "string.h"
 #include "grid.h"
+#include "error.h"
 
 using namespace SPARTA_NS;
 
@@ -80,6 +81,8 @@ int Grid::id_find_parent(cellint id, cellint &ichild)
     ichild = (id >> nbits) & mask;
     idnew = idparent | (ichild << nbits);
     if (idnew == id) break;
+    if (hash->find(idnew) == hash->end())
+      error->one(FLERR,"Grid::id_find_new() not in hash");
     index = (*hash)[idnew];
     iparent = -index-1;
   }


### PR DESCRIPTION
## Purpose

Fixed a bug noted in issue #7 when mapping surfaces to grid cells encounters an error during grid refinement.  This does not address the issue of why Cut3d is encoutering an error, but enables the code to print an appropriate error message and exit cleanly.

## Author(s)

Steve

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


