### PR TITLE
adding reaction stats at end of run and via new computes

### DIFF
--- a/doc/Section_commands.html
+++ b/doc/Section_commands.html
@@ -313,7 +313,7 @@ section</A> lists many of the same commands, grouped by category.
 <TR ALIGN="center"><TD ><A HREF = "restart.html">restart</A></TD><TD ><A HREF = "run.html">run</A></TD><TD ><A HREF = "scale_particles.html">scale_particles</A></TD><TD ><A HREF = "seed.html">seed</A></TD><TD ><A HREF = "shell.html">shell</A></TD><TD ><A HREF = "species.html">species</A></TD></TR>
 <TR ALIGN="center"><TD ><A HREF = "stats.html">stats</A></TD><TD ><A HREF = "stats_modify.html">stats_modify</A></TD><TD ><A HREF = "stats_style.html">stats_style</A></TD><TD ><A HREF = "suffix.html">suffix</A></TD><TD ><A HREF = "surf_collide.html">surf_collide</A></TD><TD ><A HREF = "surf_react.html">surf_react</A></TD></TR>
 <TR ALIGN="center"><TD ><A HREF = "surf_modify.html">surf_modify</A></TD><TD ><A HREF = "timestep.html">timestep</A></TD><TD ><A HREF = "uncompute.html">uncompute</A></TD><TD ><A HREF = "undump.html">undump</A></TD><TD ><A HREF = "unfix.html">unfix</A></TD><TD ><A HREF = "units.html">units</A></TD></TR>
-<TR ALIGN="center"><TD ><A HREF = "variable.html</TD><TD >x">variable</A><A HREF = "write_grid.html">write_grid</A></TD><TD ><A HREF = "write_isurf.html">write_isurf</A></TD><TD ><A HREF = "write_restart.html">write_restart</A></TD><TD ><A HREF = "write_surf.html">write_surf</A> 
+<TR ALIGN="center"><TD ><A HREF = "variable.html">variable</A></TD><TD ><A HREF = "write_grid.html">write_grid</A></TD><TD ><A HREF = "write_isurf.html">write_isurf</A></TD><TD ><A HREF = "write_restart.html">write_restart</A></TD><TD ><A HREF = "write_surf.html">write_surf</A> 
 </TD></TR></TABLE></DIV>
 
 <HR>
@@ -345,8 +345,9 @@ letters in parenthesis: k = KOKKOS.
 </P>
 <DIV ALIGN=center><TABLE  BORDER=1 >
 <TR ALIGN="center"><TD ><A HREF = "compute_boundary.html">boundary (k)</A></TD><TD ><A HREF = "compute_count.html">count (k)</A></TD><TD ><A HREF = "compute_distsurf_grid.html">distsurf/grid</A></TD><TD ><A HREF = "compute_eflux_grid.html">eflux/grid (k)</A></TD><TD ><A HREF = "compute_fft_grid.html">fft/grid</A></TD><TD ><A HREF = "compute_grid.html">grid (k)</A></TD></TR>
-<TR ALIGN="center"><TD ><A HREF = "compute_isurf_grid.html">isurf/grid</A></TD><TD ><A HREF = "compute_ke_particle.html">ke/particle (k)</A></TD><TD ><A HREF = "compute_lambda_grid.html">lambda/grid (k)</A></TD><TD ><A HREF = "compute_pflux_grid.html">pflux/grid (k)</A></TD><TD ><A HREF = "compute_property_grid.html">property/grid</A></TD><TD ><A HREF = "compute_reduce.html">reduce</A></TD></TR>
-<TR ALIGN="center"><TD ><A HREF = "compute_sonine_grid.html">sonine/grid (k)</A></TD><TD ><A HREF = "compute_surf.html">surf (k)</A></TD><TD ><A HREF = "compute_thermal_grid.html">thermal/grid (k)</A></TD><TD ><A HREF = "compute_temp.html">temp (k)</A></TD><TD ><A HREF = "compute_tvib_grid.html">tvib/grid</A> 
+<TR ALIGN="center"><TD ><A HREF = "compute_isurf_grid.html">isurf/grid</A></TD><TD ><A HREF = "compute_ke_particle.html">ke/particle (k)</A></TD><TD ><A HREF = "compute_lambda_grid.html">lambda/grid (k)</A></TD><TD ><A HREF = "compute_pflux_grid.html">pflux/grid (k)</A></TD><TD ><A HREF = "compute_property_grid.html">property/grid</A></TD><TD ><A HREF = "compute_react_boundary.html">react/boundary</A></TD></TR>
+<TR ALIGN="center"><TD ><A HREF = "compute_react_surf.html">react/surf</A></TD><TD ><A HREF = "compute_react_isurf_grid.html">react/isurf/grid</A></TD><TD ><A HREF = "compute_reduce.html">reduce</A></TD><TD ><A HREF = "compute_sonine_grid.html">sonine/grid (k)</A></TD><TD ><A HREF = "compute_surf.html">surf (k)</A></TD><TD ><A HREF = "compute_thermal_grid.html">thermal/grid (k)</A></TD></TR>
+<TR ALIGN="center"><TD ><A HREF = "compute_temp.html">temp (k)</A></TD><TD ><A HREF = "compute_tvib_grid.html">tvib/grid</A> 
 </TD></TR></TABLE></DIV>
 
 <HR>

--- a/doc/Section_commands.txt
+++ b/doc/Section_commands.txt
@@ -360,7 +360,7 @@ section"_#cmd_4 lists many of the same commands, grouped by category.
 "undump"_undump.html,
 "unfix"_unfix.html,
 "units"_units.html,
-"variable"_variable.html,x
+"variable"_variable.html,
 "write_grid"_write_grid.html,
 "write_isurf"_write_isurf.html,
 "write_restart"_write_restart.html,
@@ -415,6 +415,9 @@ letters in parenthesis: k = KOKKOS.
 "lambda/grid (k)"_compute_lambda_grid.html,
 "pflux/grid (k)"_compute_pflux_grid.html,
 "property/grid"_compute_property_grid.html,
+"react/boundary"_compute_react_boundary.html,
+"react/surf"_compute_react_surf.html,
+"react/isurf/grid"_compute_react_isurf_grid.html,
 "reduce"_compute_reduce.html,
 "sonine/grid (k)"_compute_sonine_grid.html,
 "surf (k)"_compute_surf.html,

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -1203,6 +1203,7 @@ relevant commands:
 <LI><A HREF = "read_isurf.html">read isurf</A>
 <LI><A HREF = "fix_ablate.html">fix ablate</A>
 <LI><A HREF = "compute_isurf_grid.html">compute isurf/grid</A>
+<LI><A HREF = "compute_react_isurf_grid.html">compute react/isurf/grid</A>
 <LI><A HREF = "fix_ave_grid.html">fix ave/grid</A>
 <LI><A HREF = "write_isurf.html">write isurf</A> 
 <LI><A HREF = "write_surf.html">write_surf</A> 
@@ -1227,10 +1228,12 @@ steps.  A per-grid cell value is used to decrement the corner point
 values in each grid cell.  The values can be (1) from a compute such
 as <A HREF = "compute_isurf_grid.html">compute isurf/grid</A> which tallies
 statistics about gas particle collisions with surfaces within each
-grid cell, or (2) from a fix such as <A HREF = "fix_ave_grid.html">fix ave/grid</A>
-which time averages these statistics over many timesteps, or (3)
-generated randomly, which is useful for debugging.  In the future, we
-plan to also allow surface reaction statistics to drive the ablation.
+grid cell.  Or <A HREF = "compute_react_isurf_grid.html">compute
+react/isurf/grid</A> which tallies the
+number of surface reactions that take place.  Or values can be (2)
+from a fix such as <A HREF = "fix_ave_grid.html">fix ave/grid</A> which time
+averages these statistics over many timesteps.  Or they can be (3)
+generated randomly, which is useful for debugging.
 </P>
 <P>The decrement of grid corner point values is done in a manner that
 models recession of the surface elements within in each grid cell.

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -1193,6 +1193,7 @@ relevant commands:
 "read isurf"_read_isurf.html
 "fix ablate"_fix_ablate.html
 "compute isurf/grid"_compute_isurf_grid.html
+"compute react/isurf/grid"_compute_react_isurf_grid.html
 "fix ave/grid"_fix_ave_grid.html
 "write isurf"_write_isurf.html 
 "write_surf"_write_surf.html :ul
@@ -1217,10 +1218,12 @@ steps.  A per-grid cell value is used to decrement the corner point
 values in each grid cell.  The values can be (1) from a compute such
 as "compute isurf/grid"_compute_isurf_grid.html which tallies
 statistics about gas particle collisions with surfaces within each
-grid cell, or (2) from a fix such as "fix ave/grid"_fix_ave_grid.html
-which time averages these statistics over many timesteps, or (3)
-generated randomly, which is useful for debugging.  In the future, we
-plan to also allow surface reaction statistics to drive the ablation.
+grid cell.  Or "compute
+react/isurf/grid"_compute_react_isurf_grid.html which tallies the
+number of surface reactions that take place.  Or values can be (2)
+from a fix such as "fix ave/grid"_fix_ave_grid.html which time
+averages these statistics over many timesteps.  Or they can be (3)
+generated randomly, which is useful for debugging.
 
 The decrement of grid corner point values is done in a manner that
 models recession of the surface elements within in each grid cell.

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -1012,51 +1012,85 @@ the simulation.  It then appends statistics about the CPU time and
 size of information stored for the simulation.  An example set of
 statistics is shown here:
 </P>
-<PRE>Loop time of 36.3787 on 8 procs for 100 steps with 10000000 particles 
+<P>Loop time of 0.639973 on 4 procs for 1000 steps with 45792 particles
+</P>
+<PRE>MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.10948    | 0.26191    | 0.42049    |  27.6 | 40.92
+Coll    | 0.013711   | 0.041659   | 0.070985   |  13.5 |  6.51
+Sort    | 0.01733    | 0.040286   | 0.063573   |  10.6 |  6.29
+Comm    | 0.02276    | 0.023555   | 0.02493    |   0.6 |  3.68
+Modify  | 0.00018167 | 0.024758   | 0.051345   |  15.6 |  3.87
+Output  | 0.0002172  | 0.0007354  | 0.0012152  |   0.0 |  0.11
+Other   |            | 0.2471     |            |       | 38.61 
 </PRE>
-<PRE>Particle moves    = 1000000000 (1B)
-Cells touched     = 1395597726 (1.4B)
-Particle comms    = 3990284 (3.99M)
-Boundary collides = 4003287 (4M)
-Boundary exits    = 0 (0K)
-SurfColl checks   = 0 (0K)
-SurfColl occurs   = 0 (0K)
-Collide attempts  = 93689476 (93.7M)
-Collide occurs    = 70166679 (70.2M)
-Reactions         = 847837 (848K)
+<PRE>Particle moves    = 38096354 (38.1M)
+Cells touched     = 43236871 (43.2M)
+Particle comms    = 146623 (0.147M)
+Boundary collides = 182782 (0.183M)
+Boundary exits    = 181792 (0.182M)
+SurfColl checks   = 7670863 (7.67M)
+SurfColl occurs   = 177740 (0.178M)
+Surf reactions    = 124169 (0.124M)
+Collide attempts  = 1232 (1K)
+Collide occurs    = 553 (0.553K)
+Gas reactions     = 23 (0.023K)
 Particles stuck   = 0 
 </PRE>
-<PRE>Particle-moves/CPUsec/proc: 3.43607e+06
-Particle-moves/step: 1e+07
-Cell-touches/particle/step: 1.3956
-Particle comm iterations/step: 1
-Particle fraction communicated: 0.00399028
-Particle fraction colliding with boundary: 0.00400329
-Particle fraction exiting boundary: 0
-Surface-checks/particle/step: 0
-Surface-collisions/particle/step: 0
-Collision-attempts/particle/step: 0.0936895
-Collisions/particle/step: 0.0701667
-Reactions/particle/step: 0.0008478 
+<PRE>Particle-moves/CPUsec/proc: 1.4882e+07
+Particle-moves/step: 38096.4
+Cell-touches/particle/step: 1.13493
+Particle comm iterations/step: 1.999
+Particle fraction communicated: 0.00384874
+Particle fraction colliding with boundary: 0.00479789
+Particle fraction exiting boundary: 0.0047719
+Surface-checks/particle/step: 0.201354
+Surface-collisions/particle/step: 0.00466554
+Surface-reactions/particle/step: 0.00325934
+Collision-attempts/particle/step: 1.232
+Collisions/particle/step: 0.553
+Gas-reactions/particle/step: 0.023 
 </PRE>
-<PRE>Move  time (%) = 16.6921 (45.8842)
-Coll  time (%) = 11.9058 (32.7275)
-Sort  time (%) = 7.24376 (19.9121)
-Comm  time (%) = 0.17353 (0.47701)
-Outpt time (%) = 0.363323 (0.998723)
-Other time (%) = 0.000194222 (0.000533888) 
-</PRE>
-<PRE>Particles: 1.25e+06 ave 1.25283e+06 max 1.24835e+06 min
-Histogram: 3 1 0 0 1 1 1 0 0 1
-Cells:     125000 ave 125000 max 125000 min
-Histogram: 8 0 0 0 0 0 0 0 0 0
-GhostCell: 15608 ave 15608 max 15608 min
-Histogram: 8 0 0 0 0 0 0 0 0 0
-EmptyCell: 7957 ave 7957 max 7957 min
-Histogram: 8 0 0 0 0 0 0 0 0 0 
+<P>Gas reaction tallies:
+  style tce #-of-reactions 45
+  reaction O2 + N --> O + O + N: 10
+  reaction O2 + O --> O + O + O: 5
+  reaction N2 + O --> N + N + O: 8
+</P>
+<P>Surface reaction tallies:
+  id 1 style global #-of-reactions 2
+    reaction all: 124025
+    reaction delete: 53525
+    reaction create: 70500
+</P>
+<PRE>Particles: 11448 ave 17655 max 5306 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:     100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:     50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0 
 </PRE>
 <P>The first line gives the total CPU run time for the simulation, in
 seconds.
+</P>
+<P>The next section gives a breakdown of the CPU timing (in seconds) in
+7 categories.  The first four are timings for particles moves, which
+includes interaction with surface elements, then particle collisions,
+then sorting of particles (required to perform collisions), and
+communication of particles between processors.  The Modify section is
+time for operations invoked by fixes and computes.  The Output section
+is for dump command and statistical output.  The Other category is
+typically for load-imbalance, as some MPI tasks wait for others MPI
+tasks to complete.  In each category the min,ave,max time across
+processors is shown, as well as a variation, and the percentage of
+total time.
 </P>
 <P>The next section gives some statistics about the run.  These are total
 counts of particle moves, grid cells touched by particles, the number
@@ -1067,12 +1101,17 @@ problem), as well as collision and reaction statistics.
 <P>The next section gives additional statistics, normalized by timestep
 or processor count.
 </P>
-<P>The next to last section gives a breakdown of the CPU timing (in
-seconds) in 6 categories.  The first four are timings for particles
-moves, which includes interaction with surface elements, then particle
-collisions, then sorting of particles (required to perform
-collisions), and communication of particles between processors.  The
-percentage of CPU time for each category is shown in parenthesis.
+<P>The next 2 sections are optional.  The "Gas reaction tallies" section
+is only output if the <A HREF = "react.html">react</A> command is used.  For each
+reaction with a non-zero tally, the number of those reactions that
+occurred during the run is printed.  The "Surface reaction tallies"
+section is only output if the <A HREF = "surf_react.html">surf_react</A> command was
+used one or more times, to assign the reaction model to individual
+surface elements or the box boundaries.  For each of the commands, and
+each of its reactions with a non-zero tally, the number of those
+reactions that occurred during the run is printed.  Note that this is
+effectively a summation over all the surface elements and/or box
+boundaries the surf_react command was assigned to.
 </P>
 <P>The last section is a histogramming across processors of various
 per-processor statistics: particle count, owned grid cells, processor,

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -1106,12 +1106,13 @@ is only output if the <A HREF = "react.html">react</A> command is used.  For eac
 reaction with a non-zero tally, the number of those reactions that
 occurred during the run is printed.  The "Surface reaction tallies"
 section is only output if the <A HREF = "surf_react.html">surf_react</A> command was
-used one or more times, to assign the reaction model to individual
+used one or more times, to assign reaction models to individual
 surface elements or the box boundaries.  For each of the commands, and
 each of its reactions with a non-zero tally, the number of those
 reactions that occurred during the run is printed.  Note that this is
 effectively a summation over all the surface elements and/or box
-boundaries the surf_react command was assigned to.
+boundaries the <A HREF = "surf_react.html">surf_react</A> command was used to assign
+a reaction model to.
 </P>
 <P>The last section is a histogramming across processors of various
 per-processor statistics: particle count, owned grid cells, processor,

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -1007,51 +1007,85 @@ the simulation.  It then appends statistics about the CPU time and
 size of information stored for the simulation.  An example set of
 statistics is shown here:
 
-Loop time of 36.3787 on 8 procs for 100 steps with 10000000 particles :pre
+Loop time of 0.639973 on 4 procs for 1000 steps with 45792 particles
 
-Particle moves    = 1000000000 (1B)
-Cells touched     = 1395597726 (1.4B)
-Particle comms    = 3990284 (3.99M)
-Boundary collides = 4003287 (4M)
-Boundary exits    = 0 (0K)
-SurfColl checks   = 0 (0K)
-SurfColl occurs   = 0 (0K)
-Collide attempts  = 93689476 (93.7M)
-Collide occurs    = 70166679 (70.2M)
-Reactions         = 847837 (848K)
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.10948    | 0.26191    | 0.42049    |  27.6 | 40.92
+Coll    | 0.013711   | 0.041659   | 0.070985   |  13.5 |  6.51
+Sort    | 0.01733    | 0.040286   | 0.063573   |  10.6 |  6.29
+Comm    | 0.02276    | 0.023555   | 0.02493    |   0.6 |  3.68
+Modify  | 0.00018167 | 0.024758   | 0.051345   |  15.6 |  3.87
+Output  | 0.0002172  | 0.0007354  | 0.0012152  |   0.0 |  0.11
+Other   |            | 0.2471     |            |       | 38.61 :pre
+
+Particle moves    = 38096354 (38.1M)
+Cells touched     = 43236871 (43.2M)
+Particle comms    = 146623 (0.147M)
+Boundary collides = 182782 (0.183M)
+Boundary exits    = 181792 (0.182M)
+SurfColl checks   = 7670863 (7.67M)
+SurfColl occurs   = 177740 (0.178M)
+Surf reactions    = 124169 (0.124M)
+Collide attempts  = 1232 (1K)
+Collide occurs    = 553 (0.553K)
+Gas reactions     = 23 (0.023K)
 Particles stuck   = 0 :pre
 
-Particle-moves/CPUsec/proc: 3.43607e+06
-Particle-moves/step: 1e+07
-Cell-touches/particle/step: 1.3956
-Particle comm iterations/step: 1
-Particle fraction communicated: 0.00399028
-Particle fraction colliding with boundary: 0.00400329
-Particle fraction exiting boundary: 0
-Surface-checks/particle/step: 0
-Surface-collisions/particle/step: 0
-Collision-attempts/particle/step: 0.0936895
-Collisions/particle/step: 0.0701667
-Reactions/particle/step: 0.0008478 :pre
+Particle-moves/CPUsec/proc: 1.4882e+07
+Particle-moves/step: 38096.4
+Cell-touches/particle/step: 1.13493
+Particle comm iterations/step: 1.999
+Particle fraction communicated: 0.00384874
+Particle fraction colliding with boundary: 0.00479789
+Particle fraction exiting boundary: 0.0047719
+Surface-checks/particle/step: 0.201354
+Surface-collisions/particle/step: 0.00466554
+Surface-reactions/particle/step: 0.00325934
+Collision-attempts/particle/step: 1.232
+Collisions/particle/step: 0.553
+Gas-reactions/particle/step: 0.023 :pre
 
-Move  time (%) = 16.6921 (45.8842)
-Coll  time (%) = 11.9058 (32.7275)
-Sort  time (%) = 7.24376 (19.9121)
-Comm  time (%) = 0.17353 (0.47701)
-Outpt time (%) = 0.363323 (0.998723)
-Other time (%) = 0.000194222 (0.000533888) :pre
+Gas reaction tallies:
+  style tce #-of-reactions 45
+  reaction O2 + N --> O + O + N: 10
+  reaction O2 + O --> O + O + O: 5
+  reaction N2 + O --> N + N + O: 8
 
-Particles: 1.25e+06 ave 1.25283e+06 max 1.24835e+06 min
-Histogram: 3 1 0 0 1 1 1 0 0 1
-Cells:     125000 ave 125000 max 125000 min
-Histogram: 8 0 0 0 0 0 0 0 0 0
-GhostCell: 15608 ave 15608 max 15608 min
-Histogram: 8 0 0 0 0 0 0 0 0 0
-EmptyCell: 7957 ave 7957 max 7957 min
-Histogram: 8 0 0 0 0 0 0 0 0 0 :pre
+Surface reaction tallies:
+  id 1 style global #-of-reactions 2
+    reaction all: 124025
+    reaction delete: 53525
+    reaction create: 70500
+
+Particles: 11448 ave 17655 max 5306 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:     100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:     50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0 :pre
 
 The first line gives the total CPU run time for the simulation, in
 seconds.
+
+The next section gives a breakdown of the CPU timing (in seconds) in
+7 categories.  The first four are timings for particles moves, which
+includes interaction with surface elements, then particle collisions,
+then sorting of particles (required to perform collisions), and
+communication of particles between processors.  The Modify section is
+time for operations invoked by fixes and computes.  The Output section
+is for dump command and statistical output.  The Other category is
+typically for load-imbalance, as some MPI tasks wait for others MPI
+tasks to complete.  In each category the min,ave,max time across
+processors is shown, as well as a variation, and the percentage of
+total time.
 
 The next section gives some statistics about the run.  These are total
 counts of particle moves, grid cells touched by particles, the number
@@ -1062,12 +1096,17 @@ problem), as well as collision and reaction statistics.
 The next section gives additional statistics, normalized by timestep
 or processor count.
 
-The next to last section gives a breakdown of the CPU timing (in
-seconds) in 6 categories.  The first four are timings for particles
-moves, which includes interaction with surface elements, then particle
-collisions, then sorting of particles (required to perform
-collisions), and communication of particles between processors.  The
-percentage of CPU time for each category is shown in parenthesis.
+The next 2 sections are optional.  The "Gas reaction tallies" section
+is only output if the "react"_react.html command is used.  For each
+reaction with a non-zero tally, the number of those reactions that
+occurred during the run is printed.  The "Surface reaction tallies"
+section is only output if the "surf_react"_surf_react.html command was
+used one or more times, to assign the reaction model to individual
+surface elements or the box boundaries.  For each of the commands, and
+each of its reactions with a non-zero tally, the number of those
+reactions that occurred during the run is printed.  Note that this is
+effectively a summation over all the surface elements and/or box
+boundaries the surf_react command was assigned to.
 
 The last section is a histogramming across processors of various
 per-processor statistics: particle count, owned grid cells, processor,

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -1101,12 +1101,13 @@ is only output if the "react"_react.html command is used.  For each
 reaction with a non-zero tally, the number of those reactions that
 occurred during the run is printed.  The "Surface reaction tallies"
 section is only output if the "surf_react"_surf_react.html command was
-used one or more times, to assign the reaction model to individual
+used one or more times, to assign reaction models to individual
 surface elements or the box boundaries.  For each of the commands, and
 each of its reactions with a non-zero tally, the number of those
 reactions that occurred during the run is printed.  Note that this is
 effectively a summation over all the surface elements and/or box
-boundaries the surf_react command was assigned to.
+boundaries the "surf_react"_surf_react.html command was used to assign
+a reaction model to.
 
 The last section is a histogramming across processors of various
 per-processor statistics: particle count, owned grid cells, processor,

--- a/doc/compute.html
+++ b/doc/compute.html
@@ -57,19 +57,21 @@ available in SPARTA:
 <LI><A HREF = "compute_count.html">count</A> - particle counts for species and mixtures and mixture groups
 <LI><A HREF = "compute_distsurf_grid.html">distsurf/grid</A> - distance from grid cells to surface
 <LI><A HREF = "compute_eflux_grid.html">eflux/grid</A> - energy flux density per grid cell
+<LI><A HREF = "compute_fft_grid.html">fft/grid</A> - FFTs across grid cells
 <LI><A HREF = "compute_grid.html">grid</A> - various per grid cell quantities
-<LI><A HREF = "compute_grid.html">grid/kk</A> - Kokkos version of compute grid
+<LI><A HREF = "compute_isurf_grid.html">isurf/grid</A> - various implicit surface element quantities
 <LI><A HREF = "compute_ke_particle.html">ke/particle</A> - temperature per particle
 <LI><A HREF = "compute_lambda_grid.html">lambda/grid</A> - mean-free path per grid cell
 <LI><A HREF = "compute_pflux_grid.html">pflux/grid</A> - momentum flux density per grid cell
 <LI><A HREF = "compute_property_grid.html">property/grid</A> - per grid cell properties
+<LI><A HREF = "compute_react_boundary.html">react/boundary</A> - reaction stats on global boundary
+<LI><A HREF = "compute_react_surf.html">react/surf</A> = reaction stats for explicit surfs
+<LI><A HREF = "compute_react_isurf_grid.html">react/isurf/grid</A> - reactions stats for implicit surfs
 <LI><A HREF = "compute_reduce.html">reduce</A> - reduce vectors to scalars
 <LI><A HREF = "compute_sonine_grid.html">sonine/grid</A> - Sonine moments per grid cell
-<LI><A HREF = "compute_surf.html">surf</A> - various per surface element quantities
+<LI><A HREF = "compute_surf.html">surf</A> - various explicit surface element quantities
 <LI><A HREF = "compute_thermal_grid.html">thermal/grid</A> - thermal temperature per grid cell
-<LI><A HREF = "compute_thermal_grid.html">thermal/grid/kk</A> - Kokkos version of compute thermal/grid
 <LI><A HREF = "compute_temp.html">temp</A> - temperature of particles
-<LI><A HREF = "compute_temp.html">temp/kk</A> - Kokkos version of compute temp
 <LI><A HREF = "compute_tvib_grid.html">tvib/grid</A> - vibrational temperature per grid cell 
 </UL>
 <P>There are also additional accelerated compute styles included in the

--- a/doc/compute.txt
+++ b/doc/compute.txt
@@ -54,19 +54,21 @@ available in SPARTA:
 "count"_compute_count.html - particle counts for species and mixtures and mixture groups
 "distsurf/grid"_compute_distsurf_grid.html - distance from grid cells to surface
 "eflux/grid"_compute_eflux_grid.html - energy flux density per grid cell
+"fft/grid"_compute_fft_grid.html - FFTs across grid cells
 "grid"_compute_grid.html - various per grid cell quantities
-"grid/kk"_compute_grid.html - Kokkos version of compute grid
+"isurf/grid"_compute_isurf_grid.html - various implicit surface element quantities
 "ke/particle"_compute_ke_particle.html - temperature per particle
 "lambda/grid"_compute_lambda_grid.html - mean-free path per grid cell
 "pflux/grid"_compute_pflux_grid.html - momentum flux density per grid cell
 "property/grid"_compute_property_grid.html - per grid cell properties
+"react/boundary"_compute_react_boundary.html - reaction stats on global boundary
+"react/surf"_compute_react_surf.html = reaction stats for explicit surfs
+"react/isurf/grid"_compute_react_isurf_grid.html - reactions stats for implicit surfs
 "reduce"_compute_reduce.html - reduce vectors to scalars
 "sonine/grid"_compute_sonine_grid.html - Sonine moments per grid cell
-"surf"_compute_surf.html - various per surface element quantities
+"surf"_compute_surf.html - various explicit surface element quantities
 "thermal/grid"_compute_thermal_grid.html - thermal temperature per grid cell
-"thermal/grid/kk"_compute_thermal_grid.html - Kokkos version of compute thermal/grid
 "temp"_compute_temp.html - temperature of particles
-"temp/kk"_compute_temp.html - Kokkos version of compute temp
 "tvib/grid"_compute_tvib_grid.html - vibrational temperature per grid cell :ul
 
 There are also additional accelerated compute styles included in the

--- a/doc/compute_boundary.html
+++ b/doc/compute_boundary.html
@@ -86,17 +86,17 @@ in different species groups.
 different ways.  The values for a single timestep can be output by the
 <A HREF = "dump.html">stats_style</A> command.
 </P>
-<P>The values over many sampling timesteps can be averaged by the <A HREF = "fix_ave_surf.html">fix
-ave/surf</A> command.  It does its averaging as if the
-particles striking the surface element at each sampling timestep were
-combined together into one large set to compute the formulas below.
-The answer is then divided by the number of sampling timesteps if it
-is not otherwise normalized by the number of particles.  Note that in
-general this is a different normalization than taking the values
-produced by the formulas below for a single timestep, summing them
-over the sampling timesteps, and then dividing by the number of
-sampling steps.  However for the current values listed below, the two
-normalization methods are the same.
+<P>The values over many sampling timesteps can be averaged by the <A HREF = "fix_ave_time.html">fix
+ave/time</A> command.  It does its averaging as if the
+particles striking the face at each sampling timestep were combined
+together into one large set to compute the formulas below.  The answer
+is then divided by the number of sampling timesteps if it is not
+otherwise normalized by the number of particles.  Note that in general
+this is a different normalization than taking the values produced by
+the formulas below for a single timestep, summing them over the
+sampling timesteps, and then dividing by the number of sampling steps.
+However for the current values listed below, the two normalization
+methods are the same.
 </P>
 <P>NOTE: If particle weighting is enabled via the <A HREF = "global.html">global
 weight</A> command, then all of the values below are scaled

--- a/doc/compute_boundary.html
+++ b/doc/compute_boundary.html
@@ -84,19 +84,19 @@ in different species groups.
 </P>
 <P>The results of this compute can be used by different commands in
 different ways.  The values for a single timestep can be output by the
-<A HREF = "dump.html">stats_style</A> command.
+<A HREF = "stats_style.html">stats_style</A> command.
 </P>
 <P>The values over many sampling timesteps can be averaged by the <A HREF = "fix_ave_time.html">fix
 ave/time</A> command.  It does its averaging as if the
-particles striking the face at each sampling timestep were combined
-together into one large set to compute the formulas below.  The answer
-is then divided by the number of sampling timesteps if it is not
-otherwise normalized by the number of particles.  Note that in general
-this is a different normalization than taking the values produced by
-the formulas below for a single timestep, summing them over the
-sampling timesteps, and then dividing by the number of sampling steps.
-However for the current values listed below, the two normalization
-methods are the same.
+particles striking the boundary at each sampling timestep were
+combined together into one large set to compute the formulas below.
+The answer is then divided by the number of sampling timesteps if it
+is not otherwise normalized by the number of particles.  Note that in
+general this is a different normalization than taking the values
+produced by the formulas below for a single timestep, summing them
+over the sampling timesteps, and then dividing by the number of
+sampling steps.  However for the current values listed below, the two
+normalization methods are the same.
 </P>
 <P>NOTE: If particle weighting is enabled via the <A HREF = "global.html">global
 weight</A> command, then all of the values below are scaled

--- a/doc/compute_boundary.txt
+++ b/doc/compute_boundary.txt
@@ -74,19 +74,19 @@ in different species groups.
 
 The results of this compute can be used by different commands in
 different ways.  The values for a single timestep can be output by the
-"stats_style"_dump.html command.
+"stats_style"_stats_style.html command.
 
 The values over many sampling timesteps can be averaged by the "fix
 ave/time"_fix_ave_time.html command.  It does its averaging as if the
-particles striking the face at each sampling timestep were combined
-together into one large set to compute the formulas below.  The answer
-is then divided by the number of sampling timesteps if it is not
-otherwise normalized by the number of particles.  Note that in general
-this is a different normalization than taking the values produced by
-the formulas below for a single timestep, summing them over the
-sampling timesteps, and then dividing by the number of sampling steps.
-However for the current values listed below, the two normalization
-methods are the same.
+particles striking the boundary at each sampling timestep were
+combined together into one large set to compute the formulas below.
+The answer is then divided by the number of sampling timesteps if it
+is not otherwise normalized by the number of particles.  Note that in
+general this is a different normalization than taking the values
+produced by the formulas below for a single timestep, summing them
+over the sampling timesteps, and then dividing by the number of
+sampling steps.  However for the current values listed below, the two
+normalization methods are the same.
 
 NOTE: If particle weighting is enabled via the "global
 weight"_global.html command, then all of the values below are scaled

--- a/doc/compute_boundary.txt
+++ b/doc/compute_boundary.txt
@@ -77,16 +77,16 @@ different ways.  The values for a single timestep can be output by the
 "stats_style"_dump.html command.
 
 The values over many sampling timesteps can be averaged by the "fix
-ave/surf"_fix_ave_surf.html command.  It does its averaging as if the
-particles striking the surface element at each sampling timestep were
-combined together into one large set to compute the formulas below.
-The answer is then divided by the number of sampling timesteps if it
-is not otherwise normalized by the number of particles.  Note that in
-general this is a different normalization than taking the values
-produced by the formulas below for a single timestep, summing them
-over the sampling timesteps, and then dividing by the number of
-sampling steps.  However for the current values listed below, the two
-normalization methods are the same.
+ave/time"_fix_ave_time.html command.  It does its averaging as if the
+particles striking the face at each sampling timestep were combined
+together into one large set to compute the formulas below.  The answer
+is then divided by the number of sampling timesteps if it is not
+otherwise normalized by the number of particles.  Note that in general
+this is a different normalization than taking the values produced by
+the formulas below for a single timestep, summing them over the
+sampling timesteps, and then dividing by the number of sampling steps.
+However for the current values listed below, the two normalization
+methods are the same.
 
 NOTE: If particle weighting is enabled via the "global
 weight"_global.html command, then all of the values below are scaled

--- a/doc/compute_isurf_grid.html
+++ b/doc/compute_isurf_grid.html
@@ -17,7 +17,7 @@
 </PRE>
 <UL><LI>ID is documented in <A HREF = "compute.html">compute</A> command 
 
-<LI>boundary = style name of this compute command 
+<LI>isurf/grid = style name of this compute command 
 
 <LI>group-ID = group ID for which grid cells to perform calculation on 
 

--- a/doc/compute_isurf_grid.txt
+++ b/doc/compute_isurf_grid.txt
@@ -13,7 +13,7 @@ compute isurf/grid command :h3
 compute ID isurf/grid group-ID mix-ID value1 value2 ... :pre
 
 ID is documented in "compute"_compute.html command :ulb,l
-boundary = style name of this compute command :l
+isurf/grid = style name of this compute command :l
 group-ID = group ID for which grid cells to perform calculation on :l
 mix-ID = mixture ID for particles to perform calculation on :l
 one or more values can be appended :l

--- a/doc/compute_react_boundary.html
+++ b/doc/compute_react_boundary.html
@@ -1,0 +1,110 @@
+<HTML>
+<CENTER><A HREF = "http://sparta.sandia.gov">SPARTA WWW Site</A> - <A HREF = "Manual.html">SPARTA Documentation</A> - <A HREF = "Section_commands.html#comm">SPARTA Commands</A> 
+</CENTER>
+
+
+
+
+
+
+<HR>
+
+<H3>compute react/boundary command 
+</H3>
+<P><B>Syntax:</B>
+</P>
+<PRE>compute ID react/boundary reaction-ID value1 value2 ... 
+</PRE>
+<UL><LI>ID is documented in <A HREF = "compute.html">compute</A> command 
+
+<LI>react/boundary = style name of this compute command 
+
+<LI>reaction-ID = surface reaction ID which defines surface reactions 
+
+<LI>zero or more values can be appended 
+
+<LI>value = <I>r:s1/s2/s3 ...</I> or <I>p:s1/s2/s3 ...</I> 
+
+<PRE>  r: or p: = list of reactant species or product species
+  s1,s2,s3 = one or more species IDs, separated by "/" character 
+</PRE>
+
+</UL>
+<P><B>Examples:</B>
+</P>
+<PRE>surf_react air prob air.surf
+compute 1 react/boundary air
+compute 2 react/boundary air r:N/O/N2/O2 p:N/O/NO 
+</PRE>
+<P>These commands will time average the reaction tallies for each face
+and output the results as part of statistical output:
+</P>
+<PRE>compute 2 react/boundary air r:N/O/N2/O2 p:N/O/NO 
+</PRE>
+<PRE>fix 1 ave/time all 10 100 1000 c_2[*]
+stats_style step np f_1[1][*] f_1[2][*] f_1[3][*] f_1[4][*] 
+</PRE>
+<P><B>Description:</B>
+</P>
+<P>Define a computation that tallies counts of reactions for each
+boundary (i.e. face) of the simulation box, based on the particles
+that collide with the boundary.  Only faces assigned to the surface
+reaction model specified by <I>reaction-ID</I> are included in the
+tallying.
+</P>
+<P>Note that when a particle collides with a face, it can bounce off
+(possibly as a different species), be captured by the surface
+(vanish), or a 2nd particle can also be emitted.
+</P>
+<P>The doc page for the <A HREF = "surf_react.html">surf_react</A> command explains the
+different reactions that can occur for each specified style.
+</P>
+<P>If no values are specified each reaction specified by the
+<A HREF = "surf_react.html">surf_react</A> style is tallied individually for each
+boundary.
+</P>
+<P>If M values are specified, then M tallies are made for each face, one
+per value.  If the value starts with "r:" then any reaction which
+occurs with one (or more) of the listed species as a reactant is
+counted as part of that tally.  If the value starts with "p:" then any
+reaction which occurs with one (or more) of the listed species as a
+product is counted as part of that tally.  Note that these rules mean
+that a single reaction may be tallied multiple times depending on
+which values it matches.
+</P>
+<P>The results of this compute can be used by different commands in
+different ways.  The values for a single timestep can be output by the
+<A HREF = "stats_style.html">stats_style</A> command.  The values over many sampling
+timesteps can be averaged by the <A HREF = "fix_ave_time.html">fix ave/time</A>
+command.
+</P>
+<HR>
+
+<P><B>Output info:</B>
+</P>
+<P>This compute calculates a global array, with the number of columns
+either equal to the number of reactions defined by the
+<A HREF = "surf_react">surf_react</A> style (if no values are specified) or equal to
+M = the # of values specified.  The number of rows is 4 for a 2d
+simulation for the 4 faces (xlo, xhi, ylo, yhi), and it is 6 for a 3d
+simulation (xlo, xhi, ylo, yhi, zlo, zhi).
+</P>
+<P>The array can be accessed by any command that uses global array values
+from a compute as input.  See <A HREF = "Section_howto.html#howto_4">Section 6.4</A>
+for an overview of SPARTA output options.
+</P>
+<P>The array values are counts of the number of reactions that occurred
+on each face.
+</P>
+<HR>
+
+<P><B>Restrictions:</B> none
+</P>
+<P><B>Related commands:</B>
+</P>
+<P><A HREF = "fix_ave_time.html">fix ave/time</A>, <A HREF = "compute_react_surf.html">compute
+react/surf</A>
+</P>
+<P><B>Default:</B> none
+</P>
+</HTML>

--- a/doc/compute_react_boundary.txt
+++ b/doc/compute_react_boundary.txt
@@ -1,0 +1,98 @@
+"SPARTA WWW Site"_sws - "SPARTA Documentation"_sd - "SPARTA Commands"_sc :c
+
+:link(sws,http://sparta.sandia.gov)
+:link(sd,Manual.html)
+:link(sc,Section_commands.html#comm)
+
+:line
+
+compute react/boundary command :h3
+
+[Syntax:]
+
+compute ID react/boundary reaction-ID value1 value2 ... :pre
+
+ID is documented in "compute"_compute.html command :ulb,l
+react/boundary = style name of this compute command :l
+reaction-ID = surface reaction ID which defines surface reactions :l
+zero or more values can be appended :l
+value = {r:s1/s2/s3 ...} or {p:s1/s2/s3 ...} :l
+  r: or p: = list of reactant species or product species
+  s1,s2,s3 = one or more species IDs, separated by "/" character :pre
+:ule
+
+[Examples:]
+
+surf_react air prob air.surf
+compute 1 react/boundary air
+compute 2 react/boundary air r:N/O/N2/O2 p:N/O/NO :pre
+
+These commands will time average the reaction tallies for each face
+and output the results as part of statistical output:
+
+compute 2 react/boundary air r:N/O/N2/O2 p:N/O/NO :pre
+fix 1 ave/time all 10 100 1000 c_2\[*\]
+stats_style step np f_1\[1\]\[*\] f_1\[2\]\[*\] f_1\[3\]\[*\] f_1\[4\]\[*\] :pre
+
+[Description:]
+
+Define a computation that tallies counts of reactions for each
+boundary (i.e. face) of the simulation box, based on the particles
+that collide with the boundary.  Only faces assigned to the surface
+reaction model specified by {reaction-ID} are included in the
+tallying.
+
+Note that when a particle collides with a face, it can bounce off
+(possibly as a different species), be captured by the surface
+(vanish), or a 2nd particle can also be emitted.
+
+The doc page for the "surf_react"_surf_react.html command explains the
+different reactions that can occur for each specified style.
+
+If no values are specified each reaction specified by the
+"surf_react"_surf_react.html style is tallied individually for each
+boundary.
+
+If M values are specified, then M tallies are made for each face, one
+per value.  If the value starts with "r:" then any reaction which
+occurs with one (or more) of the listed species as a reactant is
+counted as part of that tally.  If the value starts with "p:" then any
+reaction which occurs with one (or more) of the listed species as a
+product is counted as part of that tally.  Note that these rules mean
+that a single reaction may be tallied multiple times depending on
+which values it matches.
+
+The results of this compute can be used by different commands in
+different ways.  The values for a single timestep can be output by the
+"stats_style"_stats_style.html command.  The values over many sampling
+timesteps can be averaged by the "fix ave/time"_fix_ave_time.html
+command.
+
+:line
+
+[Output info:]
+
+This compute calculates a global array, with the number of columns
+either equal to the number of reactions defined by the
+"surf_react"_surf_react style (if no values are specified) or equal to
+M = the # of values specified.  The number of rows is 4 for a 2d
+simulation for the 4 faces (xlo, xhi, ylo, yhi), and it is 6 for a 3d
+simulation (xlo, xhi, ylo, yhi, zlo, zhi).
+
+The array can be accessed by any command that uses global array values
+from a compute as input.  See "Section 6.4"_Section_howto.html#howto_4
+for an overview of SPARTA output options.
+
+The array values are counts of the number of reactions that occurred
+on each face.
+
+:line
+
+[Restrictions:] none
+
+[Related commands:]
+
+"fix ave/time"_fix_ave_time.html, "compute
+react/surf"_compute_react_surf.html
+
+[Default:] none

--- a/doc/compute_react_isurf_grid.html
+++ b/doc/compute_react_isurf_grid.html
@@ -1,0 +1,127 @@
+<HTML>
+<CENTER><A HREF = "http://sparta.sandia.gov">SPARTA WWW Site</A> - <A HREF = "Manual.html">SPARTA Documentation</A> - <A HREF = "Section_commands.html#comm">SPARTA Commands</A> 
+</CENTER>
+
+
+
+
+
+
+<HR>
+
+<H3>compute react/isurf/grid command 
+</H3>
+<P><B>Syntax:</B>
+</P>
+<PRE>compute ID react/isurf/grid group-ID reaction-ID value1 value2 ... 
+</PRE>
+<UL><LI>ID is documented in <A HREF = "compute.html">compute</A> command 
+
+<LI>react/isurf/grid = style name of this compute command 
+
+<LI>group-ID = group ID for which grid cells to perform calculation on 
+
+<LI>reaction-ID = surface reaction ID which defines surface reactions 
+
+<LI>zero or more values can be appended 
+
+<LI>value = <I>r:s1/s2/s3 ...</I> or <I>p:s1/s2/s3 ...</I> 
+
+<PRE>  r: or p: = list of reactant species or product species
+  s1,s2,s3 = one or more species IDs, separated by "/" character 
+</PRE>
+
+</UL>
+<P><B>Examples:</B>
+</P>
+<PRE>surf_react air prob air.surf
+compute 1 react/isurf/grid all air
+compute 2 react/isurf/grid all air r:N/O/N2/O2 p:N/O/NO 
+</PRE>
+<P>These commands will dump time averages for each surface element to a
+dump file every 1000 steps:
+</P>
+<PRE>compute 2 react/isurf/grid all air r:N/O/N2/O2 p:N/O/NO
+fix 1 ave/grid all 10 100 1000 c_2[*]
+dump 1 grid all 1000 tmp.surgrid id f_1[*] 
+</PRE>
+<P><B>Description:</B>
+</P>
+<P>Define a computation that tallies counts of reactions for each grid
+cell containing implicit surface elements in a grid group, based on
+the particles that collide with those elements.  Only grid cells
+elements in the grid group specified by <I>group-ID</I> are included in the
+tallying.  See the <A HREF = "group.html">group grid</A> command for info on how
+grid cells can be assigned to grid groups.  Likewise only grid cells
+with surface elements assigned to the surface reaction model specified
+by <I>reaction-ID</I> are included in the tallying.
+</P>
+<P>Implicit surface elements are triangles for 3d simulations and line
+segments for 2d simulations.  Unlike explicit surface elements, each
+triangle or line segment is wholly contained within a single grid
+cell.  See the <A HREF = "read_isurf.html">read_isurf</A> command for details.
+</P>
+<P>This command can only be used for simulations with implicit surface
+elements.  See the similar <A HREF = "compute_react_surf.html">compute
+react/surf</A> command for use with simulations
+with explicit surface elements.
+</P>
+<P>Note that when a particle collides with a surface element, it can
+bounce off (possibly as a different species), be captured by the
+surface (vanish), or a 2nd particle can also be emitted.
+</P>
+<P>The doc page for the <A HREF = "surf_react.html">surf_react</A> command explains the
+different reactions that can occur for each specified style.
+</P>
+<P>If no values are specified each reaction specified by the
+<A HREF = "surf_react.html">surf_react</A> style is tallied individually for each
+grid cell.
+</P>
+<P>If M values are specified, then M tallies are made for each grid cell,
+one per value.  If the value starts with "r:" then any reaction which
+occurs with one (or more) of the listed species as a reactant is
+counted as part of that tally.  If the value starts with "p:" then any
+reaction which occurs with one (or more) of the listed species as a
+product is counted as part of that tally.  Note that these rules mean
+that a single reaction may be tallied multiple times depending on
+which values it matches.
+</P>
+<P>The results of this compute can be used by different commands in
+different ways.  The values for a single timestep can be output by the
+<A HREF = "dump.html">dump grid</A> command.
+</P>
+<P>The values over many sampling timesteps can be averaged by the <A HREF = "fix_ave_grid.html">fix
+ave/grid</A> command.  
+</P>
+<HR>
+
+<P><B>Output info:</B>
+</P>
+<P>This compute calculates a per-grid array, with the number of columns
+either equal to the number of reactions defined by the
+<A HREF = "surf_react">surf_react</A> style (if no values are specified) or equal to
+M = the # of values specified.
+</P>
+<P>Grid cells not in the specified <I>group-ID</I> or whose implicit surfaces
+are not assigned to the specified <I>reaction-ID</I> will output zeroes for
+all their values.
+</P>
+<P>The array can be accessed by any command that uses per-grid values
+from a compute as input.  See <A HREF = "Section_howto.html#howto_4">Section 6.4</A>
+for an overview of SPARTA output options.
+</P>
+<P>The per-grid array values are counts of the number of reactions that
+occurred on surface elements in that grid cell.
+</P>
+<HR>
+
+<P><B>Restrictions:</B> none
+</P>
+<P><B>Related commands:</B>
+</P>
+<P><A HREF = "fix_ave_grid.html">fix ave/grid</A>, <A HREF = "dump.html">dump grid</A>, <A HREF = "compute_react_surf.html">compute
+react/surf</A>
+</P>
+<P><B>Default:</B> none
+</P>
+</HTML>

--- a/doc/compute_react_isurf_grid.txt
+++ b/doc/compute_react_isurf_grid.txt
@@ -1,0 +1,115 @@
+"SPARTA WWW Site"_sws - "SPARTA Documentation"_sd - "SPARTA Commands"_sc :c
+
+:link(sws,http://sparta.sandia.gov)
+:link(sd,Manual.html)
+:link(sc,Section_commands.html#comm)
+
+:line
+
+compute react/isurf/grid command :h3
+
+[Syntax:]
+
+compute ID react/isurf/grid group-ID reaction-ID value1 value2 ... :pre
+
+ID is documented in "compute"_compute.html command :ulb,l
+react/isurf/grid = style name of this compute command :l
+group-ID = group ID for which grid cells to perform calculation on :l
+reaction-ID = surface reaction ID which defines surface reactions :l
+zero or more values can be appended :l
+value = {r:s1/s2/s3 ...} or {p:s1/s2/s3 ...} :l
+  r: or p: = list of reactant species or product species
+  s1,s2,s3 = one or more species IDs, separated by "/" character :pre
+:ule
+
+[Examples:]
+
+surf_react air prob air.surf
+compute 1 react/isurf/grid all air
+compute 2 react/isurf/grid all air r:N/O/N2/O2 p:N/O/NO :pre
+
+These commands will dump time averages for each surface element to a
+dump file every 1000 steps:
+
+compute 2 react/isurf/grid all air r:N/O/N2/O2 p:N/O/NO
+fix 1 ave/grid all 10 100 1000 c_2\[*\]
+dump 1 grid all 1000 tmp.surgrid id f_1\[*\] :pre
+
+[Description:]
+
+Define a computation that tallies counts of reactions for each grid
+cell containing implicit surface elements in a grid group, based on
+the particles that collide with those elements.  Only grid cells
+elements in the grid group specified by {group-ID} are included in the
+tallying.  See the "group grid"_group.html command for info on how
+grid cells can be assigned to grid groups.  Likewise only grid cells
+with surface elements assigned to the surface reaction model specified
+by {reaction-ID} are included in the tallying.
+
+Implicit surface elements are triangles for 3d simulations and line
+segments for 2d simulations.  Unlike explicit surface elements, each
+triangle or line segment is wholly contained within a single grid
+cell.  See the "read_isurf"_read_isurf.html command for details.
+
+This command can only be used for simulations with implicit surface
+elements.  See the similar "compute
+react/surf"_compute_react_surf.html command for use with simulations
+with explicit surface elements.
+
+Note that when a particle collides with a surface element, it can
+bounce off (possibly as a different species), be captured by the
+surface (vanish), or a 2nd particle can also be emitted.
+
+The doc page for the "surf_react"_surf_react.html command explains the
+different reactions that can occur for each specified style.
+
+If no values are specified each reaction specified by the
+"surf_react"_surf_react.html style is tallied individually for each
+grid cell.
+
+If M values are specified, then M tallies are made for each grid cell,
+one per value.  If the value starts with "r:" then any reaction which
+occurs with one (or more) of the listed species as a reactant is
+counted as part of that tally.  If the value starts with "p:" then any
+reaction which occurs with one (or more) of the listed species as a
+product is counted as part of that tally.  Note that these rules mean
+that a single reaction may be tallied multiple times depending on
+which values it matches.
+
+The results of this compute can be used by different commands in
+different ways.  The values for a single timestep can be output by the
+"dump grid"_dump.html command.
+
+The values over many sampling timesteps can be averaged by the "fix
+ave/grid"_fix_ave_grid.html command.  
+
+:line
+
+[Output info:]
+
+This compute calculates a per-grid array, with the number of columns
+either equal to the number of reactions defined by the
+"surf_react"_surf_react style (if no values are specified) or equal to
+M = the # of values specified.
+
+Grid cells not in the specified {group-ID} or whose implicit surfaces
+are not assigned to the specified {reaction-ID} will output zeroes for
+all their values.
+
+The array can be accessed by any command that uses per-grid values
+from a compute as input.  See "Section 6.4"_Section_howto.html#howto_4
+for an overview of SPARTA output options.
+
+The per-grid array values are counts of the number of reactions that
+occurred on surface elements in that grid cell.
+
+:line
+
+[Restrictions:] none
+
+[Related commands:]
+
+"fix ave/grid"_fix_ave_grid.html, "dump grid"_dump.html, "compute
+react/surf"_compute_react_surf.html
+
+[Default:] none

--- a/doc/compute_react_surf.html
+++ b/doc/compute_react_surf.html
@@ -1,0 +1,126 @@
+<HTML>
+<CENTER><A HREF = "http://sparta.sandia.gov">SPARTA WWW Site</A> - <A HREF = "Manual.html">SPARTA Documentation</A> - <A HREF = "Section_commands.html#comm">SPARTA Commands</A> 
+</CENTER>
+
+
+
+
+
+
+<HR>
+
+<H3>compute react/surf command 
+</H3>
+<P><B>Syntax:</B>
+</P>
+<PRE>compute ID react/surf group-ID reaction-ID value1 value2 ... 
+</PRE>
+<UL><LI>ID is documented in <A HREF = "compute.html">compute</A> command 
+
+<LI>react/surf = style name of this compute command 
+
+<LI>group-ID = group ID for which surface elements to perform calculation on 
+
+<LI>reaction-ID = surface reaction ID which defines surface reactions 
+
+<LI>zero or more values can be appended 
+
+<LI>value = <I>r:s1/s2/s3 ...</I> or <I>p:s1/s2/s3 ...</I> 
+
+<PRE>  r: or p: = list of reactant species or product species
+  s1,s2,s3 = one or more species IDs, separated by "/" character 
+</PRE>
+
+</UL>
+<P><B>Examples:</B>
+</P>
+<PRE>surf_react air prob air.surf
+compute 1 react/surf all air
+compute 2 react/surf all air r:N/O/N2/O2 p:N/O/NO 
+</PRE>
+<P>These commands will dump time averages for each surface element to a
+dump file every 1000 steps:
+</P>
+<PRE>compute 2 react/surf all air r:N/O/N2/O2 p:N/O/NO
+fix 1 ave/surf all 10 100 1000 c_2[*]
+dump 1 surf all 1000 tmp.surf id f_1[*] 
+</PRE>
+<P><B>Description:</B>
+</P>
+<P>Define a computation that tallies counts of reactions for each
+explicit surface element in a surface element group, based on the
+particles that collide with that element.  Only surface elements in
+the surface group specified by <I>group-ID</I> are included in the
+tallying.  See the <A HREF = "group.html">group surf</A> command for info on how
+surface elements can be assigned to surface groups.  Likewise only
+surface elements assigned to the surface reaction model specified by
+<I>reaction-ID</I> are included in the tallying.
+</P>
+<P>Explicit surface elements are triangles for 3d simulations and line
+segments for 2d simulations.  Unlike implicit surface elements, each
+explicit triangle or line segment may span multiple grid cells.  See
+the <A HREF = "read_surf.html">read_surf</A> command for details.
+</P>
+<P>This command can only be used for simulations with explicit surface
+elements.  See the similar <A HREF = "compute_react_isurf_grid.html">compute
+react/isurf/grid</A> command for use with
+simulations with implicit surface elements.
+</P>
+<P>Note that when a particle collides with a surface element, it can
+bounce off (possibly as a different species), be captured by the
+surface (vanish), or a 2nd particle can also be emitted.
+</P>
+<P>The doc page for the <A HREF = "surf_react.html">surf_react</A> command explains the
+different reactions that can occur for each specified style.
+</P>
+<P>If no values are specified each reaction specified by the
+<A HREF = "surf_react.html">surf_react</A> style is tallied individually for each
+surface element.
+</P>
+<P>If M values are specified, then M tallies are made for each surface
+element, one per value.  If the value starts with "r:" then any
+reaction which occurs with one (or more) of the listed species as a
+reactant is counted as part of that tally.  If the value starts with
+"p:" then any reaction which occurs with one (or more) of the listed
+species as a product is counted as part of that tally.  Note that
+these rules mean that a single reaction may be tallied multiple times
+depending on which values it matches.
+</P>
+<P>The results of this compute can be used by different commands in
+different ways.  The values for a single timestep can be output by the
+<A HREF = "dump.html">dump surf</A> command.
+</P>
+<P>The values over many sampling timesteps can be averaged by the <A HREF = "fix_ave_surf.html">fix
+ave/surf</A> command.
+</P>
+<HR>
+
+<P><B>Output info:</B>
+</P>
+<P>This compute calculates a per-surf array, with the number of columns
+either equal to the number of reactions defined by the
+<A HREF = "surf_react">surf_react</A> style (if no values are specified) or equal to
+M = the # of values specified.
+</P>
+<P>Surface elements not in the specified <I>group-ID</I> or not assigned to
+the specified <I>reaction-ID</I> will output zeroes for all their values.
+</P>
+<P>The array can be accessed by any command that uses per-surf values
+from a compute as input.  See <A HREF = "Section_howto.html#howto_4">Section 6.4</A>
+for an overview of SPARTA output options.
+</P>
+<P>The per-surf array values are counts of the number of reactions that
+occurred.
+</P>
+<HR>
+
+<P><B>Restrictions:</B> none
+</P>
+<P><B>Related commands:</B>
+</P>
+<P><A HREF = "fix_ave_surf.html">fix ave/surf</A>, <A HREF = "dump.html">dump surf</A>, <A HREF = "compute_react_isurf_grid.html">compute
+react/isurf/grid</A>
+</P>
+<P><B>Default:</B> none
+</P>
+</HTML>

--- a/doc/compute_react_surf.txt
+++ b/doc/compute_react_surf.txt
@@ -1,0 +1,114 @@
+"SPARTA WWW Site"_sws - "SPARTA Documentation"_sd - "SPARTA Commands"_sc :c
+
+:link(sws,http://sparta.sandia.gov)
+:link(sd,Manual.html)
+:link(sc,Section_commands.html#comm)
+
+:line
+
+compute react/surf command :h3
+
+[Syntax:]
+
+compute ID react/surf group-ID reaction-ID value1 value2 ... :pre
+
+ID is documented in "compute"_compute.html command :ulb,l
+react/surf = style name of this compute command :l
+group-ID = group ID for which surface elements to perform calculation on :l
+reaction-ID = surface reaction ID which defines surface reactions :l
+zero or more values can be appended :l
+value = {r:s1/s2/s3 ...} or {p:s1/s2/s3 ...} :l
+  r: or p: = list of reactant species or product species
+  s1,s2,s3 = one or more species IDs, separated by "/" character :pre
+:ule
+
+[Examples:]
+
+surf_react air prob air.surf
+compute 1 react/surf all air
+compute 2 react/surf all air r:N/O/N2/O2 p:N/O/NO :pre
+
+These commands will dump time averages for each surface element to a
+dump file every 1000 steps:
+
+compute 2 react/surf all air r:N/O/N2/O2 p:N/O/NO
+fix 1 ave/surf all 10 100 1000 c_2\[*\]
+dump 1 surf all 1000 tmp.surf id f_1\[*\] :pre
+
+[Description:]
+
+Define a computation that tallies counts of reactions for each
+explicit surface element in a surface element group, based on the
+particles that collide with that element.  Only surface elements in
+the surface group specified by {group-ID} are included in the
+tallying.  See the "group surf"_group.html command for info on how
+surface elements can be assigned to surface groups.  Likewise only
+surface elements assigned to the surface reaction model specified by
+{reaction-ID} are included in the tallying.
+
+Explicit surface elements are triangles for 3d simulations and line
+segments for 2d simulations.  Unlike implicit surface elements, each
+explicit triangle or line segment may span multiple grid cells.  See
+the "read_surf"_read_surf.html command for details.
+
+This command can only be used for simulations with explicit surface
+elements.  See the similar "compute
+react/isurf/grid"_compute_react_isurf_grid.html command for use with
+simulations with implicit surface elements.
+
+Note that when a particle collides with a surface element, it can
+bounce off (possibly as a different species), be captured by the
+surface (vanish), or a 2nd particle can also be emitted.
+
+The doc page for the "surf_react"_surf_react.html command explains the
+different reactions that can occur for each specified style.
+
+If no values are specified each reaction specified by the
+"surf_react"_surf_react.html style is tallied individually for each
+surface element.
+
+If M values are specified, then M tallies are made for each surface
+element, one per value.  If the value starts with "r:" then any
+reaction which occurs with one (or more) of the listed species as a
+reactant is counted as part of that tally.  If the value starts with
+"p:" then any reaction which occurs with one (or more) of the listed
+species as a product is counted as part of that tally.  Note that
+these rules mean that a single reaction may be tallied multiple times
+depending on which values it matches.
+
+The results of this compute can be used by different commands in
+different ways.  The values for a single timestep can be output by the
+"dump surf"_dump.html command.
+
+The values over many sampling timesteps can be averaged by the "fix
+ave/surf"_fix_ave_surf.html command.
+
+:line
+
+[Output info:]
+
+This compute calculates a per-surf array, with the number of columns
+either equal to the number of reactions defined by the
+"surf_react"_surf_react style (if no values are specified) or equal to
+M = the # of values specified.
+
+Surface elements not in the specified {group-ID} or not assigned to
+the specified {reaction-ID} will output zeroes for all their values.
+
+The array can be accessed by any command that uses per-surf values
+from a compute as input.  See "Section 6.4"_Section_howto.html#howto_4
+for an overview of SPARTA output options.
+
+The per-surf array values are counts of the number of reactions that
+occurred.
+
+:line
+
+[Restrictions:] none
+
+[Related commands:]
+
+"fix ave/surf"_fix_ave_surf.html, "dump surf"_dump.html, "compute
+react/isurf/grid"_compute_react_isurf_grid.html
+
+[Default:] none

--- a/doc/compute_surf.html
+++ b/doc/compute_surf.html
@@ -19,7 +19,7 @@
 </PRE>
 <UL><LI>ID is documented in <A HREF = "compute.html">compute</A> command 
 
-<LI>boundary = style name of this compute command 
+<LI>surf = style name of this compute command 
 
 <LI>group-ID = group ID for which surface elements to perform calculation on 
 
@@ -69,7 +69,7 @@ stats_style step cpu np c_2[1] c_2[2]
 </P>
 <P>Define a computation that calculates one or more values for each
 explicit surface element in a surface element group, based on the
-particles that collide with that element.  The values are summed for
+particles that collide with that element. The values are summed for
 each group of species in the specified mixture.  See the
 <A HREF = "mixture.html">mixture</A> command for how a set of species can be
 partitioned into groups.  Only surface elements in the surface group
@@ -83,8 +83,9 @@ explicit triangle or line segment may span multiple grid cells.  See
 the <A HREF = "read_surf.html">read_surf</A> command for details.
 </P>
 <P>This command can only be used for simulations with explicit surface
-elements.  See the similar <A HREF = "compute_isurfrid.html">compute isurf/grid</A>
-command for use with simulations with implicit surface elements.
+elements.  See the similar <A HREF = "compute_isurf_grid.html">compute
+isurf/grid</A> command for use with simulations
+with implicit surface elements.
 </P>
 <P>Note that when a particle collides with a surface element, it can
 bounce off (possibly as a different species), be captured by the

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -14,7 +14,7 @@ compute surf/kk command :h3
 compute ID surf group-ID mix-ID value1 value2 ... :pre
 
 ID is documented in "compute"_compute.html command :ulb,l
-boundary = style name of this compute command :l
+surf = style name of this compute command :l
 group-ID = group ID for which surface elements to perform calculation on :l
 mix-ID = mixture ID for particles to perform calculation on :l
 one or more values can be appended :l
@@ -58,7 +58,7 @@ stats_style step cpu np c_2\[1\] c_2\[2\] :pre
 
 Define a computation that calculates one or more values for each
 explicit surface element in a surface element group, based on the
-particles that collide with that element.  The values are summed for
+particles that collide with that element. The values are summed for
 each group of species in the specified mixture.  See the
 "mixture"_mixture.html command for how a set of species can be
 partitioned into groups.  Only surface elements in the surface group
@@ -72,8 +72,9 @@ explicit triangle or line segment may span multiple grid cells.  See
 the "read_surf"_read_surf.html command for details.
 
 This command can only be used for simulations with explicit surface
-elements.  See the similar "compute isurf/grid"_compute_isurfrid.html
-command for use with simulations with implicit surface elements.
+elements.  See the similar "compute
+isurf/grid"_compute_isurf_grid.html command for use with simulations
+with implicit surface elements.
 
 Note that when a particle collides with a surface element, it can
 bounce off (possibly as a different species), be captured by the

--- a/doc/fix_ablate.html
+++ b/doc/fix_ablate.html
@@ -37,7 +37,8 @@
 </UL>
 <P><B>Examples:</B>
 </P>
-<PRE>fix 1 ablate surfcells 
+<PRE>fix 1 ablate surfcells 0 0.0 random 10
+fix 1 ablate surfcells 1000 10.0 c_tally 
 </PRE>
 <P><B>Description:</B>
 </P>
@@ -103,6 +104,47 @@ and 1.0.  The second is a random integer between 1 and maxrandom.  If
 the first random # < <I>scale</I>, then the second random integer is the
 decrement value for the cell.  Thus <I>scale</I> is effectively the
 fraction of grid cells whose corner point values are decremented.
+</P>
+<HR>
+
+<P>Here is an example of commands that will couple ablation to surface
+reaction statistics to modulate ablation of a set of implicit
+surfaces.  These lines are taken from the
+examples/ablation/in.ablation.3d.reactions input script:
+</P>
+<PRE>surf_collide	    1 diffuse 300.0 1.0
+surf_react	    2 prob air.surf 
+</PRE>
+<PRE>compute             10 react/isurf/grid all 2
+fix                 10 ave/grid all 1 100 100 c_10<B>*</B>
+dump                10 grid all 100 tmp.grid id c_10<B>1</B> 
+</PRE>
+<PRE>global              surfs implicit
+fix                 ablate ablate all 100 2.0 c_10<B>1</B>   # could be f_10
+read_isurf          all 20 20 20 binary.21x21x21 99.5 ablate 
+</PRE>
+<PRE>surf_modify         all collide 1 react 2 
+</PRE>
+<P>The order of these commands matter, so here is the explanation.
+</P>
+<P>The <A HREF = "surf_modify.html">surf_modify</A> command must come after the
+<A HREF = "read_isurf.html">read_isurf</A> command, because surfaces must exist
+before assigning collision and reaction models to them.  The <A HREF = "fix_ablate.html">fix
+ablate</A> command must come before the
+<A HREF = "read_isurf.html">read_isurf</A> command, since it uses the ID of the <A HREF = "fix_ablate">fix
+ablate</A> command as an argument to create implicit surfaces.
+The <A HREF = "fix_ablate.html">fix ablate</A> command takes a compute or fix as an
+argument, in this case the ID of the <A HREF = "compute_react_isurf_grid.html">compute
+react/isurf/grid</A> command.  This is to
+specify what calculation drives the ablation.  In this case, it is the
+<A HREF = "compute_react_isurf_grid.html">compute react/isurf/grid</A> command (or
+could be the <A HREF = "fix_ave_grid.html">fix ave/grid</A> command) which tallies
+counts of surface reactions for implicit triangles in each grid cell.
+The <A HREF = "compute">compute react/isurf/grid</A> react/isurf/grid command
+requires the ID of a surface reaction model, so that it knows the list
+of possible reactions to tally.  In this case the reaction is set by
+the <A HREF = "surf_react.html">surf_react</A> command, which must therefore comes
+near the beginning of this list of commands.
 </P>
 <HR>
 

--- a/doc/fix_ablate.txt
+++ b/doc/fix_ablate.txt
@@ -26,7 +26,8 @@ maxrandom = maximum per grid cell decrement as an integer (only specified if sou
 
 [Examples:]
 
-fix 1 ablate surfcells :pre
+fix 1 ablate surfcells 0 0.0 random 10
+fix 1 ablate surfcells 1000 10.0 c_tally :pre
 
 [Description:]
 
@@ -92,6 +93,47 @@ and 1.0.  The second is a random integer between 1 and maxrandom.  If
 the first random # < {scale}, then the second random integer is the
 decrement value for the cell.  Thus {scale} is effectively the
 fraction of grid cells whose corner point values are decremented.
+
+:line
+
+Here is an example of commands that will couple ablation to surface
+reaction statistics to modulate ablation of a set of implicit
+surfaces.  These lines are taken from the
+examples/ablation/in.ablation.3d.reactions input script:
+
+surf_collide	    1 diffuse 300.0 1.0
+surf_react	    2 prob air.surf :pre
+
+compute             10 react/isurf/grid all 2
+fix                 10 ave/grid all 1 100 100 c_10[*]
+dump                10 grid all 100 tmp.grid id c_10[1] :pre
+
+global              surfs implicit
+fix                 ablate ablate all 100 2.0 c_10[1]   # could be f_10
+read_isurf          all 20 20 20 binary.21x21x21 99.5 ablate :pre
+
+surf_modify         all collide 1 react 2 :pre
+
+The order of these commands matter, so here is the explanation.
+
+The "surf_modify"_surf_modify.html command must come after the
+"read_isurf"_read_isurf.html command, because surfaces must exist
+before assigning collision and reaction models to them.  The "fix
+ablate"_fix_ablate.html command must come before the
+"read_isurf"_read_isurf.html command, since it uses the ID of the "fix
+ablate"_fix_ablate command as an argument to create implicit surfaces.
+The "fix ablate"_fix_ablate.html command takes a compute or fix as an
+argument, in this case the ID of the "compute
+react/isurf/grid"_compute_react_isurf_grid.html command.  This is to
+specify what calculation drives the ablation.  In this case, it is the
+"compute react/isurf/grid"_compute_react_isurf_grid.html command (or
+could be the "fix ave/grid"_fix_ave_grid.html command) which tallies
+counts of surface reactions for implicit triangles in each grid cell.
+The "compute react/isurf/grid"_compute react/isurf/grid command
+requires the ID of a surface reaction model, so that it knows the list
+of possible reactions to tally.  In this case the reaction is set by
+the "surf_react"_surf_react.html command, which must therefore comes
+near the beginning of this list of commands.
 
 :line
 

--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -64,10 +64,14 @@ surf_collide heatwall diffuse v_ramp 0.8 translate 5.0 0.0 0.0
 <P>Define a model for particle-surface collisions.  One or more models
 can be defined and assigned to different surfaces or simulation box
 boundaries via the <A HREF = "surf_modify.html">surf_modify</A> or
-<A HREF = "bound_modify.html">bound_modify</A> commands.  See <A HREF = "Section_howto.html#howto_9">Section
+<A HREF = "bound_modify.html">bound_modify</A> commands.  See <A HREF = "Section_howto.html#howto_9<A HREF = "surf_react.html">>Section
 4.9</A> for more details of how SPARTA defines
 surfaces as collections of geometric elements, triangles in 3d and
-line segments in 2d.
+line segments in 2d.  Chemical reactions can also be part of a
+particle-surface interaction model.  See the
+surf_react</A> command for details.  All of the collision
+styles listed here support optional reactions, except the <I>vanish</I>
+style.
 </P>
 <P>The ID for a surface collision model is used to identify it in other
 commands.  Each surface collision model ID must be unique.  The ID can

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -56,7 +56,11 @@ boundaries via the "surf_modify"_surf_modify.html or
 "bound_modify"_bound_modify.html commands.  See "Section
 4.9"_Section_howto.html#howto_9 for more details of how SPARTA defines
 surfaces as collections of geometric elements, triangles in 3d and
-line segments in 2d.
+line segments in 2d.  Chemical reactions can also be part of a
+particle-surface interaction model.  See the
+surf_react"_surf_react.html command for details.  All of the collision
+styles listed here support optional reactions, except the {vanish}
+style.
 
 The ID for a surface collision model is used to identify it in other
 commands.  Each surface collision model ID must be unique.  The ID can
@@ -253,4 +257,3 @@ twice in the same input script (active at the same time).
 :link(Bird94)
 [(Bird94)] G. A. Bird, Molecular Gas Dynamics and the Direct
 Simulation of Gas Flows, Clarendon Press, Oxford (1994).
-

--- a/doc/surf_modify.html
+++ b/doc/surf_modify.html
@@ -50,9 +50,10 @@ elements in group-ID will be computed by the surface collision model
 with <I>sc-ID</I>.
 </P>
 <P>The <I>react</I> keyword is used to assign a surface reaction model.
-Surface reaction models are defined by the<A HREF = "surf_react.html">surf_react</A>
-command, which assigns each a surface reaction ID, specified here as
-<I>sr-ID</I> or the word "none".  The latter means no reaction model.
+Surface reaction models are defined by the
+<A HREF = "surf_react.html">surf_react</A> command, which assigns each a surface
+reaction ID, specified here as <I>sr-ID</I> or the word "none".  The latter
+means no reaction model.
 </P>
 <P>The effect of this keyword is that particle collisions with surface
 elements in group-ID will induce reactions which are computed by the
@@ -69,6 +70,8 @@ to a particular surface element.
 <P>All surface elements must be assigned to a surface collision model via
 the <I>collide</I> keyword before a simlulation can be performed.  Using a
 surface reaction model is optional.
+</P>
+<P>This command cannot be used before surfaces exist.
 </P>
 <P><B>Related commands:</B>
 </P>

--- a/doc/surf_modify.txt
+++ b/doc/surf_modify.txt
@@ -42,9 +42,10 @@ elements in group-ID will be computed by the surface collision model
 with {sc-ID}.
 
 The {react} keyword is used to assign a surface reaction model.
-Surface reaction models are defined by the"surf_react"_surf_react.html
-command, which assigns each a surface reaction ID, specified here as
-{sr-ID} or the word "none".  The latter means no reaction model.
+Surface reaction models are defined by the
+"surf_react"_surf_react.html command, which assigns each a surface
+reaction ID, specified here as {sr-ID} or the word "none".  The latter
+means no reaction model.
 
 The effect of this keyword is that particle collisions with surface
 elements in group-ID will induce reactions which are computed by the
@@ -61,6 +62,8 @@ to a particular surface element.
 All surface elements must be assigned to a surface collision model via
 the {collide} keyword before a simlulation can be performed.  Using a
 surface reaction model is optional.
+
+This command cannot be used before surfaces exist.
 
 [Related commands:]
 

--- a/doc/surf_react.html
+++ b/doc/surf_react.html
@@ -70,6 +70,8 @@ Currently this is only the <I>vanish</I> collision style.  See the
 <P>The <I>global</I> style is a simple model that can be used to test whether
 surface reactions are occurring as expected.  There is no list of
 reactions for different species; all species are treated the same.
+This style thus defines two universal reactions, the first for
+particle deletion, the second for particle creation.
 </P>
 <P>The <I>global</I> style takes two parameters, <I>pdelete</I> and <I>pcreate</I>. The
 first is the probability that a "deletion" reaction takes place when a
@@ -97,7 +99,8 @@ Only reactions for which all the reactants and all the products are
 currently defined as species-IDs will be active for the simulation.
 Thus the file can contain more reactions than are used in a particular
 simulation.  See the <A HREF = "species.html">species</A> command for how species
-IDs are defined.
+IDs are defined.  This style thus defines N reactions, where
+N is the number of reactions listed in the specified file.
 </P>
 <P>As explained below each reaction has a specified probability between
 0.0 and 1.0.  That probability is used to choose which reaction (if

--- a/doc/surf_react.html
+++ b/doc/surf_react.html
@@ -60,26 +60,18 @@ which reaction (if any) takes place.  A check is made that the sum of
 probabilities for all possible reactions is <= 1.0, which should
 normally be the case if reasonable reaction coefficients are defined.
 </P>
-<P>IMPORTANT NOTE: A surface reaction model can only be specified for
-surfaces whose surface collision model is <I>diffuse</I>.  This is partly
-because reactions do not make physical sense with the other current
-surface collision models.  And because the <I>diffuse</I> model defines a
-surface temperature, which is used to initialize the rotational and
-vibrational energies of new particles appearing due to dissociation
-reactions.  Note that the <I>diffuse</I> model can effectively perform
-specular reflections if its <I>acc</I> parameter is set to 0.0.  This is a
-way to to perform surface reactions with specular reflection, which
-you cannot do directly using the <A HREF = "surf_collide.html">surf_collide
-specular</A> model.  See the
+<P>IMPORTANT NOTE: A surface reaction model can not be specified for
+surfaces whose surface collision style does not support reactions.
+Currently this is only the <I>vanish</I> collision style.  See the
 <A HREF = "surf_collide.html">surf_collide</A> doc page for details.
 </P>
 <HR>
 
 <P>The <I>global</I> style is a simple model that can be used to test whether
 surface reactions are occurring as expected.  There is no list of
-raactions for different species; all species are treated the same.
+reactions for different species; all species are treated the same.
 </P>
-<P>The <I>global</I> style takes two paramters, <I>pdelete</I> and <I>pcreate</I>. The
+<P>The <I>global</I> style takes two parameters, <I>pdelete</I> and <I>pcreate</I>. The
 first is the probability that a "deletion" reaction takes place when a
 collision occurs.  If it does, the particle is deleted.  The second is
 the probablity that a "creation" reaction occurs, which clones the
@@ -186,7 +178,7 @@ two products must be specified in this order.
 
 <P><B>Output info:</B>
 </P>
-<P>All the surface reaction models calculate a global vector of length 2.
+<P>All the surface reaction models calculate a global vector of values.
 The values can be used by the <A HREF = "stats_style.html">stats_style</A> command
 and by <A HREF = "variable.html">variables</A> that define formulas.  The latter
 means they can be used by any command that uses a variable as input,
@@ -194,11 +186,19 @@ e.g. "the <A HREF = "fix_ave_time.html">fix ave/time</A> command.  See <A HREF =
 4.4</A> for an overview of SPARTA output
 options.
 </P>
+<P>The <I>global</I> and <I>prob</I> styles each compute a vector of length 2 +
+2*nlist.  For the <I>global</I> style, nlist = 2, for "delete" and "create"
+reactions.  For the <I>prob</I> style, nlist is the number of reactions
+listed in the file is read as input.
+</P>
 <P>The first element of the vector is the count of particles that
 performed surface reactions for surface elements assigned to this
 reaction model during the current timestep.  The second element is the
 cummulative count of particles that have performed reactions since the
-beginning of the current run.
+beginning of the current run.  The next nlist elements are the count
+of each individual reaction that occurred during the current timestep.
+The final nlist elements are the cummulative count of each individual
+reaction since the beginning of the current run.
 </P>
 <HR>
 

--- a/doc/surf_react.txt
+++ b/doc/surf_react.txt
@@ -53,26 +53,18 @@ which reaction (if any) takes place.  A check is made that the sum of
 probabilities for all possible reactions is <= 1.0, which should
 normally be the case if reasonable reaction coefficients are defined.
 
-IMPORTANT NOTE: A surface reaction model can only be specified for
-surfaces whose surface collision model is {diffuse}.  This is partly
-because reactions do not make physical sense with the other current
-surface collision models.  And because the {diffuse} model defines a
-surface temperature, which is used to initialize the rotational and
-vibrational energies of new particles appearing due to dissociation
-reactions.  Note that the {diffuse} model can effectively perform
-specular reflections if its {acc} parameter is set to 0.0.  This is a
-way to to perform surface reactions with specular reflection, which
-you cannot do directly using the "surf_collide
-specular"_surf_collide.html model.  See the
+IMPORTANT NOTE: A surface reaction model can not be specified for
+surfaces whose surface collision style does not support reactions.
+Currently this is only the {vanish} collision style.  See the
 "surf_collide"_surf_collide.html doc page for details.
 
 :line
 
 The {global} style is a simple model that can be used to test whether
 surface reactions are occurring as expected.  There is no list of
-raactions for different species; all species are treated the same.
+reactions for different species; all species are treated the same.
 
-The {global} style takes two paramters, {pdelete} and {pcreate}. The
+The {global} style takes two parameters, {pdelete} and {pcreate}. The
 first is the probability that a "deletion" reaction takes place when a
 collision occurs.  If it does, the particle is deleted.  The second is
 the probablity that a "creation" reaction occurs, which clones the
@@ -179,7 +171,7 @@ two products must be specified in this order.
 
 [Output info:]
 
-All the surface reaction models calculate a global vector of length 2.
+All the surface reaction models calculate a global vector of values.
 The values can be used by the "stats_style"_stats_style.html command
 and by "variables"_variable.html that define formulas.  The latter
 means they can be used by any command that uses a variable as input,
@@ -187,11 +179,19 @@ e.g. "the "fix ave/time"_fix_ave_time.html command.  See "Section
 4.4"_Section_howto.html#howto_4 for an overview of SPARTA output
 options.
 
+The {global} and {prob} styles each compute a vector of length 2 +
+2*nlist.  For the {global} style, nlist = 2, for "delete" and "create"
+reactions.  For the {prob} style, nlist is the number of reactions
+listed in the file is read as input.
+
 The first element of the vector is the count of particles that
 performed surface reactions for surface elements assigned to this
 reaction model during the current timestep.  The second element is the
 cummulative count of particles that have performed reactions since the
-beginning of the current run.
+beginning of the current run.  The next nlist elements are the count
+of each individual reaction that occurred during the current timestep.
+The final nlist elements are the cummulative count of each individual
+reaction since the beginning of the current run.
 
 :line
 

--- a/doc/surf_react.txt
+++ b/doc/surf_react.txt
@@ -63,6 +63,8 @@ Currently this is only the {vanish} collision style.  See the
 The {global} style is a simple model that can be used to test whether
 surface reactions are occurring as expected.  There is no list of
 reactions for different species; all species are treated the same.
+This style thus defines two universal reactions, the first for
+particle deletion, the second for particle creation.
 
 The {global} style takes two parameters, {pdelete} and {pcreate}. The
 first is the probability that a "deletion" reaction takes place when a
@@ -90,7 +92,8 @@ Only reactions for which all the reactants and all the products are
 currently defined as species-IDs will be active for the simulation.
 Thus the file can contain more reactions than are used in a particular
 simulation.  See the "species"_species.html command for how species
-IDs are defined.
+IDs are defined.  This style thus defines N reactions, where
+N is the number of reactions listed in the specified file.
 
 As explained below each reaction has a specified probability between
 0.0 and 1.0.  That probability is used to choose which reaction (if

--- a/examples/ablation/in.ablation.3d.reactions
+++ b/examples/ablation/in.ablation.3d.reactions
@@ -1,0 +1,47 @@
+# 3d flow around porous media
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r r
+
+create_box  	    0 20 0 20 0 20
+create_grid 	    20 20 20 block * * *
+
+balance_grid        rcb cell
+
+global		    nrho 1 fnum 1
+
+species		    air.species O
+mixture		    air O vstream 100.0 0 0 temp 300.0
+
+surf_collide	    1 diffuse 300.0 1.0
+surf_react          2 global 0.5 0.0
+
+compute             10 react/isurf/grid all 2
+#fix                 10 ave/grid all 1 100 100 c_10[*]
+#dump                10 grid all 100 tmp.grid id c_10[1]
+
+global              surfs implicit
+
+fix                 ablate ablate all 1 1.0 c_10[1]
+read_isurf          all 20 20 20 binary.21x21x21 99.5 ablate
+
+surf_modify         all collide 1 react 2
+
+create_particles    air n 0
+fix		    in emit/face air xlo
+
+fix                 check grid/check 1 warn
+
+timestep 	    1e-3
+
+#dump                2 image all 100 binary.*.ppm type type pdiam 0.0000015 particle yes &
+#                    sline no 0.002 surf proc 0.03 size 1024 1024 &
+#                    axes yes 1 0.01 zoom 1.2
+#dump_modify	    2 pad 4 pcolor * blue backcolor white
+
+stats		    10
+stats_style	    step cpu np nscoll nsreact f_ablate
+run 		    200

--- a/examples/ablation/log.ablation.3d.reactions.5Nov19.g++.1
+++ b/examples/ablation/log.ablation.3d.reactions.5Nov19.g++.1
@@ -1,0 +1,158 @@
+SPARTA (15 Oct 2019)
+# 3d flow around porous media
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r r
+
+create_box  	    0 20 0 20 0 20
+Created orthogonal box = (0 0 0) to (20 20 20)
+create_grid 	    20 20 20 block * * *
+Created 8000 child grid cells
+  parent cells = 1
+  CPU time = 0.00738311 secs
+  create/ghost percent = 35.7574 64.2426
+
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00314188 secs
+  reassign/sort/migrate/ghost percent = 29.9135 1.53286 8.40036 60.1533
+
+global		    nrho 1 fnum 1
+
+species		    air.species O
+mixture		    air O vstream 100.0 0 0 temp 300.0
+
+surf_collide	    1 diffuse 300.0 1.0
+surf_react          2 global 0.5 0.0
+
+compute             10 react/isurf/grid all 2
+#fix                 10 ave/grid all 1 100 100 c_10[*]
+#dump                10 grid all 100 tmp.grid id c_10[1]
+
+global              surfs implicit
+
+fix                 ablate ablate all 1 1.0 c_10[1]
+read_isurf          all 20 20 20 binary.21x21x21 99.5 ablate
+  9261 corner points
+  30768 33232 pushed corner pt values
+  0.390196 19.6098 xlo xhi
+  0.390196 19.6098 ylo yhi
+  0.390196 19.6098 zlo zhi
+  0.551821 min triangle edge length
+  0.131855 min triangle area
+  7810 = cells with surfs
+  21340 = total surfs in all grid cells
+  5 = max surfs in one grid cell
+  0.551821 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  7810 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 94 7810 = cells outside/inside/overlapping surfs
+  5511 2026 233 40 = surf cells with 1,2,etc splits
+  2803.1 2803.1 = cell-wise and global flow volume
+  CPU time = 0.16163 secs
+  read/create-surfs percent = 2.29361 97.7064
+
+surf_modify         all collide 1 react 2
+
+create_particles    air n 0
+Created 2803 particles
+  CPU time = 0.00120401 secs
+fix		    in emit/face air xlo
+
+fix                 check grid/check 1 warn
+
+timestep 	    1e-3
+
+#dump                2 image all 100 binary.*.ppm type type pdiam 0.0000015 particle yes #                    sline no 0.002 surf proc 0.03 size 1024 1024 #                    axes yes 1 0.01 zoom 1.2
+#dump_modify	    2 pad 4 pcolor * blue backcolor white
+
+stats		    10
+stats_style	    step cpu np nscoll nsreact f_ablate
+run 		    200
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 3.40267 3.40267 3.40267
+  surf      (ave,min,max) = 2.44217 2.44217 2.44217
+  total     (ave,min,max) = 9.35465 9.35465 9.35465
+Step CPU Np Nscoll Nsreact f_ablate 
+       0            0     2803        0        0      1059270 
+      10    1.0983942      899      204      100      1057536 
+      20     2.028537      501      134       73      1056689 
+      30     2.958051      403      111       57      1056094 
+      40     3.895324      361      103       61      1055539 
+      50    4.8406551      359      120       63      1054997 
+      60    5.7776511      350      103       56      1054437 
+      70     6.839679      342      111       64      1053927 
+      80    7.8585169      359      116       54      1053403 
+      90     8.806329      368      105       62      1052847 
+     100    9.7280321      357      110       49      1052311 
+     110    10.662635      351      107       54      1051760 
+     120    11.593584      352      103       57      1051226 
+     130    12.513986      322       96       44      1050718 
+     140    13.428397      351       82       44      1050226 
+     150    14.354456      378      106       53      1049675 
+     160    15.265891      352      104       53      1049125 
+     170    16.189111      356       97       53      1048634 
+     180    17.119766      384      105       53      1048117 
+     190     18.04113      389      102       51      1047628 
+     200    18.951331      382      102       47      1047104 
+Loop time of 18.9514 on 1 procs for 200 steps with 382 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.024255   | 0.024255   | 0.024255   |   0.0 |  0.13
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.00053954 | 0.00053954 | 0.00053954 |   0.0 |  0.00
+Modify  | 18.923     | 18.923     | 18.923     |   0.0 | 99.85
+Output  | 0.0025771  | 0.0025771  | 0.0025771  |   0.0 |  0.01
+Other   |            | 0.0005744  |            |       |  0.00
+
+Particle moves    = 107408 (0.107M)
+Cells touched     = 172083 (0.172M)
+Particle comms    = 0 (0K)
+Boundary collides = 6545 (6.54K)
+Boundary exits    = 7391 (7.39K)
+SurfColl checks   = 416266 (0.416M)
+SurfColl occurs   = 24370 (24.4K)
+Surf reactions    = 12166 (12.2K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+
+Particle-moves/CPUsec/proc: 5667.54
+Particle-moves/step: 537.04
+Cell-touches/particle/step: 1.60214
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0609359
+Particle fraction exiting boundary: 0.0688124
+Surface-checks/particle/step: 3.87556
+Surface-collisions/particle/step: 0.226892
+Surf-reactions/particle/step: 0.113269
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Surface reaction tallies:
+  id 2 style global #-of-reactions 2
+    reaction all: 12119
+    reaction delete: 12119
+
+Particles: 382 ave 382 max 382 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      12822 ave 12822 max 12822 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    21390 ave 21390 max 21390 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/ablation/log.ablation.3d.reactions.5Nov19.g++.4
+++ b/examples/ablation/log.ablation.3d.reactions.5Nov19.g++.4
@@ -1,0 +1,158 @@
+SPARTA (15 Oct 2019)
+# 3d flow around porous media
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r r
+
+create_box  	    0 20 0 20 0 20
+Created orthogonal box = (0 0 0) to (20 20 20)
+create_grid 	    20 20 20 block * * *
+Created 8000 child grid cells
+  parent cells = 1
+  CPU time = 0.00446701 secs
+  create/ghost percent = 52.0282 47.9718
+
+balance_grid        rcb cell
+Balance grid migrated 4000 cells
+  CPU time = 0.00262904 secs
+  reassign/sort/migrate/ghost percent = 26.5077 0.462501 38.4511 34.5788
+
+global		    nrho 1 fnum 1
+
+species		    air.species O
+mixture		    air O vstream 100.0 0 0 temp 300.0
+
+surf_collide	    1 diffuse 300.0 1.0
+surf_react          2 global 0.5 0.0
+
+compute             10 react/isurf/grid all 2
+#fix                 10 ave/grid all 1 100 100 c_10[*]
+#dump                10 grid all 100 tmp.grid id c_10[1]
+
+global              surfs implicit
+
+fix                 ablate ablate all 1 1.0 c_10[1]
+read_isurf          all 20 20 20 binary.21x21x21 99.5 ablate
+  9261 corner points
+  30768 33232 pushed corner pt values
+  0.390196 19.6098 xlo xhi
+  0.390196 19.6098 ylo yhi
+  0.390196 19.6098 zlo zhi
+  0.551821 min triangle edge length
+  0.131855 min triangle area
+  7810 = cells with surfs
+  21340 = total surfs in all grid cells
+  5 = max surfs in one grid cell
+  0.551821 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  7810 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 94 7810 = cells outside/inside/overlapping surfs
+  5511 2026 233 40 = surf cells with 1,2,etc splits
+  2803.1 2803.1 = cell-wise and global flow volume
+  CPU time = 0.0487201 secs
+  read/create-surfs percent = 6.11264 93.8874
+
+surf_modify         all collide 1 react 2
+
+create_particles    air n 0
+Created 2803 particles
+  CPU time = 0.000626802 secs
+fix		    in emit/face air xlo
+
+fix                 check grid/check 1 warn
+
+timestep 	    1e-3
+
+#dump                2 image all 100 binary.*.ppm type type pdiam 0.0000015 particle yes #                    sline no 0.002 surf proc 0.03 size 1024 1024 #                    axes yes 1 0.01 zoom 1.2
+#dump_modify	    2 pad 4 pcolor * blue backcolor white
+
+stats		    10
+stats_style	    step cpu np nscoll nsreact f_ablate
+run 		    200
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.88888 1.88888 1.88888
+  surf      (ave,min,max) = 0.610542 0.600586 0.62439
+  total     (ave,min,max) = 4.70869 4.69593 4.7381
+Step CPU Np Nscoll Nsreact f_ablate 
+       0            0     2803        0        0      1059270 
+      10   0.34801984      950      232      128      1057550 
+      20   0.66285586      507      141       65      1056681 
+      30   0.91349578      394      115       62      1056069 
+      40    1.1711249      407      115       54      1055546 
+      50    1.4164858      360      108       47      1055017 
+      60    1.6636369      361       98       52      1054477 
+      70    1.9122548      342      100       45      1053956 
+      80    2.1694188      335      107       53      1053418 
+      90    2.4170768      343      106       56      1052926 
+     100     2.662324      345      109       51      1052402 
+     110    2.9155099      348      117       50      1051871 
+     120    3.1688478      350      116       56      1051330 
+     130    3.4158549      364      104       51      1050834 
+     140    3.6604848      363       93       46      1050307 
+     150    3.9111619      340       90       48      1049761 
+     160      4.16256      364       98       54      1049251 
+     170    4.4093709      396      116       63      1048713 
+     180    4.6533868      360       95       54      1048170 
+     190     4.905082      339      106       65      1047635 
+     200    5.1634679      374      111       58      1047139 
+Loop time of 5.16351 on 4 procs for 200 steps with 374 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0015688  | 0.0064928  | 0.012281   |   6.1 |  0.13
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.0016987  | 0.0018123  | 0.0019162  |   0.2 |  0.04
+Modify  | 5.1428     | 5.1449     | 5.1472     |   0.1 | 99.64
+Output  | 0.00065088 | 0.00071132 | 0.00088334 |   0.0 |  0.01
+Other   |            | 0.0096     |            |       |  0.19
+
+Particle moves    = 108328 (0.108M)
+Cells touched     = 173794 (0.174M)
+Particle comms    = 1378 (1.38K)
+Boundary collides = 6789 (6.79K)
+Boundary exits    = 7365 (7.37K)
+SurfColl checks   = 420579 (0.421M)
+SurfColl occurs   = 24292 (24.3K)
+Surf reactions    = 12131 (12.1K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+
+Particle-moves/CPUsec/proc: 5244.88
+Particle-moves/step: 541.64
+Cell-touches/particle/step: 1.60433
+Particle comm iterations/step: 2.095
+Particle fraction communicated: 0.0127206
+Particle fraction colliding with boundary: 0.0626708
+Particle fraction exiting boundary: 0.067988
+Surface-checks/particle/step: 3.88246
+Surface-collisions/particle/step: 0.224245
+Surf-reactions/particle/step: 0.111984
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Surface reaction tallies:
+  id 2 style global #-of-reactions 2
+    reaction all: 12073
+    reaction delete: 12073
+
+Particles: 93.5 ave 202 max 2 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Cells:      3206.25 ave 3338 max 3059 min
+Histogram: 1 0 0 1 0 0 0 1 0 1
+GhostCell: 420 ave 420 max 420 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 420 ave 420 max 420 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    5345.5 ave 5456 max 5250 min
+Histogram: 1 1 0 0 0 0 0 1 0 1
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/src/KOKKOS/compute_boundary_kokkos.h
+++ b/src/KOKKOS/compute_boundary_kokkos.h
@@ -52,7 +52,7 @@ class ComputeBoundaryKokkos : public ComputeBoundary, public KokkosBase {
 ------------------------------------------------------------------------- */
 
 KOKKOS_INLINE_FUNCTION
-void boundary_tally_kk(int iface, int istyle,
+void boundary_tally_kk(int iface, int istyle, int reaction,
                        Particle::OnePart *iorig, 
                        Particle::OnePart *ip, 
                        Particle::OnePart *jp,

--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -43,8 +43,9 @@ ComputeSurfKokkos::ComputeSurfKokkos(SPARTA *sparta) :
 {
   hash = NULL;
   which = NULL;
-  tally2surf = NULL;
   array_surf_tally = NULL;
+  tally2surf = NULL;
+  array_surf = NULL;
   vector_surf = NULL;
   normflux = NULL;
   id = NULL;

--- a/src/KOKKOS/compute_surf_kokkos.h
+++ b/src/KOKKOS/compute_surf_kokkos.h
@@ -48,7 +48,7 @@ enum{NUM,NUMWT,MFLUX,FX,FY,FZ,PRESS,XPRESS,YPRESS,ZPRESS,
 
 /* ----------------------------------------------------------------------
    tally values for a single particle in icell
-     colliding with surface element isurf
+     colliding with surface element isurf, performing reaction (1 to N)
    iorig = particle ip before collision
    ip,jp = particles after collision
    ip = NULL means no particles after collision
@@ -58,7 +58,8 @@ enum{NUM,NUMWT,MFLUX,FX,FY,FZ,PRESS,XPRESS,YPRESS,ZPRESS,
 
 template <int ATOMIC_REDUCTION>
 KOKKOS_INLINE_FUNCTION
-void surf_tally_kk(int isurf, int icell, Particle::OnePart *iorig, 
+void surf_tally_kk(int isurf, int icell, int reaction,
+                   Particle::OnePart *iorig, 
                    Particle::OnePart *ip, Particle::OnePart *jp) const
 {
   // skip if isurf not in surface group

--- a/src/KOKKOS/domain_kokkos.h
+++ b/src/KOKKOS/domain_kokkos.h
@@ -35,13 +35,16 @@ class DomainKokkos : public Domain {
    called by Update::move()
    xnew = final position of particle at end of move
    return boundary type of global boundary
+   return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    if needed, update particle x,v,xnew due to collision
 ------------------------------------------------------------------------- */
 
   KOKKOS_INLINE_FUNCTION
-  int collide_kokkos(Particle::OnePart *&ip, int face, double* lo, double* hi, double *xnew/*,double &dtremain*/) const
+  int collide_kokkos(Particle::OnePart *&ip, int face, double* lo, double* hi, double *xnew,
+                     /*double &dtremain,*/ int &reaction) const
   {
     //jp = NULL;
+    reaction = 0;
   
     switch (bflag[face]) {
   

--- a/src/KOKKOS/react_bird_kokkos.cpp
+++ b/src/KOKKOS/react_bird_kokkos.cpp
@@ -28,6 +28,8 @@
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
+#include "kokkos.h"
+#include "memory_kokkos.h"
 
 using namespace SPARTA_NS;
 using namespace MathConst;
@@ -48,7 +50,11 @@ ReactBirdKokkos::ReactBirdKokkos(SPARTA *sparta, int narg, char **arg) :
 #endif
             )
 {
-
+  delete [] tally_reactions;
+  delete [] tally_reactions_all;
+  memoryKK->create_kokkos(k_tally_reactions,tally_reactions,nlist,"react_bird:tally_reactions");
+  memoryKK->create_kokkos(k_tally_reactions_all,tally_reactions_all,nlist,"react_bird:tally_reactions_all");
+  d_tally_reactions = k_tally_reactions.d_view;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -56,6 +62,9 @@ ReactBirdKokkos::ReactBirdKokkos(SPARTA *sparta, int narg, char **arg) :
 ReactBirdKokkos::~ReactBirdKokkos()
 {
   if (copy) return;
+
+  tally_reactions = NULL;
+  tally_reactions_all = NULL;
 
   // deallocate views of views in serial to prevent race conditions in external tools
 
@@ -138,3 +147,29 @@ void ReactBirdKokkos::init()
   rand_pool.init(random);
 #endif
 }
+
+/* ----------------------------------------------------------------------
+   return tally associated with a reaction
+------------------------------------------------------------------------- */
+
+double ReactBirdKokkos::extract_tally(int m) 
+{
+  if (!tally_flag) {
+    tally_flag = 1;
+
+    if (sparta->kokkos->gpu_direct_flag) {
+      MPI_Allreduce(d_tally_reactions.data(),k_tally_reactions_all.d_view.data(),nlist,
+                    MPI_INT,MPI_SUM,world);
+      k_tally_reactions_all.modify<DeviceType>();
+      k_tally_reactions_all.sync<SPAHostType>();
+    } else {
+      k_tally_reactions.modify<DeviceType>();
+      k_tally_reactions.sync<SPAHostType>();
+      MPI_Allreduce(k_tally_reactions.h_view.data(),k_tally_reactions_all.h_view.data(),nlist,
+                    MPI_INT,MPI_SUM,world);
+    }
+
+  }
+
+  return 1.0*tally_reactions_all[m];
+};

--- a/src/KOKKOS/react_bird_kokkos.h
+++ b/src/KOKKOS/react_bird_kokkos.h
@@ -39,6 +39,13 @@ class ReactBirdKokkos : public ReactBird {
   virtual void init();
   virtual int attempt(Particle::OnePart *, Particle::OnePart *, 
                       double, double, double, double &, int &) = 0;
+  double extract_tally(int);
+
+  // tallies for reactions
+
+  DAT::tdual_int_1d k_tally_reactions;
+  DAT::t_int_1d d_tally_reactions;
+  DAT::tdual_int_1d k_tally_reactions_all;
 
   struct OneReactionKokkos {
     int active;                    // 1 if reaction is active

--- a/src/KOKKOS/react_tce_kokkos.h
+++ b/src/KOKKOS/react_tce_kokkos.h
@@ -135,6 +135,7 @@ int attempt_kk(Particle::OnePart *ip, Particle::OnePart *jp,
     //      nothing that is I-specific or J-specific
 
     if (react_prob > random_prob) {
+      Kokkos::atomic_fetch_add(&d_tally_reactions[d_list[i]],1);
       ip->ispecies = r->d_products[0];
 
       // Previous statment did not destroy the 2nd species (B) if

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -93,6 +93,8 @@ SurfCollideDiffuseKokkos::SurfCollideDiffuseKokkos(SPARTA *sparta) :
 
   if (narg < 4) error->all(FLERR,"Illegal surf_collide diffuse command");
 
+  allowreact = 1;
+
   tstr = NULL;
 
   if (strstr(arg[2],"v_") == arg[2]) {

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -77,20 +77,21 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
      isr = index of reaction model if >= 0, -1 for no chemistry
      ip = set to NULL if destroyed by chemsitry
      return jp = new particle if created by chemistry
+     return reaction = index of reaction (1 to N) that took place, 0 = no reaction
      resets particle(s) to post-collision outward velocity
   ------------------------------------------------------------------------- */
   
   KOKKOS_INLINE_FUNCTION
-  Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &, int) const
+  Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &, int, int &) const
   {
     Kokkos::atomic_fetch_add(&d_nsingle(),1);
   
     // if surface chemistry defined, attempt reaction
-    // reaction = 1 if reaction took place
+    // reaction > 0 if reaction took place
   
     //Particle::OnePart iorig;
     Particle::OnePart *jp = NULL;
-    //int reaction = 0;
+    //reaction = 0;
   
     //if (isr >= 0) {
     //  if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));

--- a/src/KOKKOS/surf_collide_piston_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_piston_kokkos.cpp
@@ -61,6 +61,8 @@ SurfCollidePistonKokkos::SurfCollidePistonKokkos(SPARTA *sparta) :
   copy = 0;
 
   if (narg != 2) error->all(FLERR,"Illegal surf_collide piston command");
+ 
+  allowreact = 1;
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
   d_nsingle = k_nsingle.view<DeviceType>();

--- a/src/KOKKOS/surf_collide_piston_kokkos.h
+++ b/src/KOKKOS/surf_collide_piston_kokkos.h
@@ -45,19 +45,20 @@ class SurfCollidePistonKokkos : public SurfCollidePiston {
      isr = index of reaction model if >= 0, -1 for no chemistry
      ip = set to NULL if destroyed by chemsitry
      return jp = new particle if created by chemistry
+     return reaction = index of reaction (1 to N) that took place, 0 = no reaction
      resets particle(s) to post-collision outward velocity
      ------------------------------------------------------------------------- */
   KOKKOS_INLINE_FUNCTION
-  Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &dtremain, int) const
+  Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &dtremain, int, int &) const
   {
     Kokkos::atomic_fetch_add(&d_nsingle(),1);
 
     // if surface chemistry defined, attempt reaction
-    // reaction = 1 if reaction took place
+    // reaction > 0 if reaction took place
 
     //  Particle::OnePart iorig;
     Particle::OnePart *jp = NULL;
-    //  int reaction = 0;
+    // reaction = 0;
 
     //    if (isr >= 0) {
     //      if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));

--- a/src/KOKKOS/surf_collide_specular_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_specular_kokkos.cpp
@@ -62,6 +62,8 @@ SurfCollideSpecularKokkos::SurfCollideSpecularKokkos(SPARTA *sparta) :
   copy = 0;
 
   if (narg != 2) error->all(FLERR,"Illegal surf_collide specular command");
+ 
+  allowreact = 1;
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
   d_nsingle = k_nsingle.view<DeviceType>();

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -41,22 +41,23 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
      ip = particle with current x = collision pt, current v = incident v
      norm = surface normal unit vector
      isr = index of reaction model if >= 0, -1 for no chemistry
-     ip = set to NULL if destroyed by chemsitry
+     ip = set to NULL if destroyed by chemistry
      return jp = new particle if created by chemistry
+     return reaction = index of reaction (1 to N) that took place, 0 = no reaction
      resets particle(s) to post-collision outward velocity
   ------------------------------------------------------------------------- */
   
   KOKKOS_INLINE_FUNCTION
-  Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &, int) const
+  Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &, int, int &) const
   {
     Kokkos::atomic_fetch_add(&d_nsingle(),1);
   
     // if surface chemistry defined, attempt reaction
-    // reaction = 1 if reaction took place
+    // reaction > 0 if reaction took place
   
     //Particle::OnePart iorig;
     Particle::OnePart *jp = NULL;
-    //int reaction = 0;
+    //reaction = 0;
   
     //if (isr >= 0) {
     //  if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));

--- a/src/KOKKOS/surf_collide_vanish_kokkos.h
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.h
@@ -44,11 +44,12 @@ class SurfCollideVanishKokkos : public SurfCollideVanish {
      ip = particle with current x = collision pt, current v = incident v
      norm = surface normal unit vector
      simply return ip = NULL to delete particle
+     return reaction = 0 = no reaction took place
   ------------------------------------------------------------------------- */
   
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart*
-  collide_kokkos(Particle::OnePart *&ip, const double *, double &, int) const
+  collide_kokkos(Particle::OnePart *&ip, const double *, double &, int, int&) const
   {
     Kokkos::atomic_fetch_add(&d_nsingle(),1);
 

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -616,6 +616,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
   double *x,*v;
   Surf::Tri *tri;
   Surf::Line *line;
+  int reaction; // not yet used
 
   Particle::OnePart &particle_i = d_particles[i];
   pflag = particle_i.flag;
@@ -961,29 +962,29 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
           if (DIM == 3)
             if (sc_type == 0)
               jpart = sc_kk_specular_copy[m].obj.
-                collide_kokkos(ipart,tri->norm,dtremain,tri->isr);/////
+                collide_kokkos(ipart,tri->norm,dtremain,tri->isr,reaction);/////
             else if (sc_type == 1)
               jpart = sc_kk_diffuse_copy[m].obj.
-                collide_kokkos(ipart,tri->norm,dtremain,tri->isr);/////
+                collide_kokkos(ipart,tri->norm,dtremain,tri->isr,reaction);/////
             else if (sc_type == 2)
               jpart = sc_kk_vanish_copy[m].obj.
-                collide_kokkos(ipart,tri->norm,dtremain,tri->isr);/////
+                collide_kokkos(ipart,tri->norm,dtremain,tri->isr,reaction);/////
             else if (sc_type == 3)
               jpart = sc_kk_piston_copy[m].obj.
-                collide_kokkos(ipart,tri->norm,dtremain,tri->isr);/////
+                collide_kokkos(ipart,tri->norm,dtremain,tri->isr,reaction);/////
           if (DIM != 3)
             if (sc_type == 0)
               jpart = sc_kk_specular_copy[m].obj.
-                collide_kokkos(ipart,line->norm,dtremain,line->isr);////
+                collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
             else if (sc_type == 1)
               jpart = sc_kk_diffuse_copy[m].obj.
-                collide_kokkos(ipart,line->norm,dtremain,line->isr);////
+                collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
             else if (sc_type == 2)
               jpart = sc_kk_vanish_copy[m].obj.
-                collide_kokkos(ipart,line->norm,dtremain,line->isr);////
+                collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
             else if (sc_type == 3)
               jpart = sc_kk_piston_copy[m].obj.
-                collide_kokkos(ipart,line->norm,dtremain,line->isr);////
+                collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
 
           ////Need to error out for now if surface reactions create (or destroy?) particles////
           //if (jpart) {
@@ -999,7 +1000,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
           if (nsurf_tally)
             for (m = 0; m < nsurf_tally; m++)
               slist_active_copy[m].obj.
-                    surf_tally_kk<ATOMIC_REDUCTION>(minsurf,icell,&iorig,ipart,jpart);
+                    surf_tally_kk<ATOMIC_REDUCTION>(minsurf,icell,reaction,&iorig,ipart,jpart);
 
           // nstuck = consective iterations particle is immobile
 
@@ -1165,16 +1166,16 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
 
         if (sc_type == 0)
           jpart = sc_kk_specular_copy[m].obj.
-            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface]);/////
+            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
         else if (sc_type == 1)
           jpart = sc_kk_diffuse_copy[m].obj.
-            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface]);/////
+            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
         else if (sc_type == 2)
           jpart = sc_kk_vanish_copy[m].obj.
-            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface]);/////
+            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
         else if (sc_type == 3)
           jpart = sc_kk_piston_copy[m].obj.
-            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface]);/////
+            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
 
         if (ipart) {
           double *x = ipart->x;
@@ -1185,7 +1186,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
         }
         bflag = SURFACE;
       } else {
-        bflag = domain_kk_copy.obj.collide_kokkos(ipart,outface,lo,hi,xnew/*,dtremain*/);
+        bflag = domain_kk_copy.obj.collide_kokkos(ipart,outface,lo,hi,xnew/*,dtremain*/,reaction);
       }
 
       //if (jpart) {
@@ -1197,7 +1198,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
       if (nboundary_tally)
         for (int m = 0; m < nboundary_tally; m++)
           blist_active_copy[m].obj.
-            boundary_tally_kk(outface,bflag,&iorig,ipart,jpart,domain_kk_copy.obj.norm[outface]);
+            boundary_tally_kk(outface,bflag,reaction,&iorig,ipart,jpart,domain_kk_copy.obj.norm[outface]);
 
       if (DIM == 1) {
         xnew[0] = x[0] + dtremain*v[0];

--- a/src/compute.h
+++ b/src/compute.h
@@ -86,9 +86,9 @@ class Compute : protected Pointers {
   virtual void compute_per_grid() {}
   virtual void compute_per_surf() {}
   virtual void clear() {}
-  virtual void surf_tally(int, int, Particle::OnePart *,  
+  virtual void surf_tally(int, int, int, Particle::OnePart *,  
                           Particle::OnePart *, Particle::OnePart *) {}
-  virtual void boundary_tally(int, int, Particle::OnePart *,
+  virtual void boundary_tally(int, int, int, Particle::OnePart *,
                               Particle::OnePart *, Particle::OnePart *) {}
 
   virtual void post_process_grid(int, int, double **, int *, double *, int) {}

--- a/src/compute_boundary.cpp
+++ b/src/compute_boundary.cpp
@@ -153,7 +153,8 @@ void ComputeBoundary::clear()
 }
 
 /* ----------------------------------------------------------------------
-   tally values for a single particle colliding with boundary iface/istyle
+   tally values for a single particle colliding with boundary iface/istyle,
+     performing reaction (1 to N)
    iorig = particle ip before collision
    ip,jp = particles after collision
    ip = NULL means no particles after collision
@@ -161,7 +162,7 @@ void ComputeBoundary::clear()
    jp != NULL means two particles after collision
 ------------------------------------------------------------------------- */
 
-void ComputeBoundary::boundary_tally(int iface, int istyle,
+void ComputeBoundary::boundary_tally(int iface, int istyle, int reaction,
                                      Particle::OnePart *iorig, 
                                      Particle::OnePart *ip, 
                                      Particle::OnePart *jp)

--- a/src/compute_boundary.h
+++ b/src/compute_boundary.h
@@ -34,7 +34,7 @@ class ComputeBoundary : public Compute {
   virtual void init();
   virtual void compute_array();
   virtual void clear();
-  virtual void boundary_tally(int, int, Particle::OnePart *,
+  virtual void boundary_tally(int, int, int, Particle::OnePart *,
                               Particle::OnePart *, Particle::OnePart *);
 
  protected:

--- a/src/compute_isurf_grid.cpp
+++ b/src/compute_isurf_grid.cpp
@@ -205,7 +205,7 @@ void ComputeISurfGrid::clear()
 
 /* ----------------------------------------------------------------------
    tally values for a single particle in icell 
-     colliding with surface element isurf
+     colliding with surface element isurf, performing reaction (1 to N)
    iorig = particle ip before collision
    ip,jp = particles after collision
    ip = NULL means no particles after collision
@@ -215,7 +215,7 @@ void ComputeISurfGrid::clear()
      except sum tally to to per-grid-cell array_grid
 ------------------------------------------------------------------------- */
 
-void ComputeISurfGrid::surf_tally(int isurf, int icell, 
+void ComputeISurfGrid::surf_tally(int isurf, int icell, int reaction, 
                                    Particle::OnePart *iorig, 
                                    Particle::OnePart *ip, Particle::OnePart *jp)
 {

--- a/src/compute_isurf_grid.h
+++ b/src/compute_isurf_grid.h
@@ -35,7 +35,7 @@ class ComputeISurfGrid : public Compute {
   virtual void init();
   void compute_per_grid();
   virtual void clear();
-  virtual void surf_tally(int, int, Particle::OnePart *, 
+  virtual void surf_tally(int, int, int, Particle::OnePart *, 
                           Particle::OnePart *, Particle::OnePart *);
   virtual int tallyinfo(surfint *&);
   void post_process_isurf_grid();

--- a/src/compute_react_boundary.cpp
+++ b/src/compute_react_boundary.cpp
@@ -24,19 +24,65 @@
 
 using namespace SPARTA_NS;
 
+enum{REACTANT,PRODUCT};
+
 /* ---------------------------------------------------------------------- */
 
 ComputeReactBoundary::
 ComputeReactBoundary(SPARTA *sparta, int narg, char **arg) :
   Compute(sparta, narg, arg)
 {
-  if (narg != 3) error->all(FLERR,"Illegal compute react/boundary command");
+  if (narg < 3) error->all(FLERR,"Illegal compute react/boundary command");
 
   isr = surf->find_react(arg[2]);
   if (isr < 0) error->all(FLERR,"Compute react/boundary reaction ID "
                           "does not exist");
 
   ntotal = surf->sr[isr]->nlist;
+
+  rpflag = 0;
+  reaction2col = NULL;
+
+  // parse per-column reactant/product args
+  // reset rpflag = 1 and ntotal = # of args
+
+  if (narg > 3) {
+    rpflag = 1;
+    int ncol = narg - 3;
+    memory->create(reaction2col,ntotal,ncol,"react/surf:reaction2col");
+    for (int i = 0; i < ntotal; i++)
+      for (int j = 0; j < ncol; j++)
+        reaction2col[i][j] = 0;
+    int which;
+    int icol = 0;
+    int iarg = 3;
+    while (iarg < narg) {
+      if (strncmp(arg[iarg],"r:",2) == 0) which = REACTANT;
+      else if (strncmp(arg[iarg],"p:",2) == 0) which = PRODUCT;
+      else error->all(FLERR,"Illegal compute react/surf command");
+      int n = strlen(&arg[iarg][2]) + 1;
+      char *copy = new char[n];
+      strcpy(copy,&arg[iarg][2]);
+      char *ptr = copy;
+      while (ptr = strtok(ptr,"/")) {
+        for (int ireaction = 0; ireaction < ntotal; ireaction++) {
+          reaction2col[ireaction][icol] = 0;
+          if (which == REACTANT) {
+            if (surf->sr[isr]->match_reactant(ptr,ireaction))
+              reaction2col[ireaction][icol] = 1;
+          } else if (which == PRODUCT) {
+            if (surf->sr[isr]->match_product(ptr,ireaction))
+              reaction2col[ireaction][icol] = 1;
+          }
+        }
+        ptr = NULL;
+      }
+      delete [] copy;
+      icol++;
+      iarg++;
+    }
+    ntotal = narg - 3;
+  }
 
   boundary_tally_flag = 1;
   timeflag = 1;
@@ -53,6 +99,7 @@ ComputeReactBoundary(SPARTA *sparta, int narg, char **arg) :
 
 ComputeReactBoundary::~ComputeReactBoundary()
 {
+  memory->destroy(reaction2col);
   memory->destroy(array);
   memory->destroy(myarray);
 }
@@ -114,13 +161,21 @@ void ComputeReactBoundary::boundary_tally(int iface, int istyle, int reaction,
   // skip if no reaction
 
   if (reaction == 0) return;
+  reaction--;
 
   // skip if this face's reaction model is not a match
 
   if (surf_react[iface] != isr) return;
 
   // tally the reaction
+  // for rpflag, tally each column if r2c is 1 for this reaction
+  // for rpflag = 0, tally the reaction directly
 
   double *vec = myarray[iface];
-  vec[reaction-1] += 1.0;
+
+  if (rpflag) {
+    int *r2c = reaction2col[reaction];
+    for (int i = 0; i < ntotal; i++)
+      if (r2c[i]) vec[i] += 1.0;
+  } else vec[reaction] += 1.0;
 }

--- a/src/compute_react_boundary.cpp
+++ b/src/compute_react_boundary.cpp
@@ -1,0 +1,126 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "string.h"
+#include "compute_react_boundary.h"
+#include "update.h"
+#include "domain.h"
+#include "comm.h"
+#include "surf.h"
+#include "surf_react.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+ComputeReactBoundary::
+ComputeReactBoundary(SPARTA *sparta, int narg, char **arg) :
+  Compute(sparta, narg, arg)
+{
+  if (narg != 3) error->all(FLERR,"Illegal compute react/boundary command");
+
+  isr = surf->find_react(arg[2]);
+  if (isr < 0) error->all(FLERR,"Compute react/boundary reaction ID "
+                          "does not exist");
+
+  ntotal = surf->sr[isr]->nlist;
+
+  boundary_tally_flag = 1;
+  timeflag = 1;
+  array_flag = 1;
+  nrow = 2 * domain->dimension;
+  size_array_rows = nrow;
+  size_array_cols = ntotal;
+
+  memory->create(array,size_array_rows,size_array_cols,"react/boundary:array");
+  memory->create(myarray,size_array_rows,size_array_cols,"react/boundary:array");
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeReactBoundary::~ComputeReactBoundary()
+{
+  memory->destroy(array);
+  memory->destroy(myarray);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactBoundary::init()
+{
+  if (!domain->surfreactany && comm->me == 0)
+    error->warning(FLERR,"Using compute react/boundary "
+                   "when no box faces are assigned a reaction model");
+
+  // initialize tally array in case accessed before a tally timestep
+
+  clear();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactBoundary::compute_array()
+{
+  invoked_array = update->ntimestep;
+
+  // sum tallies across processors
+
+  MPI_Allreduce(&myarray[0][0],&array[0][0],nrow*ntotal,
+                MPI_DOUBLE,MPI_SUM,world);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactBoundary::clear()
+{
+  surf_react = domain->surf_react;
+
+  // reset tally values to zero
+  // called by Update at beginning of timesteps boundary tallying is done
+
+  for (int i = 0; i < size_array_rows; i++)
+    for (int j = 0; j < ntotal; j++)
+      myarray[i][j] = 0.0;
+}
+
+/* ----------------------------------------------------------------------
+   tally values for a single particle colliding with boundary iface/istyle,
+     performing reaction (1 to N)
+   iorig = particle ip before collision
+   ip,jp = particles after collision
+   ip = NULL means no particles after collision
+   jp = NULL means one particle after collision
+   jp != NULL means two particles after collision
+------------------------------------------------------------------------- */
+
+void ComputeReactBoundary::boundary_tally(int iface, int istyle, int reaction,
+                                     Particle::OnePart *iorig, 
+                                     Particle::OnePart *ip, 
+                                     Particle::OnePart *jp)
+{
+  // skip if no reaction
+
+  if (reaction == 0) return;
+
+  // skip if this face's reaction model is not a match
+
+  if (surf_react[iface] != isr) return;
+
+  // tally the reaction
+
+  double *vec = myarray[iface];
+  vec[reaction-1] += 1.0;
+}

--- a/src/compute_react_boundary.h
+++ b/src/compute_react_boundary.h
@@ -12,27 +12,36 @@
    See the README file in the top-level SPARTA directory.
 ------------------------------------------------------------------------- */
 
-#ifdef SURF_COLLIDE_CLASS
+#ifdef COMPUTE_CLASS
 
-SurfCollideStyle(vanish,SurfCollideVanish)
+ComputeStyle(react/boundary,ComputeReactBoundary)
 
 #else
 
-#ifndef SPARTA_SURF_COLLIDE_VANISH_H
-#define SPARTA_SURF_COLLIDE_VANISH_H
+#ifndef SPARTA_REACT_BOUNDARY_SURF_H
+#define SPARTA_REACT_BOUNDARY_SURF_H
 
-#include "surf_collide.h"
+#include "compute.h"
 #include "particle.h"
 
 namespace SPARTA_NS {
 
-class SurfCollideVanish : public SurfCollide {
+class ComputeReactBoundary : public Compute {
  public:
-  SurfCollideVanish(class SPARTA *, int, char **);
-  SurfCollideVanish(class SPARTA *sparta) : SurfCollide(sparta) {}
-  virtual ~SurfCollideVanish() {}
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, 
-                             int, int &);
+  ComputeReactBoundary(class SPARTA *, int, char **);
+  ~ComputeReactBoundary();
+  virtual void init();
+  virtual void compute_array();
+  virtual void clear();
+  virtual void boundary_tally(int, int, int, Particle::OnePart *,
+                              Particle::OnePart *, Particle::OnePart *);
+
+ protected:
+  int isr,ntotal,nrow;
+
+  int *surf_react;
+
+  double **myarray;              // local accumulator array
 };
 
 }

--- a/src/compute_react_boundary.h
+++ b/src/compute_react_boundary.h
@@ -37,11 +37,12 @@ class ComputeReactBoundary : public Compute {
                               Particle::OnePart *, Particle::OnePart *);
 
  protected:
-  int isr,ntotal,nrow;
-
+  int isr,ntotal,nrow,rpflag;
   int *surf_react;
 
-  double **myarray;              // local accumulator array
+  int **reaction2col;      // 1 if ireaction triggers tally for icol
+
+  double **myarray;        // local accumulator array
 };
 
 }

--- a/src/compute_react_isurf_grid.cpp
+++ b/src/compute_react_isurf_grid.cpp
@@ -1,0 +1,285 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "string.h"
+#include "compute_react_isurf_grid.h"
+#include "particle.h"
+#include "mixture.h"
+#include "surf.h"
+#include "surf_react.h"
+#include "grid.h"
+#include "update.h"
+#include "domain.h"
+#include "comm.h"
+#include "math_extra.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+#define DELTA 4096
+
+/* ---------------------------------------------------------------------- */
+
+ComputeReactISurfGrid::
+ComputeReactISurfGrid(SPARTA *sparta, int narg, char **arg) :
+  Compute(sparta, narg, arg)
+{
+  if (narg != 4) error->all(FLERR,"Illegal compute react/isurf/grid command");
+
+  int igroup = grid->find_group(arg[2]);
+  if (igroup < 0) 
+    error->all(FLERR,"Compute react/isurf/grid group ID does not exist");
+  groupbit = grid->bitmask[igroup];
+
+  isr = surf->find_react(arg[3]);
+  if (isr < 0) 
+    error->all(FLERR,"Compute react/isurf/grid reaction ID does not exist");
+
+  ntotal = surf->sr[isr]->nlist;
+
+  per_grid_flag = 1;
+  size_per_grid_cols = ntotal;
+  post_process_isurf_grid_flag = 1;
+
+  surf_tally_flag = 1;
+  timeflag = 1;
+
+  ntally = maxtally = 0;
+  array_surf_tally = NULL;
+  tally2surf = NULL;
+
+  maxgrid = 0;
+  array_grid = NULL;
+  combined = 0;
+
+  hash = new MyHash;
+
+  dim = domain->dimension;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeReactISurfGrid::~ComputeReactISurfGrid()
+{
+  memory->destroy(array_surf_tally);
+  memory->destroy(tally2surf);
+  memory->destroy(array_grid);
+  delete hash;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactISurfGrid::init()
+{
+  if (!surf->exist)
+    error->all(FLERR,"Cannot use compute react/isurf/grid when surfs do not exist");
+  if (!surf->implicit) 
+    error->all(FLERR,"Cannot use compute react/isurf/grid with explicit surfs");
+
+  // NOTE: warn if some surfs are assigned to different surf react model
+
+
+
+
+  // initialize tally array in case accessed before a tally timestep
+
+  clear();
+
+  combined = 0;
+}
+
+/* ----------------------------------------------------------------------
+   no operations here, since compute results are stored in array_grid
+   just used by callers to indicate compute was used
+   enables prediction of next step when update needs to tally
+   NOTE: also need to mark invoked_per_surf?
+------------------------------------------------------------------------- */
+
+void ComputeReactISurfGrid::compute_per_grid()
+{
+  invoked_per_grid = update->ntimestep;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactISurfGrid::clear()
+{
+  lines = surf->lines;
+  tris = surf->tris;
+
+  // clear hash of tallied surf IDs
+  // called by Update at beginning of timesteps surf tallying is done
+
+  hash->clear();
+  ntally = 0;
+  combined = 0;
+}
+
+/* ----------------------------------------------------------------------
+   tally values for a single particle in icell 
+     colliding with surface element isurf, performing reaction (1 to N)
+   iorig = particle ip before collision
+   ip,jp = particles after collision
+   ip = NULL means no particles after collision
+   jp = NULL means one particle after collision
+   jp != NULL means two particles after collision
+   this method is exactly like ComputeSurf::surf_tally()
+     except sum tally to to per-grid-cell array_grid
+------------------------------------------------------------------------- */
+
+void ComputeReactISurfGrid::surf_tally(int isurf, int icell, int reaction, 
+                                   Particle::OnePart *iorig, 
+                                   Particle::OnePart *ip, Particle::OnePart *jp)
+{
+  // skip if no reaction
+
+  if (reaction == 0) return;
+
+  // skip if isurf not in surface group
+  // or if this surf's reaction model is not a match
+
+  if (dim == 2) {
+    if (!(lines[isurf].mask & groupbit)) return;
+    if (lines[isurf].isr != isr) return;
+  } else {
+    if (!(tris[isurf].mask & groupbit)) return;
+    if (tris[isurf].isr != isr) return;
+  }
+
+  // itally = tally index of isurf
+  // if 1st particle hitting isurf, add surf ID to hash
+  // grow tally list if needed
+  // for implicit surfs, surfID is really a cellID
+
+  int itally;
+  double *vec;
+
+  surfint surfID;
+  if (dim == 2) surfID = lines[isurf].id;
+  else surfID = tris[isurf].id;
+
+  if (hash->find(surfID) != hash->end()) itally = (*hash)[surfID];
+  else {
+    if (ntally == maxtally) grow_tally();
+    itally = ntally;
+    (*hash)[surfID] = itally;
+    tally2surf[itally] = surfID;
+    vec = array_surf_tally[itally];
+    for (int i = 0; i < ntotal; i++) vec[i] = 0.0;
+    ntally++;
+  }
+
+  // tally the reaction
+
+  vec = array_surf_tally[itally];
+  vec[reaction-1] += 1.0;
+}
+
+/* ----------------------------------------------------------------------
+   return # of tallies and their indices into my local surf list
+------------------------------------------------------------------------- */
+
+int ComputeReactISurfGrid::tallyinfo(surfint *&ptr)
+{
+  ptr = tally2surf;
+  return ntally;
+}
+
+/* ----------------------------------------------------------------------
+   sum surf tallies to owning cells via surf->collate()
+   also copy split cell values to sub-cells for use by dump grid
+------------------------------------------------------------------------- */
+
+void ComputeReactISurfGrid::post_process_isurf_grid()
+{
+  if (combined) return;
+  combined = 1;
+
+  // reallocate array_grid if necessary
+
+  int nglocal = grid->nlocal;
+
+  if (nglocal > maxgrid) {
+    memory->destroy(array_grid);
+    maxgrid = nglocal;
+    memory->create(array_grid,maxgrid,ntotal,"isurf/grid:array_grid");
+  }
+
+  // zero array_grid
+
+  int i,j;
+  for (i = 0; i < nglocal; i++)
+    for (j = 0; j < ntotal; j++)
+      array_grid[i][j] = 0.0;
+
+  // perform rendezvous comm on tallies to sum them to my grid cells
+  // array_surf_tally can be NULL if this proc has performed no tallies
+
+  surf->collate_array_implicit(ntally,ntotal,tally2surf,
+                               array_surf_tally,array_grid);
+  
+  // zero out result if icell not in grid group
+  // can't apply until now, b/c tally included surfs in ghost cells and
+  // cinfo does not have mask values for ghost cells
+
+  Grid::ChildInfo *cinfo = grid->cinfo;
+
+  for (int icell = 0; icell < nglocal; icell++) {
+    if (!(cinfo[icell].mask & groupbit)) {
+      for (j = 0; j < ntotal; j++)
+        array_grid[icell][j] = 0.0;
+    }
+  }
+
+  // copy split cell values to their sub cells, used by dump grid
+
+  Grid::ChildCell *cells = grid->cells;
+  Grid::SplitInfo *sinfo = grid->sinfo;
+
+  int jcell,nsplit;
+  int *csubs;
+
+  for (int icell = 0; icell < nglocal; icell++) {
+    if (cells[icell].nsplit <= 1) continue;
+    nsplit = cells[icell].nsplit;
+    csubs = sinfo[cells[icell].isplit].csubs;
+    for (int j = 0; j < nsplit; j++) {
+      jcell = csubs[j];
+      memcpy(array_grid[jcell],array_grid[icell],ntotal*sizeof(double));
+    }
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactISurfGrid::grow_tally()
+{
+  maxtally += DELTA;
+  memory->grow(tally2surf,maxtally,"isurf/grid:tally2surf");
+  memory->grow(array_surf_tally,maxtally,ntotal,"isurf/grid:array_surf_tally");
+}
+
+/* ----------------------------------------------------------------------
+   memory usage
+------------------------------------------------------------------------- */
+
+bigint ComputeReactISurfGrid::memory_usage()
+{
+  bigint bytes = 0;
+  bytes += ntotal*maxgrid * sizeof(double);     // array_grid
+  bytes += ntotal*maxtally * sizeof(double);    // array_surf_tally
+  bytes += maxtally * sizeof(surfint);          // tally2surf
+  return bytes;
+}

--- a/src/compute_react_isurf_grid.h
+++ b/src/compute_react_isurf_grid.h
@@ -42,8 +42,12 @@ class ComputeReactISurfGrid : public Compute {
   bigint memory_usage();
 
  protected:
-  int isr,groupbit,ntotal;
+  int groupbit;
+  int isr;                 // index of surface reaction model
+  int ntotal,rpflag;
   int maxgrid,combined;
+
+  int **reaction2col;      // 1 if ireaction triggers tally for icol
 
   int ntally;              // # of surfs I have tallied for
   int maxtally;            // # of tallies currently allocated
@@ -62,7 +66,6 @@ class ComputeReactISurfGrid : public Compute {
   MyHash *hash;
 
   int dim;                 // local copies
-  Grid::ChildInfo *cinfo;
   Surf::Line *lines;
   Surf::Tri *tris;
 

--- a/src/compute_react_isurf_grid.h
+++ b/src/compute_react_isurf_grid.h
@@ -14,39 +14,36 @@
 
 #ifdef COMPUTE_CLASS
 
-ComputeStyle(surf,ComputeSurf)
+ComputeStyle(react/isurf/grid,ComputeReactISurfGrid)
 
 #else
 
-#ifndef SPARTA_COMPUTE_SURF_H
-#define SPARTA_COMPUTE_SURF_H
+#ifndef SPARTA_COMPUTE_REACT_ISURF_GRID_H
+#define SPARTA_COMPUTE_REACT_ISURF_GRID_H
 
 #include "compute.h"
+#include "grid.h"
 #include "surf.h"
 #include "hash3.h"
 
 namespace SPARTA_NS {
 
-class ComputeSurf : public Compute {
+class ComputeReactISurfGrid : public Compute {
  public:
-  ComputeSurf(class SPARTA *, int, char **);
-  ComputeSurf(class SPARTA* sparta) : Compute(sparta) {} // needed for Kokkos
-  ~ComputeSurf();
+  ComputeReactISurfGrid(class SPARTA *, int, char **);
+  ~ComputeReactISurfGrid();
   virtual void init();
-  void compute_per_surf();
+  void compute_per_grid();
   virtual void clear();
   virtual void surf_tally(int, int, int, Particle::OnePart *, 
                           Particle::OnePart *, Particle::OnePart *);
   virtual int tallyinfo(surfint *&);
-  virtual void post_process_surf();
-  void reallocate();
+  void post_process_isurf_grid();
   bigint memory_usage();
 
  protected:
-  int groupbit,imix,nvalue,ngroup,ntotal;
-  int maxsurf,combined;
-  double nfactor_inverse;
-  int *which;
+  int isr,groupbit,ntotal;
+  int maxgrid,combined;
 
   int ntally;              // # of surfs I have tallied for
   int maxtally;            // # of tallies currently allocated
@@ -65,14 +62,10 @@ class ComputeSurf : public Compute {
   MyHash *hash;
 
   int dim;                 // local copies
+  Grid::ChildInfo *cinfo;
   Surf::Line *lines;
   Surf::Tri *tris;
 
-  int weightflag;          // 1 if cell weighting is enabled
-  double weight;           // particle weight, based on initial cell
-  double *normflux;        // normalization factor for each surf element
-
-  virtual void init_normflux();
   void grow_tally();
 };
 

--- a/src/compute_react_surf.cpp
+++ b/src/compute_react_surf.cpp
@@ -1,0 +1,237 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "string.h"
+#include "compute_react_surf.h"
+#include "update.h"
+#include "domain.h"
+#include "surf_react.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+#define DELTA 4096
+
+/* ---------------------------------------------------------------------- */
+
+ComputeReactSurf::ComputeReactSurf(SPARTA *sparta, int narg, char **arg) :
+  Compute(sparta, narg, arg)
+{
+  if (narg != 4) error->all(FLERR,"Illegal compute react/surf command");
+
+  int igroup = surf->find_group(arg[2]);
+  if (igroup < 0) error->all(FLERR,"Compute react/surf group ID does not exist");
+  groupbit = surf->bitmask[igroup];
+
+  isr = surf->find_react(arg[3]);
+  if (isr < 0) error->all(FLERR,"Compute react/surf reaction ID does not exist");
+
+  ntotal = surf->sr[isr]->nlist;
+
+  per_surf_flag = 1;
+  size_per_surf_cols = ntotal;
+
+  surf_tally_flag = 1;
+  timeflag = 1;
+
+  ntally = maxtally = 0;
+  array_surf_tally = NULL;
+  tally2surf = NULL;
+
+  maxsurf = 0;
+  array_surf = NULL;
+  combined = 0;
+
+  hash = new MyHash;
+
+  dim = domain->dimension;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeReactSurf::~ComputeReactSurf()
+{
+  memory->destroy(array_surf_tally);
+  memory->destroy(tally2surf);
+  delete hash;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactSurf::init()
+{
+  if (!surf->exist)
+    error->all(FLERR,"Cannot use compute react/surf when surfs do not exist");
+  if (surf->implicit) 
+    error->all(FLERR,"Cannot use compute react/surf with implicit surfs");
+
+  // NOTE: warn if some surfs are assigned to different surf react model
+
+
+
+
+
+  // initialize tally array in case accessed before a tally timestep
+
+  clear();
+
+  combined = 0;
+}
+
+/* ----------------------------------------------------------------------
+   no operations here, since compute results are stored in tally array
+   just used by callers to indicate compute was used
+   enables prediction of next step when update needs to tally
+------------------------------------------------------------------------- */
+
+void ComputeReactSurf::compute_per_surf()
+{
+  invoked_per_surf = update->ntimestep;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactSurf::clear()
+{
+  lines = surf->lines;
+  tris = surf->tris;
+
+  // clear hash of tallied surf IDs
+  // called by Update at beginning of timesteps surf tallying is done
+
+  hash->clear();
+  ntally = 0;
+  combined = 0;
+}
+
+/* ----------------------------------------------------------------------
+   tally values for a single particle in icell
+     colliding with surface element isurf, performing reaction (1 to N)
+   iorig = particle ip before collision
+   ip,jp = particles after collision
+   ip = NULL means no particles after collision
+   jp = NULL means one particle after collision
+   jp != NULL means two particles after collision
+------------------------------------------------------------------------- */
+
+void ComputeReactSurf::surf_tally(int isurf, int icell, int reaction,
+                                  Particle::OnePart *iorig, 
+                                  Particle::OnePart *ip, Particle::OnePart *jp)
+{
+  // skip if no reaction
+
+  if (reaction == 0) return;
+
+  // skip if isurf not in surface group
+  // or if this surf's reaction model is not a match
+
+  if (dim == 2) {
+    if (!(lines[isurf].mask & groupbit)) return;
+    if (lines[isurf].isr != isr) return;
+  } else {
+    if (!(tris[isurf].mask & groupbit)) return;
+    if (tris[isurf].isr != isr) return;
+  }
+
+  // itally = tally index of isurf
+  // if 1st reaction on this isurf, add surf ID to hash
+  // grow tally list if needed
+
+  int itally;
+  double *vec;
+
+  surfint surfID;
+  if (dim == 2) surfID = lines[isurf].id;
+  else surfID = tris[isurf].id;
+
+  if (hash->find(surfID) != hash->end()) itally = (*hash)[surfID];
+  else {
+    if (ntally == maxtally) grow_tally();
+    itally = ntally;
+    (*hash)[surfID] = itally;
+    tally2surf[itally] = surfID;
+    vec = array_surf_tally[itally];
+    for (int i = 0; i < ntotal; i++) vec[i] = 0.0;
+    ntally++;
+  }
+
+  // tally the reaction
+
+  vec = array_surf_tally[itally];
+  vec[reaction-1] += 1.0;
+}
+
+/* ----------------------------------------------------------------------
+   return # of tallies and their indices into my local surf list
+------------------------------------------------------------------------- */
+
+int ComputeReactSurf::tallyinfo(surfint *&ptr)
+{
+  ptr = tally2surf;
+  return ntally;
+}
+
+/* ----------------------------------------------------------------------
+   sum tally values to owning surfs via surf->collate()
+------------------------------------------------------------------------- */
+
+void ComputeReactSurf::post_process_surf()
+{
+  if (combined) return;
+  combined = 1;
+
+  // reallocate array_surf if necessary
+
+  int nown = surf->nown;
+
+  if (nown > maxsurf) {
+    memory->destroy(array_surf);
+    maxsurf = nown;
+    memory->create(array_surf,maxsurf,ntotal,"surf:array_surf");
+  }
+
+  // zero array_surf
+
+  int i,j;
+  for (i = 0; i < nown; i++)
+    for (j = 0; j < ntotal; j++)
+      array_surf[i][j] = 0.0;
+
+  // collate entire array of results
+
+  surf->collate_array(ntally,ntotal,tally2surf,array_surf_tally,array_surf);
+}
+
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeReactSurf::grow_tally()
+{
+  maxtally += DELTA;
+  memory->grow(tally2surf,maxtally,"surf:tally2surf");
+  memory->grow(array_surf_tally,maxtally,ntotal,"surf:array_surf_tally");
+}
+
+/* ----------------------------------------------------------------------
+   memory usage
+------------------------------------------------------------------------- */
+
+bigint ComputeReactSurf::memory_usage()
+{
+  bigint bytes = 0;
+  bytes += ntotal*maxtally * sizeof(double);    // array_surf_tally
+  bytes += maxtally * sizeof(surfint);          // tally2surf
+  return bytes;
+}

--- a/src/compute_react_surf.h
+++ b/src/compute_react_surf.h
@@ -43,8 +43,10 @@ class ComputeReactSurf : public Compute {
  protected:
   int groupbit;
   int isr;                 // index of surface reaction model
-  int ntotal;
+  int ntotal,rpflag;
   int maxsurf,combined;
+
+  int **reaction2col;      // 1 if ireaction triggers tally for icol
 
   int ntally;              // # of surfs I have tallied for
   int maxtally;            // # of tallies currently allocated

--- a/src/compute_react_surf.h
+++ b/src/compute_react_surf.h
@@ -14,12 +14,12 @@
 
 #ifdef COMPUTE_CLASS
 
-ComputeStyle(surf,ComputeSurf)
+ComputeStyle(react/surf,ComputeReactSurf)
 
 #else
 
-#ifndef SPARTA_COMPUTE_SURF_H
-#define SPARTA_COMPUTE_SURF_H
+#ifndef SPARTA_COMPUTE_REACT_SURF_H
+#define SPARTA_COMPUTE_REACT_SURF_H
 
 #include "compute.h"
 #include "surf.h"
@@ -27,11 +27,10 @@ ComputeStyle(surf,ComputeSurf)
 
 namespace SPARTA_NS {
 
-class ComputeSurf : public Compute {
+class ComputeReactSurf : public Compute {
  public:
-  ComputeSurf(class SPARTA *, int, char **);
-  ComputeSurf(class SPARTA* sparta) : Compute(sparta) {} // needed for Kokkos
-  ~ComputeSurf();
+  ComputeReactSurf(class SPARTA *, int, char **);
+  ~ComputeReactSurf();
   virtual void init();
   void compute_per_surf();
   virtual void clear();
@@ -39,14 +38,13 @@ class ComputeSurf : public Compute {
                           Particle::OnePart *, Particle::OnePart *);
   virtual int tallyinfo(surfint *&);
   virtual void post_process_surf();
-  void reallocate();
   bigint memory_usage();
 
  protected:
-  int groupbit,imix,nvalue,ngroup,ntotal;
+  int groupbit;
+  int isr;                 // index of surface reaction model
+  int ntotal;
   int maxsurf,combined;
-  double nfactor_inverse;
-  int *which;
 
   int ntally;              // # of surfs I have tallied for
   int maxtally;            // # of tallies currently allocated
@@ -68,11 +66,6 @@ class ComputeSurf : public Compute {
   Surf::Line *lines;
   Surf::Tri *tris;
 
-  int weightflag;          // 1 if cell weighting is enabled
-  double weight;           // particle weight, based on initial cell
-  double *normflux;        // normalization factor for each surf element
-
-  virtual void init_normflux();
   void grow_tally();
 };
 
@@ -88,14 +81,5 @@ E: Illegal ... command
 Self-explanatory.  Check the input script syntax and compare to the
 documentation for the command.  You can use -echo screen as a
 command-line option when running SPARTA to see the offending line.
-
-E: Compute surf mixture ID does not exist
-
-Self-explanatory.
-
-E: Number of groups in compute surf mixture has changed
-
-This mixture property cannot be changed after this compute command is
-issued.
 
 */

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -92,6 +92,8 @@ ComputeSurf::ComputeSurf(SPARTA *sparta, int narg, char **arg) :
   combined = 0;
 
   hash = new MyHash;
+
+  dim = domain->dimension;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -118,10 +120,6 @@ void ComputeSurf::init()
 
   if (ngroup != particle->mixture[imix]->ngroup)
     error->all(FLERR,"Number of groups in compute surf mixture has changed");
-
-  // local copies
-
-  dim = domain->dimension;
 
   // set normflux for all owned + ghost surfs
 
@@ -205,7 +203,7 @@ void ComputeSurf::clear()
 
 /* ----------------------------------------------------------------------
    tally values for a single particle in icell
-     colliding with surface element isurf
+     colliding with surface element isurf, performing reaction (1 to N)
    iorig = particle ip before collision
    ip,jp = particles after collision
    ip = NULL means no particles after collision
@@ -213,7 +211,8 @@ void ComputeSurf::clear()
    jp != NULL means two particles after collision
 ------------------------------------------------------------------------- */
 
-void ComputeSurf::surf_tally(int isurf, int icell, Particle::OnePart *iorig, 
+void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
+                             Particle::OnePart *iorig, 
                              Particle::OnePart *ip, Particle::OnePart *jp)
 {
   // skip if isurf not in surface group

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -105,6 +105,7 @@ ComputeSurf::~ComputeSurf()
   delete [] which;
   memory->destroy(array_surf_tally);
   memory->destroy(tally2surf);
+  memory->destroy(array_surf);
   memory->destroy(normflux);
   delete hash;
 }

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -267,13 +267,15 @@ void Domain::boundary_modify(int narg, char **arg)
    called by Update::move()
    xnew = final position of particle at end of move
    return boundary type of global boundary
+   return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    if needed, update particle x,v,xnew due to collision
 ------------------------------------------------------------------------- */
 
 int Domain::collide(Particle::OnePart *&ip, int face, int icell, double *xnew, 
-                    double &dtremain, Particle::OnePart *&jp)
+                    double &dtremain, Particle::OnePart *&jp, int &reaction)
 {
   jp = NULL;
+  reaction = 0;
 
   switch (bflag[face]) {
 
@@ -350,7 +352,7 @@ int Domain::collide(Particle::OnePart *&ip, int face, int icell, double *xnew,
   case SURFACE: 
     {
       jp = surf->sc[surf_collide[face]]->
-        collide(ip,norm[face],dtremain,surf_react[face]);
+        collide(ip,norm[face],dtremain,surf_react[face],reaction);
       
       if (ip) {
         double *x = ip->x;

--- a/src/domain.h
+++ b/src/domain.h
@@ -53,7 +53,7 @@ class Domain : protected Pointers {
   int periodic(int *);
   void boundary_modify(int, char **);
   virtual int collide(Particle::OnePart *&, int, int, double *, double &, 
-              Particle::OnePart *&);
+                      Particle::OnePart *&, int &);
   virtual void uncollide(int, double *);
   void add_region(int, char **);
   void delete_region(int, char **);

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -467,11 +467,12 @@ void FixAblate::create_surfs(int outflag)
     }
   }
 
-  // assign surf collision model, surf reaction model to new surfs
-  // NOTE: have to do this in a better way - but how
-  // NOTE: what if user assigns surfs to groups after they are created
-  //       how can those persist?
-  //       maybe should use grid cell groups for implicit surfs
+  // assign surf collision/reaction models to newly created surfs
+  // this assignment can be made in input script via surf_modify 
+  //   after implicit surfs are created
+  // for active ablation, must be re-assigned at every ablation atep
+  // for now just assume all surfs are assigned to first collide/react model
+  // NOTE: need a more flexible way to do this
 
   int nslocal = surf->nlocal;
 
@@ -479,10 +480,16 @@ void FixAblate::create_surfs(int outflag)
     Surf::Line *lines = surf->lines;
     for (int i = 0; i < nslocal; i++)
       lines[i].isc = 0;
+    if (surf->nsr)
+      for (int i = 0; i < nslocal; i++)
+        lines[i].isr = 0;
   } else {
     Surf::Tri *tris = surf->tris;
     for (int i = 0; i < nslocal; i++)
       tris[i].isc = 0;
+    if (surf->nsr)
+      for (int i = 0; i < nslocal; i++)
+        tris[i].isr = 0;
   }
 
   // watertight check can be done before surfs are mapped to grid cells

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -478,15 +478,17 @@ void FixAblate::create_surfs(int outflag)
 
   if (dim == 2) {
     Surf::Line *lines = surf->lines;
-    for (int i = 0; i < nslocal; i++)
-      lines[i].isc = 0;
+    if (surf->nsc)
+      for (int i = 0; i < nslocal; i++)
+        lines[i].isc = 0;
     if (surf->nsr)
       for (int i = 0; i < nslocal; i++)
         lines[i].isr = 0;
   } else {
     Surf::Tri *tris = surf->tris;
-    for (int i = 0; i < nslocal; i++)
-      tris[i].isc = 0;
+    if (surf->nsc)
+      for (int i = 0; i < nslocal; i++)
+        tris[i].isc = 0;
     if (surf->nsr)
       for (int i = 0; i < nslocal; i++)
         tris[i].isr = 0;

--- a/src/react.h
+++ b/src/react.h
@@ -23,6 +23,7 @@ namespace SPARTA_NS {
 class React : protected Pointers {
  public:
   char *style;
+  int nlist;                 // # of reactions read from file
 
   int recombflag;            // 1 if any recombination reactions defined
   int recombflag_user;       // 0 if user has turned off recomb reactions
@@ -42,6 +43,8 @@ class React : protected Pointers {
   virtual void ambi_check() = 0;
   virtual int attempt(Particle::OnePart *, Particle::OnePart *, 
                       double, double, double, double &, int &) = 0;
+  virtual char *reactionID(int) = 0;
+  virtual double extract_tally(int) = 0;
 
   void modify_params(int, char **);
   RanPark* get_random() { return random; }

--- a/src/react_bird.cpp
+++ b/src/react_bird.cpp
@@ -65,8 +65,7 @@ ReactBird::ReactBird(SPARTA *sparta, int narg, char **arg) :
 
 /* ---------------------------------------------------------------------- */
 
-ReactBird::ReactBird(SPARTA *sparta) :
-  React(sparta)
+ReactBird::ReactBird(SPARTA *sparta) : React(sparta)
 {
   rlist = NULL;
   reactions = NULL;
@@ -79,6 +78,9 @@ ReactBird::ReactBird(SPARTA *sparta) :
 ReactBird::~ReactBird()
 {
   if (copy) return;
+
+  delete [] tally_reactions;
+  delete [] tally_reactions_all;
 
   if (rlist) {
     for (int i = 0; i < maxlist; i++) {

--- a/src/react_bird.h
+++ b/src/react_bird.h
@@ -31,9 +31,16 @@ class ReactBird : public React {
   void ambi_check();
   virtual int attempt(Particle::OnePart *, Particle::OnePart *, 
                       double, double, double, double &, int &) = 0;
+  char *reactionID(int);
+  double extract_tally(int);
 
  protected:
   FILE *fp;
+
+  // tallies for reactions
+
+  int *tally_reactions,*tally_reactions_all;
+  int tally_flag;
 
   struct OneReaction {
     int active;                    // 1 if reaction is active
@@ -45,10 +52,10 @@ class ReactBird : public React {
     char **id_reactants,**id_products;  // species IDs of reactants/products
     int *reactants,*products;      // species indices of reactants/products
     double *coeff;                 // numerical coeffs for reaction
+    char *id;                      // reaction ID (formula)
   };
 
   OneReaction *rlist;              // list of all reactions read from file
-  int nlist;                       // # of reactions read from file
   int maxlist;                     // max # of reactions in rlist
 
   // all reactions a pair of reactant species is part of

--- a/src/react_bird.h
+++ b/src/react_bird.h
@@ -32,7 +32,7 @@ class ReactBird : public React {
   virtual int attempt(Particle::OnePart *, Particle::OnePart *, 
                       double, double, double, double &, int &) = 0;
   char *reactionID(int);
-  double extract_tally(int);
+  virtual double extract_tally(int);
 
  protected:
   FILE *fp;

--- a/src/react_qk.cpp
+++ b/src/react_qk.cpp
@@ -187,6 +187,7 @@ int ReactQK::attempt(Particle::OnePart *ip, Particle::OnePart *jp,
     //      nothing that is I-specific or J-specific
     
     if (react_prob > random_prob) {
+      tally_reactions[list[i]]++;
       ip->ispecies = r->products[0];
       jp->ispecies = r->products[1];
       

--- a/src/react_tce.cpp
+++ b/src/react_tce.cpp
@@ -141,6 +141,7 @@ int ReactTCE::attempt(Particle::OnePart *ip, Particle::OnePart *jp,
     //      nothing that is I-specific or J-specific
 
     if (react_prob > random_prob) {
+      tally_reactions[list[i]]++;
       ip->ispecies = r->products[0];
 
       // Previous statment did not destroy the 2nd species (B) if

--- a/src/react_tce_qk.cpp
+++ b/src/react_tce_qk.cpp
@@ -92,6 +92,8 @@ int ReactTCEQK::attempt(Particle::OnePart *ip, Particle::OnePart *jp,
       reaction = attempt_qk(ip,jp,r,
                             pre_etrans,pre_erot,
                             pre_evib,post_etotal,kspecies);
+
+    if (reaction) tally_reactions[list[i]]++;
   }
   
   return 0;

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -151,6 +151,7 @@ void Surf::modify_params(int narg, char **arg)
   while (iarg < narg) {
     if (strcmp(arg[iarg],"collide") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal surf_modify command");
+      if (!exist) error->all(FLERR,"Surf_modify when surfs do not yet exist");
 
       int isc = find_collide(arg[iarg+1]);
       if (isc < 0) error->all(FLERR,"Could not find surf_modify sc-ID");
@@ -171,7 +172,8 @@ void Surf::modify_params(int narg, char **arg)
 
     } else if (strcmp(arg[iarg],"react") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal surf_modify command");
-      
+      if (!exist) error->all(FLERR,"Surf_modify when surfs do not yet exist");
+
       int isr;
       if (strcmp(arg[iarg+1],"none") == 0) isr = -1;
       else {

--- a/src/surf_collide.h
+++ b/src/surf_collide.h
@@ -35,7 +35,7 @@ class SurfCollide : protected Pointers {
   virtual ~SurfCollide();
   virtual void init();
   virtual Particle::OnePart *collide(Particle::OnePart *&, double *, 
-                                     double &, int) = 0;
+                                     double &, int, int &) = 0;
 
   virtual void dynamic() {}
   void tally_update();

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -138,20 +138,21 @@ void SurfCollideDiffuse::init()
    isr = index of reaction model if >= 0, -1 for no chemistry
    ip = set to NULL if destroyed by chemsitry
    return jp = new particle if created by chemistry
+   return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity
 ------------------------------------------------------------------------- */
 
 Particle::OnePart *SurfCollideDiffuse::
-collide(Particle::OnePart *&ip, double *norm, double &, int isr)
+collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 {
   nsingle++;
 
   // if surface chemistry defined, attempt reaction
-  // reaction = 1 if reaction took place
+  // reaction > 0 if reaction took place
 
   Particle::OnePart iorig;
   Particle::OnePart *jp = NULL;
-  int reaction = 0;
+  reaction = 0;
 
   if (isr >= 0) {
     if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));

--- a/src/surf_collide_diffuse.h
+++ b/src/surf_collide_diffuse.h
@@ -31,7 +31,8 @@ class SurfCollideDiffuse : public SurfCollide {
   SurfCollideDiffuse(class SPARTA *sparta) : SurfCollide(sparta) {}
   ~SurfCollideDiffuse();
   void init();
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int);
+  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, 
+                             int, int &);
 
   void dynamic();
 

--- a/src/surf_collide_piston.cpp
+++ b/src/surf_collide_piston.cpp
@@ -32,6 +32,8 @@ SurfCollidePiston::SurfCollidePiston(SPARTA *sparta, int narg, char **arg) :
 {
   if (narg != 3) error->all(FLERR,"Illegal surf_collide piston command");
 
+  allowreact = 1;
+
   vwall = input->numeric(FLERR,arg[2]); 
   if (vwall <= 0.0) error->all(FLERR,"Surf_collide piston velocity <= 0.0");
 }
@@ -84,20 +86,22 @@ void SurfCollidePiston::init()
    isr = index of reaction model if >= 0, -1 for no chemistry
    ip = set to NULL if destroyed by chemsitry
    return jp = new particle if created by chemistry
+   return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity
 ------------------------------------------------------------------------- */
 
 Particle::OnePart *SurfCollidePiston::
-collide(Particle::OnePart *&ip, double *norm, double &dtremain, int isr)
+collide(Particle::OnePart *&ip, double *norm, double &dtremain, 
+        int isr, int & reaction)
 {
   nsingle++;
 
   // if surface chemistry defined, attempt reaction
-  // reaction = 1 if reaction took place
+  // reaction > 0 if reaction took place
 
   Particle::OnePart iorig;
   Particle::OnePart *jp = NULL;
-  int reaction = 0;
+  reaction = 0;
 
   if (isr >= 0) {
     if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));

--- a/src/surf_collide_piston.h
+++ b/src/surf_collide_piston.h
@@ -32,7 +32,8 @@ class SurfCollidePiston : public SurfCollide {
   SurfCollidePiston(class SPARTA *sparta) : SurfCollide(sparta) {}
   ~SurfCollidePiston() {}
   void init();
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int);
+  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, 
+                             int, int &);
 
  protected:
   double vwall;

--- a/src/surf_collide_specular.cpp
+++ b/src/surf_collide_specular.cpp
@@ -28,6 +28,8 @@ SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
   SurfCollide(sparta, narg, arg)
 {
   if (narg != 2) error->all(FLERR,"Illegal surf_collide specular command");
+
+  allowreact = 1;
 }
 
 /* ----------------------------------------------------------------------
@@ -37,20 +39,21 @@ SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
    isr = index of reaction model if >= 0, -1 for no chemistry
    ip = set to NULL if destroyed by chemsitry
    return jp = new particle if created by chemistry
+   return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity
 ------------------------------------------------------------------------- */
 
 Particle::OnePart *SurfCollideSpecular::
-collide(Particle::OnePart *&ip, double *norm, double &, int isr)
+collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 {
   nsingle++;
 
   // if surface chemistry defined, attempt reaction
-  // reaction = 1 if reaction took place
+  // reaction > 0 if reaction took place
 
   Particle::OnePart iorig;
   Particle::OnePart *jp = NULL;
-  int reaction = 0;
+  reaction = 0;
 
   if (isr >= 0) {
     if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));

--- a/src/surf_collide_specular.h
+++ b/src/surf_collide_specular.h
@@ -31,7 +31,8 @@ class SurfCollideSpecular : public SurfCollide {
   SurfCollideSpecular(class SPARTA *, int, char **);
   SurfCollideSpecular(class SPARTA *sparta) : SurfCollide(sparta) {}
   virtual ~SurfCollideSpecular() {}
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int);
+  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, 
+                             int, int &);
 };
 
 }

--- a/src/surf_collide_vanish.cpp
+++ b/src/surf_collide_vanish.cpp
@@ -32,10 +32,11 @@ SurfCollideVanish::SurfCollideVanish(SPARTA *sparta, int narg, char **arg) :
    norm = surface normal unit vector
    isr = index of reaction model if >= 0, -1 for no chemistry
    simply return ip = NULL to delete particle
+   return reaction = 0 = no reaction took place
 ------------------------------------------------------------------------- */
 
 Particle::OnePart *SurfCollideVanish::
-collide(Particle::OnePart *&ip, double *, double &, int)
+collide(Particle::OnePart *&ip, double *, double &, int, int &reaction)
 {
   nsingle++;
 

--- a/src/surf_react.cpp
+++ b/src/surf_react.cpp
@@ -96,6 +96,11 @@ SurfReact::~SurfReact()
   }
   memory->destroy(rlist);
 
+  delete [] tally_single;
+  delete [] tally_total;
+  delete [] tally_single_all;
+  delete [] tally_total_all;
+
   memory->destroy(reactions);
   memory->destroy(indices);
 }
@@ -377,6 +382,24 @@ void SurfReact::tally_update()
 char *SurfReact::reactionID(int m)
 {
   return rlist[m].id;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int SurfReact::match_reactant(char *species, int m)
+{
+  for (int i = 0; i < rlist[m].nreactant; i++)
+    if (strcmp(species,rlist[m].id_reactants[i]) == 0) return 1;
+  return 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int SurfReact::match_product(char *species, int m)
+{
+  for (int i = 0; i < rlist[m].nproduct; i++)
+    if (strcmp(species,rlist[m].id_products[i]) == 0) return 1;
+  return 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/surf_react.cpp
+++ b/src/surf_react.cpp
@@ -54,14 +54,17 @@ SurfReact::SurfReact(SPARTA *sparta, int, char **arg) :
       error->all(FLERR,"Surf_react ID must be alphanumeric or "
                  "underscore characters");
 
-  n = strlen(arg[0]) + 1;
+  n = strlen(arg[1]) + 1;
   style = new char[n];
-  strcpy(style,arg[0]);
+  strcpy(style,arg[1]);
 
   vector_flag = 1;
   size_vector = 2;
     
+  // tallies
+
   nsingle = ntotal = 0;
+  tally_two_flag = tally_single_flag = tally_total_flag = 0;
 
   // surface reaction data structs
 
@@ -89,6 +92,7 @@ SurfReact::~SurfReact()
     delete [] rlist[i].reactants;
     delete [] rlist[i].products;
     delete [] rlist[i].coeff;
+    delete [] rlist[i].id;
   }
   memory->destroy(rlist);
 
@@ -101,6 +105,8 @@ SurfReact::~SurfReact()
 void SurfReact::init()
 {
   nsingle = ntotal = 0;
+  for (int i = 0; i < nlist; i++)
+    tally_single[i] = tally_total[i] = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -218,7 +224,7 @@ void SurfReact::readfile(char *fname)
     if (nlist == maxlist) {
       maxlist += DELTALIST;
       rlist = (OneReaction *) 
-        memory->srealloc(rlist,maxlist*sizeof(OneReaction),"react/tce:rlist");
+        memory->srealloc(rlist,maxlist*sizeof(OneReaction),"surf_react:rlist");
       for (int i = nlist; i < maxlist; i++) {
         r = &rlist[i];
         r->nreactant = r->nproduct = 0;
@@ -227,6 +233,7 @@ void SurfReact::readfile(char *fname)
         r->reactants = new int[MAXREACTANT];
         r->products = new int[MAXPRODUCT];
         r->coeff = new double[MAXCOEFF];
+        r->id = NULL;
       }
     }
 
@@ -234,6 +241,11 @@ void SurfReact::readfile(char *fname)
 
     int side = 0;
     int species = 1;
+
+    n = strlen(line1) - 1;
+    r->id = new char[n+1];
+    strncpy(r->id,line1,n);
+    r->id[n] = '\0';
 
     word = strtok(line1," \t\n");
 
@@ -351,15 +363,47 @@ void SurfReact::tally_update()
 {
   ntotal += nsingle;
   nsingle = 0;
+
+  for (int i = 0; i < nlist; i++) {
+    tally_total[i] += tally_single[i];
+    tally_single[i] = 0;
+  }
+
+  tally_two_flag = tally_single_flag = tally_total_flag = 0;
+}
+
+/* ---------------------------------------------------------------------- */
+
+char *SurfReact::reactionID(int m)
+{
+  return rlist[m].id;
 }
 
 /* ---------------------------------------------------------------------- */
 
 double SurfReact::compute_vector(int i)
 {
-  one[0] = nsingle;
-  one[1] = ntotal + nsingle;
-  MPI_Allreduce(&one,&all,2,MPI_DOUBLE,MPI_SUM,world);
+  if (i < 2) {
+    if (!tally_two_flag) {
+      tally_two_flag = 1;
+      one[0] = nsingle;
+      one[1] = ntotal;
+      MPI_Allreduce(one,all,2,MPI_DOUBLE,MPI_SUM,world);
+    }
+    return all[i];
+  }
+    
+  if (i < 2+nlist) {
+    if (!tally_single_flag) {
+      tally_single_flag = 1;
+      MPI_Allreduce(tally_single,tally_single_all,nlist,MPI_INT,MPI_SUM,world);
+    }
+    return 1.0*tally_single_all[i-2];
+  }
 
-  return all[i];
+  if (!tally_total_flag) {
+    tally_total_flag = 1;
+    MPI_Allreduce(tally_total,tally_total_all,nlist,MPI_INT,MPI_SUM,world);
+  }
+  return 1.0*tally_total_all[i-nlist-2];
 }

--- a/src/surf_react.h
+++ b/src/surf_react.h
@@ -34,8 +34,11 @@ class SurfReact : protected Pointers {
   virtual void init();
   virtual int react(Particle::OnePart *&, double *, Particle::OnePart *&) = 0;
 
-  void tally_update();
   virtual char *reactionID(int);
+  virtual int match_reactant(char *, int);
+  virtual int match_product(char *, int);
+
+  void tally_update();
   double compute_vector(int i);
 
  protected:

--- a/src/surf_react.h
+++ b/src/surf_react.h
@@ -27,6 +27,7 @@ class SurfReact : protected Pointers {
 
   int vector_flag;          // 0/1 if compute_vector() function exists
   int size_vector;          // length of global vector
+  int nlist;                // # of reactions defined or read from file
 
   SurfReact(class SPARTA *, int, char **);
   virtual ~SurfReact();
@@ -34,12 +35,21 @@ class SurfReact : protected Pointers {
   virtual int react(Particle::OnePart *&, double *, Particle::OnePart *&) = 0;
 
   void tally_update();
+  virtual char *reactionID(int);
   double compute_vector(int i);
 
  protected:
   FILE *fp;
+
+  // tallies for reactions
+
   int nsingle,ntotal;
   double one[2],all[2];
+  int *tally_single,*tally_total;
+  int *tally_single_all,*tally_total_all;
+  int tally_two_flag,tally_single_flag,tally_total_flag;
+
+  // reaction info, as read from file
 
   struct OneReaction {
     int active;                    // 1 if reaction is active
@@ -50,10 +60,10 @@ class SurfReact : protected Pointers {
     char **id_reactants,**id_products;  // species IDs of reactants/products
     int *reactants,*products;      // species indices of reactants/products
     double *coeff;                 // numerical coeffs for reaction
+    char *id;                      // reaction ID (formula)
   };
 
   OneReaction *rlist;              // list of all reactions read from file
-  int nlist;                       // # of reactions read from file
   int maxlist;                     // max # of reactions in rlist
 
   // possible reactions a reactant species is part of

--- a/src/surf_react_global.h
+++ b/src/surf_react_global.h
@@ -31,6 +31,8 @@ class SurfReactGlobal : public SurfReact {
   ~SurfReactGlobal();
   int react(Particle::OnePart *&, double *, Particle::OnePart *&);
 
+  char *reactionID(int);
+
  private:
   double prob_create,prob_destroy;
   class RanPark *random;     // RNG for reaction probabilities

--- a/src/surf_react_global.h
+++ b/src/surf_react_global.h
@@ -32,6 +32,8 @@ class SurfReactGlobal : public SurfReact {
   int react(Particle::OnePart *&, double *, Particle::OnePart *&);
 
   char *reactionID(int);
+  int match_reactant(char *, int) {return 1;}
+  int match_product(char *, int) {return 1;}
 
  private:
   double prob_create,prob_destroy;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -385,7 +385,7 @@ template < int DIM, int SURF > void Update::move()
   bool hitflag;
   int m,icell,icell_original,nmask,outface,bflag,nflag,pflag,itmp;
   int side,minside,minsurf,nsurf,cflag,isurf,exclude,stuck_iterate;
-  int pstart,pstop,entryexit,any_entryexit;
+  int pstart,pstop,entryexit,any_entryexit,reaction;
   surfint *csurfs;
   cellint *neigh;
   double dtremain,frac,newfrac,param,minparam,rnew,dtsurf,tc,tmp;
@@ -881,10 +881,10 @@ template < int DIM, int SURF > void Update::move()
 
               if (DIM == 3)
                 jpart = surf->sc[tri->isc]->
-                  collide(ipart,tri->norm,dtremain,tri->isr);
+                  collide(ipart,tri->norm,dtremain,tri->isr,reaction);
               if (DIM != 3)
                 jpart = surf->sc[line->isc]->
-                  collide(ipart,line->norm,dtremain,line->isr);
+                  collide(ipart,line->norm,dtremain,line->isr,reaction);
 
               if (jpart) {
                 particles = particle->particles;
@@ -898,7 +898,8 @@ template < int DIM, int SURF > void Update::move()
 
               if (nsurf_tally)
                 for (m = 0; m < nsurf_tally; m++)
-                  slist_active[m]->surf_tally(minsurf,icell,&iorig,ipart,jpart);
+                  slist_active[m]->surf_tally(minsurf,icell,reaction,
+                                              &iorig,ipart,jpart);
               
               // nstuck = consective iterations particle is immobile
 
@@ -1068,7 +1069,8 @@ template < int DIM, int SURF > void Update::move()
           if (nboundary_tally) 
             memcpy(&iorig,&particles[i],sizeof(Particle::OnePart));
 
-          bflag = domain->collide(ipart,outface,icell,xnew,dtremain,jpart);
+          bflag = domain->collide(ipart,outface,icell,xnew,dtremain,
+                                  jpart,reaction);
 
           if (jpart) {
             particles = particle->particles;
@@ -1079,7 +1081,7 @@ template < int DIM, int SURF > void Update::move()
           if (nboundary_tally)
             for (m = 0; m < nboundary_tally; m++)
               blist_active[m]->
-                boundary_tally(outface,bflag,&iorig,ipart,jpart);
+                boundary_tally(outface,bflag,reaction,&iorig,ipart,jpart);
 
           if (DIM == 1) {
             xnew[0] = x[0] + dtremain*v[0];
@@ -1360,7 +1362,7 @@ int Update::split2d(int icell, double *x)
 }
 
 /* ----------------------------------------------------------------------
-   setup lists of all computes that tally surface and boundary bounce info
+   setup lists of all computes that tally surface collision/reaction info
    return 1 if there are any, 0 if not
 ------------------------------------------------------------------------- */
 
@@ -1376,8 +1378,7 @@ int Update::collide_react_setup()
 }
 
 /* ----------------------------------------------------------------------
-   setup lists of all computes that tally surface and boundary bounce info
-   return 1 if there are any, 0 if not
+   zero counters in all computes that tally surface collision/reaction info
 ------------------------------------------------------------------------- */
 
 void Update::collide_react_update()
@@ -1425,7 +1426,8 @@ int Update::bounce_setup()
 
 /* ----------------------------------------------------------------------
    set bounce tally flags for current timestep
-   nsurf_tally = # of computes needing bounce info on this step
+   nsurf_tally = # of surface computes needing bounce info on this step
+   nboundary_tally = # of boundary computes needing bounce info on this step
    clear accumulators in computes that will be invoked this step
 ------------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Purpose

Enable ablation modeling to be driven by reaction statistics.  Also provide new computes
and global into for monitoring reaction statistics.  Either globally or on a per-surf (explicit surfs)
or per-grid-cell (implicit surfs) basis.

## Author(s)

Steve and Arnaud

## Backward Compatibility

Made some code changes (function args, added tally stats) that will likely
affect Kokkos versions.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


