### PR TITLE
added options for transparent surface elements

### DIFF
--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -161,7 +161,8 @@ it gives quick access to documentation for all SPARTA commands.
 <BR>
   6.13 <A HREF = "Section_howto.html#howto_13">Surface elements: explicit, implicit, distributed</A> 
 <BR>
-  6.14 <A HREF = "#howto_14">Implicit surface ablation</A> 
+  6.14 <A HREF = "#howto_14">Implicit surface ablation</A>
+  6.14 <A HREF = "#howto_15">Transparent surface elements</A> 
 <BR></UL>
 <LI><A HREF = "Section_example.html">Example problems</A> 
 
@@ -219,6 +220,8 @@ it gives quick access to documentation for all SPARTA commands.
 <BR></UL>
 
 </OL>
+
+
 
 
 

--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -161,8 +161,9 @@ it gives quick access to documentation for all SPARTA commands.
 <BR>
   6.13 <A HREF = "Section_howto.html#howto_13">Surface elements: explicit, implicit, distributed</A> 
 <BR>
-  6.14 <A HREF = "#howto_14">Implicit surface ablation</A>
-  6.14 <A HREF = "#howto_15">Transparent surface elements</A> 
+  6.14 <A HREF = "Section_howto.html#howto_14">Implicit surface ablation</A> 
+<BR>
+  6.15 <A HREF = "Section_howto.html#howto_15">Transparent surface elements</A> 
 <BR></UL>
 <LI><A HREF = "Section_example.html">Example problems</A> 
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -118,8 +118,8 @@ it gives quick access to documentation for all SPARTA commands.
   6.11 "Using the ambipolar approximation"_howto_11 :b
   6.12 "Using multiple vibrational energy levels"_howto_12 :b
   6.13 "Surface elements: explicit, implicit, distributed"_howto_13 :b
-  6.14 "Implicit surface ablation"_#howto_14
-  6.14 "Transparent surface elements"_#howto_15 :ule,b
+  6.14 "Implicit surface ablation"_howto_14 :b
+  6.15 "Transparent surface elements"_howto_15 :ule,b
 "Example problems"_Section_example.html :l
 "Performance & scalability"_Section_perf.html :l
 "Additional tools"_Section_tools.html :l

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -118,7 +118,8 @@ it gives quick access to documentation for all SPARTA commands.
   6.11 "Using the ambipolar approximation"_howto_11 :b
   6.12 "Using multiple vibrational energy levels"_howto_12 :b
   6.13 "Surface elements: explicit, implicit, distributed"_howto_13 :b
-  6.14 "Implicit surface ablation"_#howto_14 :ule,b
+  6.14 "Implicit surface ablation"_#howto_14
+  6.14 "Transparent surface elements"_#howto_15 :ule,b
 "Example problems"_Section_example.html :l
 "Performance & scalability"_Section_perf.html :l
 "Additional tools"_Section_tools.html :l
@@ -185,6 +186,7 @@ it gives quick access to documentation for all SPARTA commands.
 :link(howto_12,Section_howto.html#howto_12)
 :link(howto_13,Section_howto.html#howto_13)
 :link(howto_14,Section_howto.html#howto_14)
+:link(howto_15,Section_howto.html#howto_15)
 
 :link(mod_1,Section_python.html#mod_1)
 :link(mod_2,Section_python.html#mod_2)

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -1294,10 +1294,10 @@ there may be some corner cases we haven't thought about or tested.
 </P>
 <P>These are the relevant commands.  See their doc pages for details:
 </P>
-<P><A HREF = "read_surf.html">read_surf transparent</A>
-<A HREF = "surf_collide.html">surf_collide transparent</A>
-<A HREF = "compute_surf.html">compute surf</A>
-</P>
+<UL><LI><A HREF = "read_surf.html">read_surf transparent</A>
+<LI><A HREF = "surf_collide.html">surf_collide transparent</A>
+<LI><A HREF = "compute_surf.html">compute surf</A> 
+</UL>
 <P>The <A HREF = "read_surf.html">read_surf</A> command with its <I>transparent</I> keyword
 is used to flag all the read-in surface elements as transparent.  This
 means they must be in a file separate from regular non-transparent

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -28,7 +28,8 @@ SPARTA works.
 6.11 <A HREF = "#howto_11">Using the ambipolar approximation</A><BR>
 6.12 <A HREF = "#howto_12">Using multiple vibrational energy levels</A><BR>
 6.13 <A HREF = "#howto_13">Surface elements: explicit, implicit, distributed</A><BR>
-6.14 <A HREF = "#howto_14">Implicit surface ablation</A> <BR>
+6.14 <A HREF = "#howto_14">Implicit surface ablation</A><BR>
+6.15 <A HREF = "#howto_15">Transparent surface elements</A> <BR>
 
 <P>The example input scripts included in the SPARTA distribution and
 highlighted in <A HREF = "Section_example.html">Section 5</A> of the manual also
@@ -1261,5 +1262,66 @@ also output implicit surface elements for visualization by tools such
 as ParaView which can read SPARTA surface element files after suitable
 post-processing.  See the <A HREF = "Section_tools.html#paraview">Section tools
 paraview</A> doc page for more details.
+</P>
+<HR>
+
+<A NAME = "howto_15"></A><H4>6.15 Transparent surface elements 
+</H4>
+<P>Transparent surfaces are useful for tallying flow statistics.
+Particles pass through them unaffected.  However the flux of particles
+through those surface elements can be tallied and output.
+</P>
+<P>Transparent surfaces are treated differently than regular surfaces.
+They do not need to be watertight.  E.g. you can define a set of line
+segments that form a straight (or curved) line in 2d.  Or a set of
+triangle that form a plane (or curved surface) in 3d.  You can define
+multiple such surfaces, e.g. multiple disjoint planes, and tally flow
+statistics through each of them.  To tally or sum the statistics
+separately, you may want to assign the triangles in each plane to a
+different surface group via the <A HREF = "read_surf.html">read_surf group</A> or
+<A HREF = "group.html">group surf</A> commands.
+</P>
+<P>Note that for purposes of collisions, transparent surface elements are
+one-sided.  A collision is only tallied for particles passing through
+the outward face of the element.  If you want to tally particles
+passing through in both directions, then define 2 transparent
+surfaces, with opposite orientation.  Again, you may want to put the 2
+surfaces in separate groups.
+</P>
+<P>There also should be no restriction on transparent surfaces
+intersecting each other or intersecting regular surfaces.  Though
+there may be some corner cases we haven't thought about or tested.
+</P>
+<P>These are the relevant commands.  See their doc pages for details:
+</P>
+<P><A HREF = "read_surf.html">read_surf transparent</A>
+<A HREF = "surf_collide.html">surf_collide transparent</A>
+<A HREF = "compute_surf.html">compute surf</A>
+</P>
+<P>The <A HREF = "read_surf.html">read_surf</A> command with its <I>transparent</I> keyword
+is used to flag all the read-in surface elements as transparent.  This
+means they must be in a file separate from regular non-transparent
+elements.
+</P>
+<P>The <A HREF = "surf_collide.html">surf_collide</A> command must be used with its
+<I>transparent</I> model and assigned to all transparent surface elements
+via the <A HREF = "surf_modify.html">surf_modify</A> command.
+</P>
+<P>The <A HREF = "compute_surf.html">compute_surf</A> command can be used to tally the
+count, mass flux, and energy flux of particles that pass through
+transparent surface elements.  These quantities can then be time
+averaged via the <A HREF = "fix_ave_surf.html">fix ave/surf</A> command or output
+via the <A HREF = "dump_surf.html">dump surf</A> command in the usual ways,
+as described in <A HREF = "Section_howto.html#howto_4">Section 6.4</A>.
+</P>
+<P>The examples/circle/in.circle.transparent script shows how to use
+these commands when modeling flow around a 2d circle.  Two additional
+transparent line segments are placed in front of the circle to tally
+particle count and kinetic energy flux in both directions in front of
+the object.  These are defined in the data.plane1 and data.plane2
+files.  The resulting tallies are output with the
+<A HREF = "stats_style.html">stats_style</A> command.  They could also be output
+with a <A HREF = "dump_surf.html">dump surf</A> command for more resolution if the 2
+lines were each defined as multiple line segments.
 </P>
 </HTML>

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -25,7 +25,8 @@ SPARTA works.
 6.11 "Using the ambipolar approximation"_#howto_11
 6.12 "Using multiple vibrational energy levels"_#howto_12
 6.13 "Surface elements: explicit, implicit, distributed"_#howto_13
-6.14 "Implicit surface ablation"_#howto_14 :all(b)
+6.14 "Implicit surface ablation"_#howto_14
+6.15 "Transparent surface elements"_#howto_15 :all(b)
 
 The example input scripts included in the SPARTA distribution and
 highlighted in "Section 5"_Section_example.html of the manual also
@@ -1251,3 +1252,64 @@ also output implicit surface elements for visualization by tools such
 as ParaView which can read SPARTA surface element files after suitable
 post-processing.  See the "Section tools
 paraview"_Section_tools.html#paraview doc page for more details.
+
+:line
+
+6.15 Transparent surface elements :link(howto_15),h4
+
+Transparent surfaces are useful for tallying flow statistics.
+Particles pass through them unaffected.  However the flux of particles
+through those surface elements can be tallied and output.
+
+Transparent surfaces are treated differently than regular surfaces.
+They do not need to be watertight.  E.g. you can define a set of line
+segments that form a straight (or curved) line in 2d.  Or a set of
+triangle that form a plane (or curved surface) in 3d.  You can define
+multiple such surfaces, e.g. multiple disjoint planes, and tally flow
+statistics through each of them.  To tally or sum the statistics
+separately, you may want to assign the triangles in each plane to a
+different surface group via the "read_surf group"_read_surf.html or
+"group surf"_group.html commands.
+
+Note that for purposes of collisions, transparent surface elements are
+one-sided.  A collision is only tallied for particles passing through
+the outward face of the element.  If you want to tally particles
+passing through in both directions, then define 2 transparent
+surfaces, with opposite orientation.  Again, you may want to put the 2
+surfaces in separate groups.
+
+There also should be no restriction on transparent surfaces
+intersecting each other or intersecting regular surfaces.  Though
+there may be some corner cases we haven't thought about or tested.
+
+These are the relevant commands.  See their doc pages for details:
+
+"read_surf transparent"_read_surf.html
+"surf_collide transparent"_surf_collide.html
+"compute surf"_compute_surf.html :ul
+
+The "read_surf"_read_surf.html command with its {transparent} keyword
+is used to flag all the read-in surface elements as transparent.  This
+means they must be in a file separate from regular non-transparent
+elements.
+
+The "surf_collide"_surf_collide.html command must be used with its
+{transparent} model and assigned to all transparent surface elements
+via the "surf_modify"_surf_modify.html command.
+
+The "compute_surf"_compute_surf.html command can be used to tally the
+count, mass flux, and energy flux of particles that pass through
+transparent surface elements.  These quantities can then be time
+averaged via the "fix ave/surf"_fix_ave_surf.html command or output
+via the "dump surf"_dump_surf.html command in the usual ways,
+as described in "Section 6.4"_Section_howto.html#howto_4.
+
+The examples/circle/in.circle.transparent script shows how to use
+these commands when modeling flow around a 2d circle.  Two additional
+transparent line segments are placed in front of the circle to tally
+particle count and kinetic energy flux in both directions in front of
+the object.  These are defined in the data.plane1 and data.plane2
+files.  The resulting tallies are output with the
+"stats_style"_stats_style.html command.  They could also be output
+with a "dump surf"_dump_surf.html command for more resolution if the 2
+lines were each defined as multiple line segments.

--- a/doc/compute_surf.html
+++ b/doc/compute_surf.html
@@ -96,6 +96,11 @@ contributions from 0, 1, or 2 outgoing particles.  The exception is
 the <I>n</I> and <I>nwt</I> values which simply tally counts of particles
 colliding with the surface element.
 </P>
+<P>If the surface element is transparent, the particle will pass through
+the surface unaltered.  The flux of particle count, mass, or energy to
+the surface can still be tallied by this compute.  See details on
+transparent surface elements below.
+</P>
 <P>Also note that all values for a collision are tallied based on the
 species group of the incident particle.  Quantities associated with
 outgoing particles are part of the same tally, even if they are in
@@ -247,6 +252,32 @@ surface element by particles in the group, such that energy lost by a
 particle is a positive flux.  This is simply the sum of kinetic,
 rotational, and vibrational energies.  Thus the total energy flux is
 the sum of what is computed by the <I>ke</I>, <I>erot</I>, and <I>evib</I> values.
+</P>
+<HR>
+
+<P><B>Transparent surface elements:</B>
+</P>
+<P>This compute will tally information on particles that pass through
+transparent surface elements.  The <A HREF = "Section_howto.html#howto_15">Section
+6.15</A> doc page provides an overview of
+transparent surfaces and how to create them.
+</P>
+<P>The <I>n</I> and <I>nwt</I> value are calculated the same for transparent
+surfaces.  I.e. they are the count and weighted count of particles
+passing through the surface.
+</P>
+<P>The <I>mflux</I>, <I>ke</I>, <I>erot</I>. <I>evib</I>, and <I>etot</I> values are fluxes.  For
+transparent surfaces, they are calculated for the incident particle as
+if they had struck the surface.  The outgoing particle is ignored.
+This means the tally quantity is the flux of particles onto the
+outward face of the surface.  No tallying is done for particles
+hitting the inward face of the surface.  See <A HREF = "Section_howto.html#howto_15">Section
+6.15</A> for how to do tallying in both
+directions.
+</P>
+<P>All the other values are calculated as described above.  This means
+they will be zero, since the incident particle and outgoing particle
+have the same mass and velocity.
 </P>
 <HR>
 

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -85,6 +85,11 @@ contributions from 0, 1, or 2 outgoing particles.  The exception is
 the {n} and {nwt} values which simply tally counts of particles
 colliding with the surface element.
 
+If the surface element is transparent, the particle will pass through
+the surface unaltered.  The flux of particle count, mass, or energy to
+the surface can still be tallied by this compute.  See details on
+transparent surface elements below.
+
 Also note that all values for a collision are tallied based on the
 species group of the incident particle.  Quantities associated with
 outgoing particles are part of the same tally, even if they are in
@@ -236,6 +241,32 @@ surface element by particles in the group, such that energy lost by a
 particle is a positive flux.  This is simply the sum of kinetic,
 rotational, and vibrational energies.  Thus the total energy flux is
 the sum of what is computed by the {ke}, {erot}, and {evib} values.
+
+:line
+
+[Transparent surface elements:]
+
+This compute will tally information on particles that pass through
+transparent surface elements.  The "Section
+6.15"_Section_howto.html#howto_15 doc page provides an overview of
+transparent surfaces and how to create them.
+
+The {n} and {nwt} value are calculated the same for transparent
+surfaces.  I.e. they are the count and weighted count of particles
+passing through the surface.
+
+The {mflux}, {ke}, {erot}. {evib}, and {etot} values are fluxes.  For
+transparent surfaces, they are calculated for the incident particle as
+if they had struck the surface.  The outgoing particle is ignored.
+This means the tally quantity is the flux of particles onto the
+outward face of the surface.  No tallying is done for particles
+hitting the inward face of the surface.  See "Section
+6.15"_Section_howto.html#howto_15 for how to do tallying in both
+directions.
+
+All the other values are calculated as described above.  This means
+they will be zero, since the incident particle and outgoing particle
+have the same mass and velocity.
 
 :line
 

--- a/doc/read_surf.html
+++ b/doc/read_surf.html
@@ -19,7 +19,7 @@
 
 <LI>zero or more keyword/args pairs may be appended 
 
-<LI>keyword = <I>origin</I> or <I>trans</I> or <I>atrans</I> or <I>ftrans</I> or <I>scale</I> or <I>rotate</I> or <I>invert</I> or <I>clip</I> or <I>group</I> or <I>typeadd</I> or <I>particle</I> or <I>file</I> 
+<LI>keyword = <I>origin</I> or <I>trans</I> or <I>atrans</I> or <I>ftrans</I> or <I>scale</I> or <I>rotate</I> or <I>transparent</I> or <I>invert</I> or <I>clip</I> or <I>group</I> or <I>typeadd</I> or <I>particle</I> or <I>file</I> 
 
 <PRE>  origin args = Ox Oy Oz
     Ox,Oy,Oz = set origin of surface to this point (distance units)
@@ -34,6 +34,7 @@
   rotate args = theta Rx Ry Rz
     theta = rotate surface by this angle in counter-clockwise direction (degrees)
     Rx,Ry,Rz = rotate around vector starting at origin pointing in this direction
+  transparent args = none
   invert args = none
   clip args = none or fraction
     fraction = push points close to the box boundary to the boundary (optional)
@@ -346,6 +347,16 @@ coordinates of all vertices by an angle <I>theta</I> in a counter-clockwise
 direction, around the vector starting at the origin and pointing in
 the direction <I>Rx,Ry,Rz</I>.  Any rotation can be represented by an
 appropriate choice of origin, <I>theta</I> and (Rx,Ry,Rz).
+</P>
+<P>The <I>transparent</I> keyword flags all the read in surface elements as
+transparent, meaning particles pass through them.  This is useful for
+tallying flow statistics.  The <A HREF = "surf_collide.html">surf_collide
+transparent</A> command must also be used to assign a
+transparent collision model to those the surface elements.  The
+<A HREF = "compute_surf.html">compute surf</A> command will tally fluxes differently
+for transparent surf elements.  The <A HREF = "Section_howto.html#howto_15">Section
+6.15</A> doc page provides an overview of
+transparent surfaces.  See those doc pages for details.
 </P>
 <P>The <I>invert</I> keyword does not change the origin or any vertex
 coordinates.  It flips the direction of the outward surface normal of

--- a/doc/read_surf.txt
+++ b/doc/read_surf.txt
@@ -14,7 +14,7 @@ read_surf filename keyword args ... :pre
 
 filename = name of surface file :ulb,l
 zero or more keyword/args pairs may be appended :l
-keyword = {origin} or {trans} or {atrans} or {ftrans} or {scale} or {rotate} or {invert} or {clip} or {group} or {typeadd} or {particle} or {file} :l
+keyword = {origin} or {trans} or {atrans} or {ftrans} or {scale} or {rotate} or {transparent} or {invert} or {clip} or {group} or {typeadd} or {particle} or {file} :l
   origin args = Ox Oy Oz
     Ox,Oy,Oz = set origin of surface to this point (distance units)
   trans args = Dx Dy Dz
@@ -28,6 +28,7 @@ keyword = {origin} or {trans} or {atrans} or {ftrans} or {scale} or {rotate} or 
   rotate args = theta Rx Ry Rz
     theta = rotate surface by this angle in counter-clockwise direction (degrees)
     Rx,Ry,Rz = rotate around vector starting at origin pointing in this direction
+  transparent args = none
   invert args = none
   clip args = none or fraction
     fraction = push points close to the box boundary to the boundary (optional)
@@ -339,6 +340,16 @@ coordinates of all vertices by an angle {theta} in a counter-clockwise
 direction, around the vector starting at the origin and pointing in
 the direction {Rx,Ry,Rz}.  Any rotation can be represented by an
 appropriate choice of origin, {theta} and (Rx,Ry,Rz).
+
+The {transparent} keyword flags all the read in surface elements as
+transparent, meaning particles pass through them.  This is useful for
+tallying flow statistics.  The "surf_collide
+transparent"_surf_collide.html command must also be used to assign a
+transparent collision model to those the surface elements.  The
+"compute surf"_compute_surf.html command will tally fluxes differently
+for transparent surf elements.  The "Section
+6.15"_Section_howto.html#howto_15 doc page provides an overview of
+transparent surfaces.  See those doc pages for details.
 
 The {invert} keyword does not change the origin or any vertex
 coordinates.  It flips the direction of the outward surface normal of

--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -17,7 +17,7 @@
 </PRE>
 <UL><LI>ID = user-assigned name for the surface collision model 
 
-<LI>style = <I>specular</I> or <I>diffuse</I> or <I>vanish</I> 
+<LI>style = <I>specular</I> or <I>diffuse</I> or <I>piston</I> or <I>transparent</I> or <I>vanish</I> 
 
 <LI>args = arguments for specific style 
 
@@ -28,6 +28,7 @@
     acc = accommodation coefficient
   <I>piston</I> args = Vwall
     Vwall = velocity of boundary wall (velocity units)
+  <I>transparent</I> args = none 
   <I>vanish</I> args = none 
   <I>specular/kk</I> args = none
   <I>diffuse/kk</I> args = Tsurf acc
@@ -55,6 +56,7 @@
 <P><B>Examples:</B>
 </P>
 <PRE>surf_collide 1 specular
+surf_collide 1 transparent
 surf_collide 1 diffuse 273.15 0.9
 surf_collide heatwall diffuse v_ramp 0.8
 surf_collide heatwall diffuse v_ramp 0.8 translate 5.0 0.0 0.0 
@@ -150,6 +152,19 @@ surface is moving away from the incident particle.  For example, in
 the z-dimension, if the upper box face is assigned <I>Vwall</I>, it is
 moving upward.  Similarly if the lower box face is assigned <I>Vwall</I>,
 it is moving downward.
+</P>
+<HR>
+
+<P>The <I>transparent</I> style simply allows particles to pass through the
+surface without altering the particle properties.
+</P>
+<P>This is useful for tallying flow statistics.  The surface elements
+must have been flagged as transparent when they were read in, via the
+<A HREF = "read_surf.html">read_surf</A> command and its transparent keyword.  The
+<A HREF = "compute_surf.html">compute surf</A> command will tally fluxes differently
+for transparent surf elements.  The <A HREF = "Section_howto.html#howto_15">Section
+6.15</A> doc page provides an overview of
+transparent surfaces.  See those doc pages for details.
 </P>
 <HR>
 

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -13,7 +13,7 @@ surf_collide command :h3
 surf_collide ID style args keyword values ... :pre
 
 ID = user-assigned name for the surface collision model :ulb,l
-style = {specular} or {diffuse} or {vanish} :l
+style = {specular} or {diffuse} or {piston} or {transparent} or {vanish} :l
 args = arguments for specific style :l
   {specular} args = none
   {diffuse} args = Tsurf acc
@@ -22,6 +22,7 @@ args = arguments for specific style :l
     acc = accommodation coefficient
   {piston} args = Vwall
     Vwall = velocity of boundary wall (velocity units)
+  {transparent} args = none 
   {vanish} args = none 
   {specular/kk} args = none
   {diffuse/kk} args = Tsurf acc
@@ -44,6 +45,7 @@ values = values for specific keyword :l
 [Examples:]
 
 surf_collide 1 specular
+surf_collide 1 transparent
 surf_collide 1 diffuse 273.15 0.9
 surf_collide heatwall diffuse v_ramp 0.8
 surf_collide heatwall diffuse v_ramp 0.8 translate 5.0 0.0 0.0 :pre
@@ -139,6 +141,19 @@ surface is moving away from the incident particle.  For example, in
 the z-dimension, if the upper box face is assigned {Vwall}, it is
 moving upward.  Similarly if the lower box face is assigned {Vwall},
 it is moving downward.
+
+:line
+
+The {transparent} style simply allows particles to pass through the
+surface without altering the particle properties.
+
+This is useful for tallying flow statistics.  The surface elements
+must have been flagged as transparent when they were read in, via the
+"read_surf"_read_surf.html command and its transparent keyword.  The
+"compute surf"_compute_surf.html command will tally fluxes differently
+for transparent surf elements.  The "Section
+6.15"_Section_howto.html#howto_15 doc page provides an overview of
+transparent surfaces.  See those doc pages for details.
 
 :line
 

--- a/examples/circle/data.plane1
+++ b/examples/circle/data.plane1
@@ -1,0 +1,13 @@
+surf file from Pizza.py
+
+2 points
+1 lines
+
+Points
+
+1 1.0 2.0
+2 1.0 8.0
+
+Lines
+
+1 1 2

--- a/examples/circle/data.plane2
+++ b/examples/circle/data.plane2
@@ -1,0 +1,13 @@
+surf file from Pizza.py
+
+2 points
+1 lines
+
+Points
+
+1 1 8.0
+2 1 2.0
+
+Lines
+
+1 1 2

--- a/examples/circle/in.circle.transparent
+++ b/examples/circle/in.circle.transparent
@@ -1,0 +1,56 @@
+# 2d flow around a circle with transparent surfaces in front to tally stats
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    10 10 1 
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0 
+
+# data.circle = regular surface particles flow around
+# data.plane1 = line segment with normal into flow
+# data.plane2 = line segment with normal towards circle
+# the two line segments are on top of each other
+
+read_surf           data.circle group circle
+read_surf           data.plane1 group plane1 transparent
+read_surf           data.plane2 group plane2 transparent
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_collide	    2 transparent
+
+surf_modify         circle collide 1
+surf_modify         plane1 collide 2
+surf_modify         plane2 collide 2
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo # subsonic 0.1 NULL
+
+compute             plane1 surf plane1 all n ke
+compute             plane2 surf plane2 all n ke
+fix                 plane1 ave/surf plane1 1 100 100 c_plane1[*]
+fix                 plane2 ave/surf plane2 1 100 100 c_plane2[*]
+compute             reduce reduce sum f_plane1[*] f_plane2[*]
+                  
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 &
+#                    surf proc 0.01 size 512 512 zoom 1.75 &
+#                    gline yes 0.005 
+#dump_modify	    2 pad 4
+
+# the last 4 columns are the particle count and energy flux
+# through the 2 transparent surfaces in front of the circle
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck c_reduce[*]
+run 		    1000

--- a/examples/circle/log.circle.transparent.6Nov19.g++.1
+++ b/examples/circle/log.circle.transparent.6Nov19.g++.1
@@ -1,0 +1,189 @@
+SPARTA (15 Oct 2019)
+# 2d flow around a circle with transparent surfaces in front to tally stats
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  parent cells = 1
+  CPU time = 0.00222397 secs
+  create/ghost percent = 93.9751 6.02487
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000206947 secs
+  reassign/sort/migrate/ghost percent = 66.2442 0.460829 19.8157 13.4793
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+# data.circle = regular surface particles flow around
+# data.plane1 = line segment with normal into flow
+# data.plane2 = line segment with normal towards circle
+# the two line segments are on top of each other
+
+read_surf           data.circle group circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 = cells with surfs
+  80 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.376743 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000591993 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 40.0322 16.029 1.36931 35.1188 7.45066 8.61861 0
+  surf2grid time = 0.000207901 secs
+  map/rvous1/rvous2/split percent = 11.1239 31.3073 0 28.7844
+read_surf           data.plane1 group plane1 transparent
+  2 points
+  51 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  38 = cells with surfs
+  96 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.376743 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000296831 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 20.1606 18.5542 1.68675 46.8273 12.7711 14.2169 0.321285
+  surf2grid time = 0.000138998 secs
+  map/rvous1/rvous2/split percent = 16.6381 35.8491 0 25.9005
+read_surf           data.plane2 group plane2 transparent
+  2 points
+  52 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  38 = cells with surfs
+  112 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.376743 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000286102 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 18.9167 18.5 1.75 47.9167 12.9167 14.6667 0
+  surf2grid time = 0.000137091 secs
+  map/rvous1/rvous2/split percent = 18.2609 35.6522 0 24.8696
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_collide	    2 transparent
+
+surf_modify         circle collide 1
+surf_modify         plane1 collide 2
+surf_modify         plane2 collide 2
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo # subsonic 0.1 NULL
+
+compute             plane1 surf plane1 all n ke
+compute             plane2 surf plane2 all n ke
+fix                 plane1 ave/surf plane1 1 100 100 c_plane1[*]
+fix                 plane2 ave/surf plane2 1 100 100 c_plane2[*]
+compute             reduce reduce sum f_plane1[*] f_plane2[*]
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+# the last 4 columns are the particle count and energy flux
+# through the 2 transparent surfaces in front of the circle
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck c_reduce[*]
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51388 1.51388 1.51388
+  surf      (ave,min,max) = 0.00535583 0.00535583 0.00535583
+  total     (ave,min,max) = 1.52082 1.52082 1.52082
+Step CPU Np Natt Ncoll Nscoll Nscheck c_reduce[1] c_reduce[2] c_reduce[3] c_reduce[4] 
+       0            0        0        0        0        0        0            0            0            0            0 
+     100  0.082910061    19692        0        0      282    32510        93.43 1.3933789e-18        19.25 3.5694713e-19 
+     200   0.24229193    31501        0        0      367    44152       125.11 1.7252863e-18        59.75 9.3608862e-19 
+     300     0.452178    36891        0        0      405    49430       125.29 1.7145248e-18        73.83 1.081233e-18 
+     400   0.67389202    39597        0        0      369    52242       126.15 1.7161244e-18        81.81 1.1657458e-18 
+     500   0.84556794    41001        0        0      400    54138       125.37 1.7152398e-18        83.24 1.1610165e-18 
+     600     1.015378    42010        0        0      453    55612       127.37 1.7523289e-18        84.47 1.1677749e-18 
+     700    1.1903341    42455        0        0      396    55268       126.98 1.762476e-18        86.65 1.1998715e-18 
+     800     1.364994    42837        0        0      436    55984       126.93  1.73758e-18        85.75 1.1921052e-18 
+     900    1.5391071    43231        0        0      412    55946       126.51 1.7170818e-18        88.08 1.2046001e-18 
+    1000    1.7134089    43609        0        0      392    56766       127.97 1.7675756e-18         86.2 1.1736408e-18 
+Loop time of 1.71342 on 1 procs for 1000 steps with 43609 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.2971     | 1.2971     | 1.2971     |   0.0 | 75.70
+Coll    | 0.18679    | 0.18679    | 0.18679    |   0.0 | 10.90
+Sort    | 0.13601    | 0.13601    | 0.13601    |   0.0 |  7.94
+Comm    | 0.0058208  | 0.0058208  | 0.0058208  |   0.0 |  0.34
+Modify  | 0.086764   | 0.086764   | 0.086764   |   0.0 |  5.06
+Output  | 0.00021577 | 0.00021577 | 0.00021577 |   0.0 |  0.01
+Other   |            | 0.0007439  |            |       |  0.04
+
+Particle moves    = 36457452 (36.5M)
+Cells touched     = 38742017 (38.7M)
+Particle comms    = 0 (0K)
+Boundary collides = 171685 (0.172M)
+Boundary exits    = 167142 (0.167M)
+SurfColl checks   = 48730470 (48.7M)
+SurfColl occurs   = 371258 (0.371M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+
+Particle-moves/CPUsec/proc: 2.12775e+07
+Particle-moves/step: 36457.5
+Cell-touches/particle/step: 1.06266
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00470919
+Particle fraction exiting boundary: 0.00458458
+Surface-checks/particle/step: 1.33664
+Surface-collisions/particle/step: 0.0101833
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 43609 ave 43609 max 43609 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    52 ave 52 max 52 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/circle/log.circle.transparent.6Nov19.g++.4
+++ b/examples/circle/log.circle.transparent.6Nov19.g++.4
@@ -1,0 +1,190 @@
+SPARTA (15 Oct 2019)
+# 2d flow around a circle with transparent surfaces in front to tally stats
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (../grid.cpp:415)
+Created 100 child grid cells
+  parent cells = 1
+  CPU time = 0.00218391 secs
+  create/ghost percent = 94.869 5.131
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000758171 secs
+  reassign/sort/migrate/ghost percent = 62.7987 0.251572 19.1195 17.8302
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+# data.circle = regular surface particles flow around
+# data.plane1 = line segment with normal into flow
+# data.plane2 = line segment with normal towards circle
+# the two line segments are on top of each other
+
+read_surf           data.circle group circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 = cells with surfs
+  80 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.376743 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000869036 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.3978 16.4335 2.41427 34.0741 16.6804 11.7421 0.219479
+  surf2grid time = 0.000296116 secs
+  map/rvous1/rvous2/split percent = 4.7504 44.525 0.724638 24.3156
+read_surf           data.plane1 group plane1 transparent
+  2 points
+  51 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  38 = cells with surfs
+  96 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.376743 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000365973 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.0879 20 1.04235 39.6743 20.1954 20.1954 0.586319
+  surf2grid time = 0.000145197 secs
+  map/rvous1/rvous2/split percent = 7.55337 33.6617 1.47783 26.7652
+read_surf           data.plane2 group plane2 transparent
+  2 points
+  52 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  38 = cells with surfs
+  112 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.376743 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000359058 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 18.9243 18.1275 5.84329 37.3174 19.7875 20.5843 0.531208
+  surf2grid time = 0.000133991 secs
+  map/rvous1/rvous2/split percent = 8.18505 29.8932 1.60142 26.1566
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_collide	    2 transparent
+
+surf_modify         circle collide 1
+surf_modify         plane1 collide 2
+surf_modify         plane2 collide 2
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo # subsonic 0.1 NULL
+
+compute             plane1 surf plane1 all n ke
+compute             plane2 surf plane2 all n ke
+fix                 plane1 ave/surf plane1 1 100 100 c_plane1[*]
+fix                 plane2 ave/surf plane2 1 100 100 c_plane2[*]
+compute             reduce reduce sum f_plane1[*] f_plane2[*]
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+# the last 4 columns are the particle count and energy flux
+# through the 2 transparent surfaces in front of the circle
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck c_reduce[*]
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51388 1.51388 1.51388
+  surf      (ave,min,max) = 0.00535583 0.00535583 0.00535583
+  total     (ave,min,max) = 1.51963 1.51963 1.51963
+Step CPU Np Natt Ncoll Nscoll Nscheck c_reduce[1] c_reduce[2] c_reduce[3] c_reduce[4] 
+       0            0        0        0        0        0        0            0            0            0            0 
+     100  0.049607038    19643        0        0      288    32434        92.91 1.3805983e-18        18.87 3.5421381e-19 
+     200   0.12602401    31526        0        0      319    44028       125.03 1.7094225e-18        59.31 9.1767206e-19 
+     300   0.21617913    36797        0        0      367    49460       126.23 1.7248074e-18         75.4 1.0941747e-18 
+     400   0.31301808    39440        0        0      394    51600       126.13 1.726495e-18        81.87  1.17386e-18 
+     500   0.41380715    41071        0        0      413    54392        125.8 1.7259964e-18        82.76 1.1592852e-18 
+     600   0.51655507    42005        0        0      407    54376       126.17 1.7217056e-18        84.81 1.1743096e-18 
+     700   0.62295508    42605        0        0      403    55450       127.08 1.7136366e-18        85.01 1.1623534e-18 
+     800   0.71614313    43022        0        0      400    55684        126.1 1.7172872e-18        86.68 1.1832143e-18 
+     900   0.79538703    43221        0        0      438    56562       127.82 1.7401223e-18        86.08 1.1745235e-18 
+    1000     0.876899    43425        0        0      442    56658       127.53 1.746672e-18        87.85 1.2034453e-18 
+Loop time of 0.876934 on 4 procs for 1000 steps with 43425 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.075398   | 0.363      | 0.66532    |  47.6 | 41.39
+Coll    | 0.0091157  | 0.035868   | 0.063618   |  14.1 |  4.09
+Sort    | 0.014283   | 0.034606   | 0.055075   |  10.8 |  3.95
+Comm    | 0.019723   | 0.020726   | 0.022205   |   0.7 |  2.36
+Modify  | 0.001709   | 0.025203   | 0.050265   |  14.8 |  2.87
+Output  | 0.00020289 | 0.0002377  | 0.00032115 |   0.0 |  0.03
+Other   |            | 0.3973     |            |       | 45.31
+
+Particle moves    = 36474413 (36.5M)
+Cells touched     = 38762161 (38.8M)
+Particle comms    = 141871 (0.142M)
+Boundary collides = 171800 (0.172M)
+Boundary exits    = 167251 (0.167M)
+SurfColl checks   = 48727886 (48.7M)
+SurfColl occurs   = 371315 (0.371M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+
+Particle-moves/CPUsec/proc: 1.03983e+07
+Particle-moves/step: 36474.4
+Cell-touches/particle/step: 1.06272
+Particle comm iterations/step: 1.998
+Particle fraction communicated: 0.0038896
+Particle fraction colliding with boundary: 0.00471015
+Particle fraction exiting boundary: 0.00458543
+Surface-checks/particle/step: 1.33595
+Surface-collisions/particle/step: 0.0101802
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10856.2 ave 16703 max 5039 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    52 ave 52 max 52 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -116,6 +116,8 @@ action surf_collide_specular_kokkos.cpp
 action surf_collide_specular_kokkos.h
 action surf_collide_vanish_kokkos.cpp
 action surf_collide_vanish_kokkos.h
+action surf_collide_transparent_kokkos.cpp
+action surf_collide_transparent_kokkos.h
 action surf_kokkos.cpp
 action surf_kokkos.h
 action update_kokkos.cpp

--- a/src/KOKKOS/surf_collide_transparent_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.cpp
@@ -1,0 +1,67 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "math.h"
+#include "surf_collide_transparent_kokkos.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+SurfCollideTransparentKokkos::SurfCollideTransparentKokkos(SPARTA *sparta, int narg, char **arg) :
+  SurfCollideTransparent(sparta, narg, arg)
+{
+  k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
+  d_nsingle = k_nsingle.view<DeviceType>();
+  h_nsingle = k_nsingle.h_view;
+}
+
+SurfCollideTransparentKokkos::SurfCollideTransparentKokkos(SPARTA *sparta) :
+  SurfCollideTransparent(sparta)
+{
+  // ID and style
+  // ID must be all alphanumeric chars or underscores
+
+  int narg = 2;
+  const char* arg[] = {"sc_kk_transparent_copy","transparent"};
+
+  int n = strlen(arg[0]) + 1;
+  id = new char[n];
+  strcpy(id,arg[0]);
+
+  for (int i = 0; i < n-1; i++)
+    if (!isalnum(id[i]) && id[i] != '_')
+      error->all(FLERR,"Surf_collide ID must be alphanumeric or "
+                 "underscore characters");
+
+  n = strlen(arg[1]) + 1;
+  style = new char[n];
+  strcpy(style,arg[1]);
+
+  vector_flag = 1;
+  size_vector = 2;
+    
+  nsingle = ntotal = 0;
+
+  copy = 0;
+
+  if (narg != 2) error->all(FLERR,"Illegal surf_collide transparent command");
+
+  transparent = 1;
+
+  k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
+  d_nsingle = k_nsingle.view<DeviceType>();
+  h_nsingle = k_nsingle.h_view;
+}

--- a/src/KOKKOS/surf_collide_transparent_kokkos.h
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.h
@@ -52,6 +52,8 @@ class SurfCollideTransparentKokkos : public SurfCollideTransparent {
   collide_kokkos(Particle::OnePart *&ip, const double *, double &, int, int&) const
   {
     Kokkos::atomic_fetch_add(&d_nsingle(),1);
+
+    return NULL;
   }
 };
 

--- a/src/KOKKOS/surf_collide_transparent_kokkos.h
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.h
@@ -1,0 +1,71 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef SURF_COLLIDE_CLASS
+
+SurfCollideStyle(transparent/kk,SurfCollideTransparentKokkos)
+
+#else
+
+#ifndef SPARTA_SURF_COLLIDE_TRANSPARENT_KOKKOS_H
+#define SPARTA_SURF_COLLIDE_TRANSPARENT_KOKKOS_H
+
+#include "surf_collide_transparent.h"
+#include "kokkos_type.h"
+
+namespace SPARTA_NS {
+
+class SurfCollideTransparentKokkos : public SurfCollideTransparent {
+ public:
+  typedef ArrayTypes<DeviceType> AT;
+
+  SurfCollideTransparentKokkos(class SPARTA *, int, char **);
+  SurfCollideTransparentKokkos(class SPARTA *);
+  ~SurfCollideTransparentKokkos() {}
+  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int) { return NULL; }
+
+  DAT::tdual_int_scalar k_nsingle;
+  typename AT::t_int_scalar d_nsingle;
+  HAT::t_int_scalar h_nsingle;
+
+  /* ----------------------------------------------------------------------
+     particle collision with surface with optional chemistry
+     ip = particle with current x = collision pt, current v = incident v
+     norm = surface normal unit vector
+     simply return ip = NULL to delete particle
+     return reaction = 0 = no reaction took place
+  ------------------------------------------------------------------------- */
+  
+  KOKKOS_INLINE_FUNCTION
+  Particle::OnePart*
+  collide_kokkos(Particle::OnePart *&ip, const double *, double &, int, int&) const
+  {
+    Kokkos::atomic_fetch_add(&d_nsingle(),1);
+  }
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running SPARTA to see the offending line.
+
+*/

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -425,7 +425,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
 
     if (surf->nsc > 0) {
       int nspec,ndiff,nvan,npist,ntrans;
-      nspec = ndiff = nvan = npist = 0;
+      nspec = ndiff = nvan = npist = ntrans = 0;
       for (int n = 0; n < surf->nsc; n++) {
         if (strcmp(surf->sc[n]->style,"specular") == 0) {
           sc_kk_specular_copy[nspec].copy((SurfCollideSpecularKokkos*)(surf->sc[n]));

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -76,6 +76,7 @@ UpdateKokkos::UpdateKokkos(SPARTA *sparta) : Update(sparta),
   sc_kk_diffuse_copy{VAL_2(KKCopy<SurfCollideDiffuseKokkos>(sparta))},
   sc_kk_vanish_copy{VAL_2(KKCopy<SurfCollideVanishKokkos>(sparta))},
   sc_kk_piston_copy{VAL_2(KKCopy<SurfCollidePistonKokkos>(sparta))},
+  sc_kk_transparent_copy{VAL_2(KKCopy<SurfCollideTransparentKokkos>(sparta))},
   blist_active_copy{VAL_2(KKCopy<ComputeBoundaryKokkos>(sparta))},
   slist_active_copy{VAL_2(KKCopy<ComputeSurfKokkos>(sparta))}
 {
@@ -129,6 +130,7 @@ UpdateKokkos::~UpdateKokkos()
     sc_kk_diffuse_copy[i].uncopy();
     sc_kk_vanish_copy[i].uncopy();
     sc_kk_piston_copy[i].uncopy();
+    sc_kk_transparent_copy[i].uncopy();
   }
 
   for (int i=0; i<KOKKOS_MAX_BLIST; i++) {
@@ -422,7 +424,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
       error->all(FLERR,"Kokkos currently supports two instances of each surface collide method");
 
     if (surf->nsc > 0) {
-      int nspec,ndiff,nvan,npist;
+      int nspec,ndiff,nvan,npist,ntrans;
       nspec = ndiff = nvan = npist = 0;
       for (int n = 0; n < surf->nsc; n++) {
         if (strcmp(surf->sc[n]->style,"specular") == 0) {
@@ -446,11 +448,18 @@ template < int DIM, int SURF > void UpdateKokkos::move()
           sc_type_list[n] = 3;
           sc_map[n] = npist;
           npist++;
+        } else if (strcmp(surf->sc[n]->style,"transparent") == 0) {
+          sc_kk_transparent_copy[ntrans].copy((SurfCollideTransparentKokkos*)(surf->sc[n]));
+          sc_type_list[n] = 4;
+          sc_map[n] = ntrans;
+          ntrans++;
         } else {
           error->all(FLERR,"Unknown Kokkos surface collide method");
         }
       }
-      if (nspec > KOKKOS_MAX_SURF_COLL_PER_TYPE || ndiff > KOKKOS_MAX_SURF_COLL_PER_TYPE || nvan > KOKKOS_MAX_SURF_COLL_PER_TYPE)
+      if (nspec > KOKKOS_MAX_SURF_COLL_PER_TYPE || ndiff > KOKKOS_MAX_SURF_COLL_PER_TYPE ||
+          nvan > KOKKOS_MAX_SURF_COLL_PER_TYPE || npist > KOKKOS_MAX_SURF_COLL_PER_TYPE ||
+          ntrans > KOKKOS_MAX_SURF_COLL_PER_TYPE)
         error->all(FLERR,"Kokkos currently supports two instances of each surface collide method");
     }
 
@@ -972,6 +981,9 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
             else if (sc_type == 3)
               jpart = sc_kk_piston_copy[m].obj.
                 collide_kokkos(ipart,tri->norm,dtremain,tri->isr,reaction);/////
+            else if (sc_type == 4)
+              jpart = sc_kk_transparent_copy[m].obj.
+                collide_kokkos(ipart,tri->norm,dtremain,tri->isr,reaction);/////
           if (DIM != 3)
             if (sc_type == 0)
               jpart = sc_kk_specular_copy[m].obj.
@@ -984,6 +996,9 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
                 collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
             else if (sc_type == 3)
               jpart = sc_kk_piston_copy[m].obj.
+                collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
+            else if (sc_type == 4)
+              jpart = sc_kk_transparent_copy[m].obj.
                 collide_kokkos(ipart,line->norm,dtremain,line->isr,reaction);////
 
           ////Need to error out for now if surface reactions create (or destroy?) particles////
@@ -1175,6 +1190,9 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
             collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
         else if (sc_type == 3)
           jpart = sc_kk_piston_copy[m].obj.
+            collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
+        else if (sc_type == 4)
+          jpart = sc_kk_transparent_copy[m].obj.
             collide_kokkos(ipart,domain_kk_copy.obj.norm[outface],dtremain,domain_kk_copy.obj.surf_react[outface],reaction);/////
 
         if (ipart) {

--- a/src/KOKKOS/update_kokkos.h
+++ b/src/KOKKOS/update_kokkos.h
@@ -25,6 +25,7 @@
 #include "surf_collide_specular_kokkos.h"
 #include "surf_collide_vanish_kokkos.h"
 #include "surf_collide_piston_kokkos.h"
+#include "surf_collide_transparent_kokkos.h"
 #include "compute_boundary_kokkos.h"
 #include "compute_surf_kokkos.h"
 
@@ -131,6 +132,7 @@ class UpdateKokkos : public Update {
   KKCopy<SurfCollideDiffuseKokkos> sc_kk_diffuse_copy[KOKKOS_MAX_SURF_COLL_PER_TYPE];
   KKCopy<SurfCollideVanishKokkos> sc_kk_vanish_copy[KOKKOS_MAX_SURF_COLL_PER_TYPE];
   KKCopy<SurfCollidePistonKokkos> sc_kk_piston_copy[KOKKOS_MAX_SURF_COLL_PER_TYPE];
+  KKCopy<SurfCollideTransparentKokkos> sc_kk_transparent_copy[KOKKOS_MAX_SURF_COLL_PER_TYPE];
   KKCopy<ComputeBoundaryKokkos> blist_active_copy[KOKKOS_MAX_BLIST];
   KKCopy<ComputeSurfKokkos> slist_active_copy[KOKKOS_MAX_SLIST];
 

--- a/src/cut2d.cpp
+++ b/src/cut2d.cpp
@@ -498,6 +498,7 @@ int Cut2d::split_face(int id_caller, int, double *onelo, double *onehi)
 
 /* ----------------------------------------------------------------------
    create clines = list of lines clipped to cell
+   skip transparent surfs
 ------------------------------------------------------------------------- */
 
 int Cut2d::build_clines()
@@ -521,6 +522,7 @@ int Cut2d::build_clines()
   for (int i = 0; i < nsurf; i++) {
     m = surfs[i];
     line = &lines[m];
+    if (line->transparent) continue;
     memcpy(p1,line->p1,2*sizeof(double));
     memcpy(p2,line->p2,2*sizeof(double));
 

--- a/src/cut3d.cpp
+++ b/src/cut3d.cpp
@@ -662,6 +662,7 @@ int Cut3d::split(cellint id_caller, double *lo_caller, double *hi_caller,
 /* ----------------------------------------------------------------------
    add each triangle as vertex and edges to BPG
    add full edge even if outside cell, clipping comes later
+   skip transparent surfs
 ------------------------------------------------------------------------- */
 
 int Cut3d::add_tris()
@@ -684,6 +685,7 @@ int Cut3d::add_tris()
   for (i = 0; i < nsurf; i++) {
     m = surfs[i];
     tri = &tris[m];
+    if (tri->transparent) continue;
     memcpy(p1,tri->p1,3*sizeof(double));
     memcpy(p2,tri->p2,3*sizeof(double));
     memcpy(p3,tri->p3,3*sizeof(double));

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1215,6 +1215,15 @@ void Grid::set_inout()
     error->all(FLERR,"Cannot mark grid cells as inside/outside surfs because "
                "ghost cells do not exist");
 
+  // if all surfs are transparent, just mark all cells as OUTSIDE
+
+  if (surf->all_transparent()) {
+    for (icell = 0; icell < nlocal; icell++) cinfo[icell].type = OUTSIDE;
+    return;
+  }
+
+  // set dimensional dependent quantities
+
   int faceflip[6] = {XHI,XLO,YHI,YLO,ZHI,ZLO};
 
   int me = comm->me;

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -108,19 +108,12 @@ void Grid::surf2grid_cell_algorithm(int outflag)
   if (dim == 3) cut3d = new Cut3d(sparta);
   else cut2d = new Cut2d(sparta,domain->axisymmetric);
 
-  Surf::Line *surf_lines;
-  Surf::Tri *surf_tris;
-  if (surf->distributed) {
-    surf_lines = surf->mylines;
-    surf_tris = surf->mytris;
-  } else {
-    surf_lines = surf->lines;
-    surf_tris = surf->tris;
-  }
-
   // compute overlap of surfs with each cell I own
   // info stored in nsurf,csurfs
   // skip if nsplit <= 0 b/c split cells could exist if restarting
+
+  Surf::Line *lines = surf->lines;
+  Surf::Tri *tris = surf->tris;
 
   int max = 0;
   
@@ -155,12 +148,12 @@ void Grid::surf2grid_cell_algorithm(int outflag)
       if (dim == 2) {
  
         for (i = 0; i < nsurf; i++) {
-          if (!surf_lines[ptr[i]].transparent) nontrans = 1;
+          if (!lines[ptr[i]].transparent) nontrans = 1;
           break;
         }
       } else {
         for (i = 0; i < nsurf; i++) {
-          if (!surf_tris[ptr[i]].transparent) nontrans = 1;
+          if (!tris[ptr[i]].transparent) nontrans = 1;
           break;
         }
       }
@@ -411,6 +404,9 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
       cells[icell].csurfs[cells[icell].nsurf++] = outbuf[m].surfID;
     }
 
+    Surf::Line *lines = surf->lines;
+    Surf::Tri *tris = surf->tris;
+
     for (icell = 0; icell < nlocal; icell++)
       if (cells[icell].nsurf) {
 
@@ -422,12 +418,12 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
 
         if (dim == 2) {
           for (i = 0; i < n; i++) {
-            if (!surf_lines[list[i]].transparent) nontrans = 1;
+            if (!lines[list[i]].transparent) nontrans = 1;
             break;
           }
         } else {
           for (i = 0; i < n; i++) {
-            if (!surf_tris[list[i]].transparent) nontrans = 1;
+            if (!tris[list[i]].transparent) nontrans = 1;
             break;
           }
         }
@@ -523,14 +519,15 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
 
     // reset Surf hash to point to surf list in lines/tris
 
+    Surf::Line *lines = surf->lines;
+    Surf::Tri *tris = surf->tris;
+
     if (dim == 2) {
-      Surf::Line *lines = surf->lines;
       for (i = 0; i < nreturn2; i++) {
         surfID = lines[i].id;
         shash[surfID] = i;
       }
     } else {
-      Surf::Tri *tris = surf->tris;
       for (i = 0; i < nreturn2; i++) {
         surfID = tris[i].id;
         shash[surfID] = i;
@@ -558,12 +555,12 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
 
         if (dim == 2) {
           for (i = 0; i < n; i++) {
-            if (!surf_lines[list[i]].transparent) nontrans = 1;
+            if (!lines[list[i]].transparent) nontrans = 1;
             break;
           }
         } else {
           for (i = 0; i < n; i++) {
-            if (!surf_tris[list[i]].transparent) nontrans = 1;
+            if (!tris[list[i]].transparent) nontrans = 1;
             break;
           }
         }

--- a/src/read_surf.cpp
+++ b/src/read_surf.cpp
@@ -1293,6 +1293,10 @@ void ReadSurf::process_args(int start, int narg, char **arg)
       else error->all(FLERR,"Invalid read_surf command");
       iarg += 2;
 
+    } else if (strcmp(arg[iarg],"transparent") == 0) {
+      transparent();
+      iarg++;
+
     // file must be last keyword, else WriteSurf will flag error
 
     } else if (strcmp(arg[iarg],"file") == 0) {
@@ -1963,6 +1967,30 @@ void ReadSurf::clip3d()
   if (me == 0) {
     if (screen) fprintf(screen,"  clipped to " BIGINT_FORMAT " tris\n",delta);
     if (logfile) fprintf(logfile,"  clipped to " BIGINT_FORMAT " tris\n",delta);
+  }
+}
+
+/* ----------------------------------------------------------------------
+   set transparent flag of all surface elements read in
+------------------------------------------------------------------------- */
+
+void ReadSurf::transparent()
+{
+  if (dim == 2) {
+    Surf::Line *lines;
+    if (distributed) lines = surf->mylines;
+    else lines = surf->lines;
+
+    for (int i = nsurf_old; i < nsurf_new; i++)
+      lines[i].transparent = 1;
+
+  } else if (dim == 3) {
+    Surf::Tri *tris;
+    if (distributed) tris = surf->mytris;
+    else tris = surf->tris;
+
+    for (int i = nsurf_old; i < nsurf_new; i++)
+      tris[i].transparent = 1;
   }
 }
 

--- a/src/read_surf.h
+++ b/src/read_surf.h
@@ -97,6 +97,7 @@ class ReadSurf : protected Pointers {
   void invert();
   void clip2d();
   void clip3d();
+  void transparent();
 
   void check_consecutive();
   void push_points_to_boundary(double);

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -208,7 +208,7 @@ void Surf::init()
       error->warning(FLERR,"Surfs are distributed with infinite grid cutoff");
 
   // check that every element is assigned to a surf collision model
-  // skip if caller turned off the check, e.g. BalanceGrid
+  // skip if caller turned off the check, e.g. BalanceGrid, b/c too early
 
   int dim = domain->dimension;
   bigint flag,allflag;
@@ -260,7 +260,40 @@ void Surf::init()
               "but invalid collision model",allflag);
       error->all(FLERR,str);
     }
-  }    
+  }
+
+  // checks on transparent surfaces
+  // must be assigned to transparent surf collision model
+  // must not be assigned to any surf reaction model
+
+  if (surf_collision_check) {
+    flag = 0;
+    if (dim == 2) {
+      for (int i = 0; i < nlocal+nghost; i++) {
+        if (!lines[i].transparent) continue;
+        if (!sc[lines[i].isc]->transparent) flag++;
+        if (lines[i].isr >= 0) flag++;
+      }
+    } 
+    if (dim == 3) {
+      for (int i = 0; i < nlocal+nghost; i++) {
+        if (!tris[i].transparent) continue;
+        if (!sc[tris[i].isc]->transparent) flag++;
+        if (tris[i].isr >= 0) flag++;
+      }
+    } 
+
+    if (distributed)
+      MPI_Allreduce(&flag,&allflag,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
+    else allflag = flag;
+
+    if (allflag) {
+      char str[64];
+      sprintf(str,BIGINT_FORMAT " transparent surface elements "
+              "with invalid collision model or reaction model",allflag);
+      error->all(FLERR,str);
+    }
+  }
 
   // initialize surf collision and reaction models
 
@@ -315,6 +348,7 @@ void Surf::add_line(surfint id, int itype, double *p1, double *p2)
   lines[nlocal].p2[0] = p2[0];
   lines[nlocal].p2[1] = p2[1];
   lines[nlocal].p2[2] = 0.0;
+  lines[nlocal].transparent = 0;
   nlocal++;
 }
 
@@ -373,6 +407,7 @@ void Surf::add_line_own(surfint id, int itype, double *p1, double *p2)
   mylines[m].p2[0] = p2[0];
   mylines[m].p2[1] = p2[1];
   mylines[m].p2[2] = 0.0;
+  mylines[m].transparent = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -399,6 +434,7 @@ void Surf::add_line_temporary(surfint id, int itype, double *p1, double *p2)
   tmplines[ntmp].p2[0] = p2[0];
   tmplines[ntmp].p2[1] = p2[1];
   tmplines[ntmp].p2[2] = 0.0;
+  tmplines[ntmp].transparent = 0;
   ntmp++;
 }
 
@@ -430,38 +466,8 @@ void Surf::add_tri(surfint id, int itype, double *p1, double *p2, double *p3)
   tris[nlocal].p3[0] = p3[0];
   tris[nlocal].p3[1] = p3[1];
   tris[nlocal].p3[2] = p3[2];
+  tris[nlocal].transparent = 0;
   nlocal++;
-}
-
-/* ----------------------------------------------------------------------
-   add a triangle to tmptris list
-   called by ReadSurf for mutliple file input
-------------------------------------------------------------------------- */
-
-void Surf::add_tri_temporary(surfint id, int itype, 
-                             double *p1, double *p2, double *p3)
-{
-  if (ntmp == nmaxtmp) {
-    if ((bigint) nmaxtmp + DELTA > MAXSMALLINT)
-      error->one(FLERR,"Surf add_tri_temporary overflowed");
-    nmaxtmp += DELTA;
-    grow_temporary(nmaxtmp-DELTA);
-  }
-
-  tmptris[ntmp].id = id;
-  tmptris[ntmp].type = itype;
-  tmptris[ntmp].mask = 1;
-  tmptris[ntmp].isc = tmptris[ntmp].isr = -1;
-  tmptris[ntmp].p1[0] = p1[0];
-  tmptris[ntmp].p1[1] = p1[1];
-  tmptris[ntmp].p1[2] = p1[2];
-  tmptris[ntmp].p2[0] = p2[0];
-  tmptris[ntmp].p2[1] = p2[1];
-  tmptris[ntmp].p2[2] = p2[2];
-  tmptris[ntmp].p3[0] = p3[0];
-  tmptris[ntmp].p3[1] = p3[1];
-  tmptris[ntmp].p3[2] = p3[2];
-  ntmp++;
 }
 
 /* ----------------------------------------------------------------------
@@ -522,6 +528,7 @@ void Surf::add_tri_own(surfint id, int itype, double *p1, double *p2, double *p3
   mytris[m].p3[0] = p3[0];
   mytris[m].p3[1] = p3[1];
   mytris[m].p3[2] = p3[2];
+  mytris[m].transparent = 0;
 }
 
 /* ----------------------------------------------------------------------
@@ -556,9 +563,42 @@ void Surf::add_tri_own_clip(surfint id, int itype,
   mytris[nown].p3[0] = p3[0];
   mytris[nown].p3[1] = p3[1];
   mytris[nown].p3[2] = p3[2];
-
+  mytris[nown].transparent = 0;
   nown++;
 }
+
+/* ----------------------------------------------------------------------
+   add a triangle to tmptris list
+   called by ReadSurf for mutliple file input
+------------------------------------------------------------------------- */
+
+void Surf::add_tri_temporary(surfint id, int itype, 
+                             double *p1, double *p2, double *p3)
+{
+  if (ntmp == nmaxtmp) {
+    if ((bigint) nmaxtmp + DELTA > MAXSMALLINT)
+      error->one(FLERR,"Surf add_tri_temporary overflowed");
+    nmaxtmp += DELTA;
+    grow_temporary(nmaxtmp-DELTA);
+  }
+
+  tmptris[ntmp].id = id;
+  tmptris[ntmp].type = itype;
+  tmptris[ntmp].mask = 1;
+  tmptris[ntmp].isc = tmptris[ntmp].isr = -1;
+  tmptris[ntmp].p1[0] = p1[0];
+  tmptris[ntmp].p1[1] = p1[1];
+  tmptris[ntmp].p1[2] = p1[2];
+  tmptris[ntmp].p2[0] = p2[0];
+  tmptris[ntmp].p2[1] = p2[1];
+  tmptris[ntmp].p2[2] = p2[2];
+  tmptris[ntmp].p3[0] = p3[0];
+  tmptris[ntmp].p3[1] = p3[1];
+  tmptris[ntmp].p3[2] = p3[2];
+  tmptris[ntmp].transparent = 0;
+  ntmp++;
+}
+
 
 /* ----------------------------------------------------------------------
    hash all my nlocal surfs with key = ID, value = index
@@ -882,6 +922,7 @@ void Surf::check_watertight_2d_all()
 
   int ndup = 0;
   for (int i = 0; i < nsurf; i++) {
+    if (lines[i].transparent) continue;
     p1 = lines[i].p1;
     key.pt[0] = p1[0]; key.pt[1] = p1[1];
     if (phash.find(key) == phash.end()) phash[key] = 1;
@@ -1110,6 +1151,7 @@ void Surf::check_watertight_3d_all()
 
   int ndup = 0;
   for (int i = 0; i < nsurf; i++) {
+    if (tris[i].transparent) continue;
     p1 = tris[i].p1;
     p2 = tris[i].p2;
     p3 = tris[i].p3;
@@ -1487,6 +1529,8 @@ void Surf::check_point_near_surf_2d()
     csurfs = cells[icell].csurfs;
     for (i = 0; i < n; i++) {
       line = &lines[csurfs[i]];
+      // skip transparent surf elements
+      if (line->transparent) continue;
       for (j = 0; j < n; j++) {
         if (i == j) continue;
         p1 = lines[csurfs[j]].p1;
@@ -1549,6 +1593,8 @@ void Surf::check_point_near_surf_3d()
     csurfs = cells[icell].csurfs;
     for (i = 0; i < n; i++) {
       tri = &tris[csurfs[i]];
+      // skip transparent surf elements
+      if (tri->transparent) continue;
       for (j = 0; j < n; j++) {
         if (i == j) continue;
         p1 = tris[csurfs[j]].p1;

--- a/src/surf.h
+++ b/src/surf.h
@@ -161,6 +161,8 @@ class Surf : protected Pointers {
   void add_tri_own_clip(surfint, int, double *, double *, double *);
   void add_tri_temporary(surfint, int, double *, double *, double *);
   void rehash();
+  int all_transparent();
+
   void setup_owned();
   void setup_bbox();
 

--- a/src/surf.h
+++ b/src/surf.h
@@ -65,6 +65,7 @@ class Surf : protected Pointers {
     double p1[3],p2[3];     // end points of line segment
                             // rhand rule: Z x (p2-p1) = outward normal
     double norm[3];         // outward normal to line segment
+    int transparent;        // 1 if surf is transparent
   };
 
   struct Tri {
@@ -76,6 +77,7 @@ class Surf : protected Pointers {
     double p1[3],p2[3],p3[3];  // corner points of triangle
                             // rhand rule: (p2-p1) x (p3-p1) = outward normal
     double norm[3];         // outward normal to triangle
+    int transparent;        // 1 if surf is transparent
   };
 
   Line *lines;              // list of lines for surface collisions

--- a/src/surf_collide.cpp
+++ b/src/surf_collide.cpp
@@ -43,6 +43,7 @@ SurfCollide::SurfCollide(SPARTA *sparta, int, char **arg) :
 
   dynamicflag = 0;
   allowreact = 0;
+  transparent = 0;
   vector_flag = 1;
   size_vector = 2;
     

--- a/src/surf_collide.h
+++ b/src/surf_collide.h
@@ -27,6 +27,7 @@ class SurfCollide : protected Pointers {
  
   int dynamicflag;          // 1 if any param is dynamically updated
   int allowreact;           // 1 if allows for surface reactions
+  int transparent;          // 1 if transparent collision model
   int vector_flag;          // 0/1 if compute_vector() function exists
   int size_vector;          // length of global vector
 

--- a/src/surf_collide_transparent.cpp
+++ b/src/surf_collide_transparent.cpp
@@ -39,7 +39,7 @@ SurfCollideTransparent(SPARTA *sparta, int narg, char **arg) :
 ------------------------------------------------------------------------- */
 
 Particle::OnePart *SurfCollideTransparent::
-collide(Particle::OnePart *&ip, double *, double &, int)
+collide(Particle::OnePart *&ip, double *, double &, int, int &)
 {
   nsingle++;
 

--- a/src/surf_collide_transparent.cpp
+++ b/src/surf_collide_transparent.cpp
@@ -1,0 +1,47 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "math.h"
+#include "string.h"
+#include "surf_collide_transparent.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+SurfCollideTransparent::
+SurfCollideTransparent(SPARTA *sparta, int narg, char **arg) :
+  SurfCollide(sparta, narg, arg)
+{
+  if (narg != 2) error->all(FLERR,"Illegal surf_collide transparent command");
+
+  transparent = 1;
+}
+
+/* ----------------------------------------------------------------------
+   particle collision with surface with optional chemistry
+   ip = particle with current x = collision pt, current v = incident v
+   norm = surface normal unit vector
+   isr = index of reaction model if >= 0, -1 for no chemistry
+   simply return ip = NULL to delete particle
+------------------------------------------------------------------------- */
+
+Particle::OnePart *SurfCollideTransparent::
+collide(Particle::OnePart *&ip, double *, double &, int)
+{
+  nsingle++;
+
+  return NULL;
+}

--- a/src/surf_collide_transparent.h
+++ b/src/surf_collide_transparent.h
@@ -1,0 +1,50 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under 
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef SURF_COLLIDE_CLASS
+
+SurfCollideStyle(transparent,SurfCollideTransparent)
+
+#else
+
+#ifndef SPARTA_SURF_COLLIDE_TRANSPARENT_H
+#define SPARTA_SURF_COLLIDE_TRANSPARENT_H
+
+#include "surf_collide.h"
+#include "particle.h"
+
+namespace SPARTA_NS {
+
+class SurfCollideTransparent : public SurfCollide {
+ public:
+  SurfCollideTransparent(class SPARTA *, int, char **);
+  SurfCollideTransparent(class SPARTA *sparta) : SurfCollide(sparta) {}
+  virtual ~SurfCollideTransparent() {}
+  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running SPARTA to see the offending line.
+
+*/

--- a/src/surf_collide_transparent.h
+++ b/src/surf_collide_transparent.h
@@ -31,7 +31,8 @@ class SurfCollideTransparent : public SurfCollide {
   SurfCollideTransparent(class SPARTA *, int, char **);
   SurfCollideTransparent(class SPARTA *sparta) : SurfCollide(sparta) {}
   virtual ~SurfCollideTransparent() {}
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int);
+  Particle::OnePart *collide(Particle::OnePart *&, double *, 
+                             double &, int, int &);
 };
 
 }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -57,11 +57,11 @@ enum{PERAUTO,PERCELL,PERSURF};                  // several files
 
 // either set ID or PROC/INDEX, set other to -1
 
-#define MOVE_DEBUG 1              // un-comment to debug one particle
-#define MOVE_DEBUG_ID 316507228  // particle ID
+//#define MOVE_DEBUG 1              // un-comment to debug one particle
+#define MOVE_DEBUG_ID 707672596  // particle ID
 #define MOVE_DEBUG_PROC -1        // owning proc
 #define MOVE_DEBUG_INDEX -1   // particle index on owning proc
-#define MOVE_DEBUG_STEP 505    // timestep
+#define MOVE_DEBUG_STEP 94    // timestep
 
 /* ---------------------------------------------------------------------- */
 
@@ -798,31 +798,6 @@ template < int DIM, int SURF > void Update::move()
 #endif
               
               if (hitflag && param < minparam && side == OUTSIDE) {
-
-                // NOTE: these were the old checks
-                //       think it is now sufficient to test for particle
-                //       in an INSIDE cell in fix grid/check
-
-              //if (hitflag && side != ONSURF2OUT && param <= minparam) {
-
-                // this if test is to avoid case where particle
-                // previously hit 1 of 2 (or more) touching angled surfs at
-                // common edge/corner, on this iteration first surf
-                // is excluded, but others may be hit on inside:
-                // param will be epsilon and exclude must be set
-                // skip the hits of other touching surfs
-
-                //if (side == INSIDE && param < EPSPARAM && exclude >= 0) 
-                // continue;
-
-                // this if test is to avoid case where particle
-                // hits 2 touching angled surfs at common edge/corner
-                // from far away:
-                // param is same, but hits one on outside, one on inside
-                // only keep surf hit on outside
-
-                //if (param == minparam && side == INSIDE) continue;
-
                 cflag = 1;
                 minparam = param;
                 minside = side;
@@ -841,16 +816,6 @@ template < int DIM, int SURF > void Update::move()
             nscheck_one += nsurf;
             
             if (cflag) {
-              // NOTE: this check is no longer needed?
-              if (minside == INSIDE) {
-                char str[128];
-                sprintf(str,
-                        "Particle %d on proc %d hit inside of "
-                        "surf %d on step " BIGINT_FORMAT,
-                        i,me,minsurf,update->ntimestep);
-                error->one(FLERR,str);
-              }
-
               if (DIM == 3) tri = &tris[minsurf];
               if (DIM != 3) line = &lines[minsurf];
 


### PR DESCRIPTION
## Purpose

Add option to make sets of surface elements transparent.  I.e. particles just pass thru them,  The purpose is to allow statistics about the flow to be tallied for there surfaces.  New options for these commands: read_surf transparent, surf_collide transparent, compute surf.  Also a new example script in examples/circle.

## Author(s)

Steve

## Backward Compatibility

Shouldn't change existing non-transparent surfs.  But regression testing should be done.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


