### PR TITLE
Fix issue with Kokkos irregular class

### DIFF
--- a/src/KOKKOS/irregular_kokkos.cpp
+++ b/src/KOKKOS/irregular_kokkos.cpp
@@ -373,6 +373,8 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
   if (sendmax*nbytes > bufmax) {
     bufmax = sendmax*nbytes;
     d_buf = DAT::t_char_1d("Irregular:buf",bufmax);
+  } else if (d_buf.extent(0) < bufmax) {
+    d_buf = DAT::t_char_1d("Irregular:buf",bufmax);
   }
 
   // send each message

--- a/src/irregular.h
+++ b/src/irregular.h
@@ -29,10 +29,10 @@ class Irregular : protected Pointers {
   Irregular(class SPARTA *);
   ~Irregular();
   void create_procs(int, int *, int sort = 0);
-  int create_data_uniform(int, int *, int sort = 0);
+  virtual int create_data_uniform(int, int *, int sort = 0);
   int create_data_uniform_grouped(int, int *, int sort = 0);
   int create_data_variable(int, int *, int *, int &, int sort = 0);
-  int augment_data_uniform(int, int *);
+  virtual int augment_data_uniform(int, int *);
   void exchange_uniform(char *, int, char *);
   void exchange_variable(char *, int *, char *);
   void reverse(int, int *);


### PR DESCRIPTION
## Purpose

Fixes failing "implicit" regression tests due to non-Kokkos methods being called when Kokkos is enabled.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

No issues.