### PR TITLE
Fix thread-safety bug in Kokkos versions of compute boundary and compute surf

### DIFF
--- a/src/KOKKOS/compute_boundary_kokkos.h
+++ b/src/KOKKOS/compute_boundary_kokkos.h
@@ -37,6 +37,7 @@ class ComputeBoundaryKokkos : public ComputeBoundary, public KokkosBase {
   void compute_array();
   void clear();
   void pre_boundary_tally();
+  void post_boundary_tally();
 
   enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
   enum{PERIODIC,OUTFLOW,REFLECT,SURFACE,AXISYM};  // same as Domain
@@ -51,6 +52,7 @@ class ComputeBoundaryKokkos : public ComputeBoundary, public KokkosBase {
    jp != NULL means two particles after collision
 ------------------------------------------------------------------------- */
 
+template <int ATOMIC_REDUCTION>
 KOKKOS_INLINE_FUNCTION
 void boundary_tally_kk(int iface, int istyle, int reaction,
                        Particle::OnePart *iorig, 
@@ -68,6 +70,9 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
   // set nflag and tflag if normal and tangent computation already done once
   // particle weight used for all keywords except NUM
   // styles PERIODIC and OUTFLOW do not have post-bounce velocity
+
+  auto v_myarray = ScatterViewHelper<NeedDup<ATOMIC_REDUCTION,DeviceType>::value,decltype(dup_myarray),decltype(ndup_myarray)>::get(dup_myarray,ndup_myarray);
+  auto a_myarray = v_myarray.template access<AtomicDup<ATOMIC_REDUCTION,DeviceType>::value>();
 
   double vsqpre,ivsqpost,jvsqpost;
   double ierot,jerot,ievib,jevib,iother,jother,otherpre;
@@ -87,8 +92,8 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
 
   if (istyle == PERIODIC) {
     for (int m = 0; m < nvalue; m++) {
-      if (d_which[m] == NUM) d_myarray(iface,k++) += 1.0;
-      else if (d_which[m] == NUMWT) d_myarray(iface,k++) += weight;
+      if (d_which[m] == NUM) a_myarray(iface,k++) += 1.0;
+      else if (d_which[m] == NUMWT) a_myarray(iface,k++) += weight;
       else k++;
     }
 
@@ -96,20 +101,20 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
     for (int m = 0; m < nvalue; m++) {
       switch (d_which[m]) {
       case NUM:
-        d_myarray(iface,k++) += 1.0;
+        a_myarray(iface,k++) += 1.0;
         break;
       case NUMWT:
-        d_myarray(iface,k++) += weight;
+        a_myarray(iface,k++) += weight;
         break;
       case MFLUX:
-        d_myarray(iface,k++) += origmass;
+        a_myarray(iface,k++) += origmass;
         break;
       case PRESS:
         if (!nflag) {
           nflag = 1;
           pre = MathExtraKokkos::dot3(vorig,norm);
         }
-        d_myarray(iface,k++) -= origmass * pre;
+        a_myarray(iface,k++) -= origmass * pre;
         break;
       case XSHEAR:
         if (!tflag) {
@@ -117,7 +122,7 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           MathExtraKokkos::scale3(MathExtraKokkos::dot3(vorig,norm),norm,vnorm);
           MathExtraKokkos::sub3(vorig,vnorm,vtang);
         }
-        d_myarray(iface,k++) += origmass * vtang[0];
+        a_myarray(iface,k++) += origmass * vtang[0];
         break;
       case YSHEAR:
         if (!tflag) {
@@ -125,7 +130,7 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           MathExtraKokkos::scale3(MathExtraKokkos::dot3(vorig,norm),norm,vnorm);
           MathExtraKokkos::sub3(vorig,vnorm,vtang);
         }
-        d_myarray(iface,k++) += origmass * vtang[1];
+        a_myarray(iface,k++) += origmass * vtang[1];
         break;
       case ZSHEAR:
         if (!tflag) {
@@ -133,21 +138,21 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           MathExtraKokkos::scale3(MathExtraKokkos::dot3(vorig,norm),norm,vnorm);
           MathExtraKokkos::sub3(vorig,vnorm,vtang);
         }
-        d_myarray(iface,k++) += origmass * vtang[2];
+        a_myarray(iface,k++) += origmass * vtang[2];
         break;
       case KE:
         vsqpre = MathExtraKokkos::lensq3(vorig);
-        d_myarray(iface,k++) += 0.5 * mvv2e * origmass * vsqpre;
+        a_myarray(iface,k++) += 0.5 * mvv2e * origmass * vsqpre;
         break;
       case EROT:
-        d_myarray(iface,k++) += weight * iorig->erot;
+        a_myarray(iface,k++) += weight * iorig->erot;
         break;
       case EVIB:
-        d_myarray(iface,k++) += weight * iorig->evib;
+        a_myarray(iface,k++) += weight * iorig->evib;
         break;
       case ETOT:
         vsqpre = MathExtraKokkos::lensq3(vorig);
-        d_myarray(iface,k++) += 0.5*mvv2e*origmass*vsqpre + 
+        a_myarray(iface,k++) += 0.5*mvv2e*origmass*vsqpre + 
           weight*(iorig->erot+iorig->evib);
         break;
       }
@@ -157,21 +162,21 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
     for (int m = 0; m < nvalue; m++) {
       switch (d_which[m]) {
       case NUM:
-        d_myarray(iface,k++) += 1.0;
+        a_myarray(iface,k++) += 1.0;
         break;
       case NUMWT:
-        d_myarray(iface,k++) += weight;
+        a_myarray(iface,k++) += weight;
         break;
       case MFLUX:
-        d_myarray(iface,k++) += origmass;
-        if (ip) d_myarray(iface,k++) -= imass;
-        if (jp) d_myarray(iface,k++) -= jmass;
+        a_myarray(iface,k++) += origmass;
+        if (ip) a_myarray(iface,k++) -= imass;
+        if (jp) a_myarray(iface,k++) -= jmass;
         break;
       case PRESS:
         MathExtraKokkos::scale3(-origmass,vorig,pdelta);
         if (ip) MathExtraKokkos::axpy3(imass,ip->v,pdelta);
         if (jp) MathExtraKokkos::axpy3(jmass,jp->v,pdelta);
-        d_myarray(iface,k++) += MathExtraKokkos::dot3(pdelta,norm);
+        a_myarray(iface,k++) += MathExtraKokkos::dot3(pdelta,norm);
         break;
       case XSHEAR:
         if (!tflag) {
@@ -182,7 +187,7 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           MathExtraKokkos::scale3(MathExtraKokkos::dot3(pdelta,norm),norm,pnorm);
           MathExtraKokkos::sub3(pdelta,pnorm,ptang);
         }
-        d_myarray(iface,k++) -= ptang[0];
+        a_myarray(iface,k++) -= ptang[0];
         break;
       case YSHEAR:
         if (!tflag) {
@@ -193,7 +198,7 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           MathExtraKokkos::scale3(MathExtraKokkos::dot3(pdelta,norm),norm,pnorm);
           MathExtraKokkos::sub3(pdelta,pnorm,ptang);
         }
-        d_myarray(iface,k++) -= ptang[1];
+        a_myarray(iface,k++) -= ptang[1];
         break;
       case ZSHEAR:
         if (!tflag) {
@@ -204,7 +209,7 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           MathExtraKokkos::scale3(MathExtraKokkos::dot3(pdelta,norm),norm,pnorm);
           MathExtraKokkos::sub3(pdelta,pnorm,ptang);
         }
-        d_myarray(iface,k++) -= ptang[2];
+        a_myarray(iface,k++) -= ptang[2];
         break;
       case KE:
         vsqpre = origmass * MathExtraKokkos::lensq3(vorig);
@@ -212,21 +217,21 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
         else ivsqpost = 0.0;
         if (jp) jvsqpost = jmass * MathExtraKokkos::lensq3(jp->v);
         else jvsqpost = 0.0;
-        d_myarray(iface,k++) -= 0.5*mvv2e * (ivsqpost + jvsqpost - vsqpre);
+        a_myarray(iface,k++) -= 0.5*mvv2e * (ivsqpost + jvsqpost - vsqpre);
         break;
       case EROT:
         if (ip) ierot = ip->erot;
         else ierot = 0.0;
         if (jp) jerot = jp->erot;
         else jerot = 0.0;
-        d_myarray(iface,k++) -= weight * (ierot + jerot - iorig->erot);
+        a_myarray(iface,k++) -= weight * (ierot + jerot - iorig->erot);
         break;
       case EVIB:
         if (ip) ievib = ip->evib;
         else ievib = 0.0;
         if (jp) jevib = jp->evib;
         else jevib = 0.0;
-        d_myarray(iface,k++) -= weight * (ievib + jevib - iorig->evib);
+        a_myarray(iface,k++) -= weight * (ievib + jevib - iorig->evib);
         break;
       case ETOT:
         vsqpre = origmass * MathExtraKokkos::lensq3(vorig);
@@ -239,7 +244,7 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
           jvsqpost = jmass * MathExtraKokkos::lensq3(jp->v);
           jother = jp->erot + jp->evib;
         } else jvsqpost = jother = 0.0;
-        d_myarray(iface,k++) -= 0.5*mvv2e*(ivsqpost + jvsqpost - vsqpre) + 
+        a_myarray(iface,k++) -= 0.5*mvv2e*(ivsqpost + jvsqpost - vsqpre) + 
           weight * (iother + jother - otherpre);
         break;
       }
@@ -254,6 +259,10 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
 
   DAT::tdual_float_2d_lr k_myarray; // local accumulator array
   DAT::t_float_2d_lr d_myarray;
+
+  int need_dup;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterDuplicated> dup_myarray;
+  Kokkos::Experimental::ScatterView<F_FLOAT**, typename DAT::t_float_2d_lr::array_layout,DeviceType,Kokkos::Experimental::ScatterSum,Kokkos::Experimental::ScatterNonDuplicated> ndup_myarray;
 
   t_species_1d d_species;
   DAT::t_int_2d d_s2g;

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -136,6 +136,11 @@ struct AtomicView<1> {
   enum {value = Kokkos::Atomic|Kokkos::Unmanaged};
 };
 
+template<>
+struct AtomicView<-1> {
+  enum {value = Kokkos::Atomic|Kokkos::Unmanaged};
+};
+
 // Determine memory traits for array
 // Do atomic trait when running with CUDA
 template<int NEED_ATOMICS, class DeviceType>
@@ -148,6 +153,11 @@ template<>
 struct AtomicDup<1,Kokkos::Cuda> {
   enum {value = Kokkos::Experimental::ScatterAtomic};
 };
+
+template<>
+struct AtomicDup<-1,Kokkos::Cuda> {
+  enum {value = Kokkos::Experimental::ScatterAtomic};
+};
 #endif
 
 #ifdef SPARTA_KOKKOS_USE_ATOMICS
@@ -157,11 +167,21 @@ template<>
 struct AtomicDup<1,Kokkos::OpenMP> {
   enum {value = Kokkos::Experimental::ScatterAtomic};
 };
+
+template<>
+struct AtomicDup<-1,Kokkos::OpenMP> {
+  enum {value = Kokkos::Experimental::ScatterAtomic};
+};
 #endif
 
 #ifdef KOKKOS_ENABLE_THREADS
 template<>
 struct AtomicDup<1,Kokkos::Threads> {
+  enum {value = Kokkos::Experimental::ScatterAtomic};
+};
+
+template<>
+struct AtomicDup<-1,Kokkos::Threads> {
   enum {value = Kokkos::Experimental::ScatterAtomic};
 };
 #endif
@@ -183,11 +203,21 @@ template<>
 struct NeedDup<1,Kokkos::OpenMP> {
   enum {value = Kokkos::Experimental::ScatterDuplicated};
 };
+
+template<>
+struct NeedDup<-1,Kokkos::OpenMP> {
+  enum {value = Kokkos::Experimental::ScatterDuplicated};
+};
 #endif
 
 #ifdef KOKKOS_ENABLE_THREADS
 template<>
 struct NeedDup<1,Kokkos::Threads> {
+  enum {value = Kokkos::Experimental::ScatterDuplicated};
+};
+
+template<>
+struct NeedDup<-1,Kokkos::Threads> {
   enum {value = Kokkos::Experimental::ScatterDuplicated};
 };
 #endif

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -369,7 +369,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
   nscheck_one = nscollide_one = 0;
   surf->nreact_one = 0;
 
-  if (sparta->kokkos->atomic_reduction) {
+  if (!sparta->kokkos->need_atomics || sparta->kokkos->atomic_reduction) {
     h_ntouch_one() = 0;
     h_nexit_one() = 0;
     h_nboundary_one() = 0;
@@ -510,7 +510,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
 
     int error_flag;
 
-    if (sparta->kokkos->atomic_reduction) {
+    if (!sparta->kokkos->need_atomics || sparta->kokkos->atomic_reduction) {
       ntouch_one = h_ntouch_one();
       nexit_one = h_nexit_one();
       nboundary_one = h_nboundary_one();

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -595,9 +595,19 @@ template < int DIM, int SURF > void UpdateKokkos::move()
   nscollide_running += nscollide_one;
   surf->nreact_running += surf->nreact_one;
 
-  if (nsurf_tally)
-    for (int m = 0; m < nsurf_tally; m++)
-      slist_active_copy[m].obj.post_surf_tally();
+  if (nsurf_tally) {
+    for (int m = 0; m < nsurf_tally; m++) {
+      ComputeSurfKokkos* compute_surf_kk = (ComputeSurfKokkos*)(slist_active[m]);
+      compute_surf_kk->post_surf_tally();
+    }
+  }
+
+  if (nboundary_tally) {
+    for (int m = 0; m < nboundary_tally; m++) {
+      ComputeBoundaryKokkos* compute_boundary_kk = (ComputeBoundaryKokkos*)(blist_active[m]);
+      compute_boundary_kk->post_boundary_tally();
+    }
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1216,7 +1226,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
       if (nboundary_tally)
         for (int m = 0; m < nboundary_tally; m++)
           blist_active_copy[m].obj.
-            boundary_tally_kk(outface,bflag,reaction,&iorig,ipart,jpart,domain_kk_copy.obj.norm[outface]);
+            boundary_tally_kk<ATOMIC_REDUCTION>(outface,bflag,reaction,&iorig,ipart,jpart,domain_kk_copy.obj.norm[outface]);
 
       if (DIM == 1) {
         xnew[0] = x[0] + dtremain*v[0];

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -489,15 +489,12 @@ template < int DIM, int SURF > void UpdateKokkos::move()
 
     //k_mlist.sync<SPADeviceType>();
     copymode = 1;
-    if (sparta->kokkos->atomic_reduction) {
-      if (sparta->kokkos->need_atomics) {
-        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,1> >(pstart,pstop),*this);
-      } else {
-        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,0> >(pstart,pstop),*this);
-      }
-    } else {
+    if (!sparta->kokkos->need_atomics)
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,0> >(pstart,pstop),*this);
+    else if (sparta->kokkos->atomic_reduction)
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,1> >(pstart,pstop),*this);
+    else
       Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,-1> >(pstart,pstop),*this,reduce);
-    }
     copymode = 0;
 
     Kokkos::deep_copy(h_scalars,d_scalars);


### PR DESCRIPTION
## Purpose

Fix thread-safety bug in `compute_boundary_kokkos` and `compute_surf_kokkos` that could lead to incorrect tallies when using GPUs or more than 1 thread.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

No issues.