### PR TITLE
Fix compile error when using -DSPARTA_BIGBIG

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -196,7 +196,7 @@ void Grid::surf2grid_surf_algorithm(int subflag, int outflag)
 {
   int i,j,m,n,icell,isurf,nontrans;
   double t1,t2,t3,t4;
-  int *list;
+  surfint *list;
 
   int dim = domain->dimension;
   int distributed = surf->distributed;


### PR DESCRIPTION
## Purpose

Fix compile error when using `-DSPARTA_BIGBIG`

## Author(s)

Stan Moore (SNL) (fix from @sjplimp ).

## Backward Compatibility

No issues.