### PR TITLE
tweaks to surf collide doc page

### DIFF
--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -19,8 +19,6 @@
 
 <LI>style = <I>specular</I> or <I>diffuse</I> or <I>cll</I> or <I>impulsive</I> or <I>td</I> or <I>piston</I> or <I>vanish</I> or <I>specular/kk</I> or <I>diffuse/kk</I> or <I>piston/kk</I> or <I>vanish/kk</I> 
 
-<LI>style = <I>specular</I> or <I>diffuse</I> or <I>piston</I> or <I>transparent</I> or <I>vanish</I> 
-
 <LI>args = arguments for specific style 
 
 <PRE>  <I>specular</I> or <I>specular/kk</I> args = none
@@ -630,8 +628,5 @@ Experiments and simulations, The Journal of Chemical Physics, (1990).
 <P><B>(Goodman74)</B> F. O. Goodman, Determination of characteristic surface
 vibration temperatures by molecular beam scattering: Application to
 specular scattering in the H-LiF (001) system, Surface Science, (1974)
-</P>
-<P>=======
->>>>>>> master
 </P>
 </HTML>

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -14,7 +14,6 @@ surf_collide ID style args keyword values ... :pre
 
 ID = user-assigned name for the surface collision model :ulb,l
 style = {specular} or {diffuse} or {cll} or {impulsive} or {td} or {piston} or {vanish} or {specular/kk} or {diffuse/kk} or {piston/kk} or {vanish/kk} :l
-style = {specular} or {diffuse} or {piston} or {transparent} or {vanish} :l
 args = arguments for specific style :l
   {specular} or {specular/kk} args = none
   {diffuse} or {diffuse/kk} args = Tsurf acc
@@ -605,8 +604,3 @@ Experiments and simulations, The Journal of Chemical Physics, (1990).
 [(Goodman74)] F. O. Goodman, Determination of characteristic surface
 vibration temperatures by molecular beam scattering: Application to
 specular scattering in the H-LiF (001) system, Surface Science, (1974)
-
-
-
-=======
->>>>>>> master


### PR DESCRIPTION
## Purpose

Fix a couple format errors on surf collide doc page.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


