### PR TITLE
fix a bug with grid adaptation updating per-grid fix memory twice

### DIFF
--- a/src/adapt_grid.cpp
+++ b/src/adapt_grid.cpp
@@ -272,10 +272,6 @@ void AdaptGrid::command(int narg, char **arg)
     grid->type_check();
   }
 
-  // final update of any per grid fixes for all new child cells
-  
-  if (modify->n_pergrid) add_grid_fixes();
-
   // write out new parent grid file
 
   if (file) write_file();
@@ -586,7 +582,6 @@ void AdaptGrid::check_args(int nevery)
 void AdaptGrid::setup(int iter)
 {
   // zero new child cell counter on first iteration
-  // used in add_grid_fixes after all new child cells have been added
 
   if (iter == 0) nnew = 0;
 
@@ -932,27 +927,6 @@ void AdaptGrid::refine_random()
   rnum = n;
 
   //printf("RNUM2 %d: %d\n",me,rnum);
-}
-
-/* ----------------------------------------------------------------------
-   final add of new child cells to fixes
-   allow for each cell ID to no longer exist or be for a parent cell
-     due to subsequent iterations
-   NOTE: first stage must happen earlier so fix memory for new cell is valid
-------------------------------------------------------------------------- */
-
-void AdaptGrid::add_grid_fixes()
-{
-  Grid::MyHash *hash = grid->hash;
-  grid->rehash();
-
-  int icell;
-  for (int i = 0; i < nnew; i++) {
-    if (hash->find(newcells[i]) == hash->end()) continue;
-    icell = (*hash)[newcells[i]];
-    if (icell < 0) continue;
-    modify->add_grid_one();
-  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/adapt_grid.h
+++ b/src/adapt_grid.h
@@ -56,7 +56,6 @@ class AdaptGrid : protected Pointers {
   void setup(int);
   int refine();
   int coarsen(int);
-  void add_grid_fixes();
   void cleanup();
   void write_file();
 

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -187,10 +187,6 @@ void FixAdapt::end_of_step()
     grid->type_check(0);
   }
 
-  // final update of any per grid fixes for all new child cells
-
-  if (modify->n_pergrid) adapt->add_grid_fixes();
-
   // notify all classes that store per-grid data that grid may have changed
   
   grid->notify_changed();


### PR DESCRIPTION
## Purpose

Fix an issue with grid adaptation trying to update per-grid-cell fix memory one too many times.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


