### PR TITLE
Cleanup for AddressSanitizer tool

### DIFF
--- a/src/KOKKOS/react_bird_kokkos.cpp
+++ b/src/KOKKOS/react_bird_kokkos.cpp
@@ -130,7 +130,7 @@ void ReactBirdKokkos::init()
         h_list(k) = reactions[i][j].list[k];
       Kokkos::deep_copy(k_reactions.h_view(i,j).d_list,h_list);
 
-      if (!recombflag) continue;
+      if (!recombflag || !reactions[i][j].sp2recomb) continue;
 
       k_reactions.h_view(i,j).d_sp2recomb = DAT::t_int_1d("react/bird:sp2recomb",nspecies);
       auto h_sp2recomb = Kokkos::create_mirror_view(k_reactions.h_view(i,j).d_sp2recomb);

--- a/src/react_bird.cpp
+++ b/src/react_bird.cpp
@@ -336,7 +336,10 @@ void ReactBird::init()
     for (int j = 0; j < nspecies; j++) {
       int n = reactions[i][j].n;
       int *list = reactions[i][j].list;
-      reactions[i][j].sp2recomb = &sp2recomb_ij[offset];
+      if (offset < nij*nspecies)
+        reactions[i][j].sp2recomb = &sp2recomb_ij[offset];
+      else
+        reactions[i][j].sp2recomb = NULL; // Needed for Kokkos
       for (int m = 0; m < n; m++) {
         r = &rlist[list[m]];
         if (r->type == RECOMBINATION) {


### PR DESCRIPTION
## Purpose

Get rid of invalid memory issue flagged by AddressSanitizer tool when using Kokkos version of react bird. This is *not* a bug since the memory is never used.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

No issues.