### PR TITLE
Update nmax variable in surf.cpp when reading restart file

### DIFF
--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -3631,6 +3631,7 @@ void Surf::read_restart(FILE *fp)
     lines = (Line *) memory->smalloc(nsurf*sizeof(Line),"surf:lines");
     // NOTE: need different logic for different surf styles
     nlocal = nsurf;
+    nmax = nsurf;
 
     if (me == 0) {
       for (int i = 0; i < nsurf; i++) {
@@ -3654,6 +3655,7 @@ void Surf::read_restart(FILE *fp)
     tris = (Tri *) memory->smalloc(nsurf*sizeof(Tri),"surf:tris");
     // NOTE: need different logic for different surf styles
     nlocal = nsurf;
+    nmax = nsurf;
 
     if (me == 0) {
       for (int i = 0; i < nsurf; i++) {


### PR DESCRIPTION
## Purpose

When a restart file with surfaces is read in, the `nmax` variable is not updated, which gives a wrong allocation tally. This led to a bug when using Kokkos, and possibly in other cases as well. This PR fixes the issue.

## Author(s)

Stan Moore(SNL)

