### PR TITLE
Add check for global mem/limit greater than 2GB

### DIFF
--- a/doc/global.txt
+++ b/doc/global.txt
@@ -373,7 +373,8 @@ will allocate extra memory limited to that many MBytes on each
 processor. {Bytes} can be specified as a floating point value or an 
 integer, e.g. 0.5 if you want to use 1/2 MByte of extra memory or 100 
 for a 100 MByte buffer. Specifying a value of 0 (the default) means no 
-limit is used. 
+limit is used. The value used for {mem/limit} must not exceed 2GB or an
+error will occur.
 
 For load-balancing, the communication of grid and particle data to new 
 processors will then be performed in multiple passes (if necessary) so 

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -174,7 +174,7 @@ void ParticleKokkos::sort_kokkos()
   sorted_kk = 1;
   int reorder_scheme = COPYPARTICLELIST;
   if (update->mem_limit_grid_flag)
-    update->global_mem_limit = grid->nlocal*sizeof(Grid::ChildCell);
+    update->set_mem_limit_grid();
   if (update->global_mem_limit > 0 || (update->mem_limit_grid_flag && !grid->nlocal))
     reorder_scheme = FIXEDMEMORY;
 

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -233,7 +233,7 @@ int Comm::migrate_particles(int nmigrate, int *plist)
 void Comm::migrate_cells(int nmigrate)
 {
   if (update->mem_limit_grid_flag)
-    update->global_mem_limit = grid->nlocal*sizeof(Grid::ChildCell);
+    update->set_mem_limit_grid();
 
   if (update->global_mem_limit > 0 || 
       (update->mem_limit_grid_flag && !grid->nlocal))

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -408,7 +408,7 @@ void ReadRestart::command(int narg, char **arg)
         fseek(fp,-(sizeof(int)+grid_read_size),SEEK_CUR);
 
         if (update->mem_limit_grid_flag)
-          update->global_mem_limit = grid_nlocal*sizeof(Grid::ChildCell);
+          update->set_mem_limit_grid();
 
         int maxbuf_new = MAX(grid_read_size,update->global_mem_limit);
         maxbuf_new = MAX(maxbuf_new,sizeof(Particle::OnePartRestart));

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1611,8 +1611,11 @@ void Update::global(int narg, char **arg)
       if (strcmp(arg[iarg+1],"grid") == 0) mem_limit_grid_flag = 1;
       else {
         double factor = input->numeric(FLERR,arg[iarg+1]);
-        global_mem_limit = static_cast<int> (factor * 1024*1024);
-        if (global_mem_limit < 0) error->all(FLERR,"Illegal global command");
+        bigint global_mem_limit_big = static_cast<bigint> (factor * 1024*1024);
+        if (global_mem_limit_big < 0) error->all(FLERR,"Illegal global command");
+        if (global_mem_limit_big > MAXSMALLINT)
+          error->all(FLERR,"Global mem/limit setting cannot exceed 2GB");
+        global_mem_limit = global_mem_limit_big;
       }
       iarg += 2;
     } else error->all(FLERR,"Illegal global command");
@@ -1669,3 +1672,17 @@ void Update::reset_timestep(bigint newstep)
   for (int i = 0; i < modify->ncompute; i++)
     if (modify->compute[i]->timeflag) modify->compute[i]->clearstep();
 }
+
+/* ----------------------------------------------------------------------
+   get mem/limit based on grid memory
+------------------------------------------------------------------------- */
+
+void Update::set_mem_limit_grid()
+{
+  bigint global_mem_limit_big = static_cast<bigint> (grid->nlocal*sizeof(Grid::ChildCell));
+
+  if global_mem_limit_big > MAXSMALLINT)
+    error->all(FLERR,"Global mem/limit setting cannot exceed 2GB");
+  global_mem_limit = global_mem_limit_big;
+}
+

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1681,7 +1681,7 @@ void Update::set_mem_limit_grid()
 {
   bigint global_mem_limit_big = static_cast<bigint> (grid->nlocal*sizeof(Grid::ChildCell));
 
-  if global_mem_limit_big > MAXSMALLINT)
+  if (global_mem_limit_big > MAXSMALLINT)
     error->all(FLERR,"Global mem/limit setting cannot exceed 2GB");
   global_mem_limit = global_mem_limit_big;
 }

--- a/src/update.h
+++ b/src/update.h
@@ -67,6 +67,7 @@ class Update : protected Pointers {
   int reorder_period;        // # of timesteps between particle reordering
   int global_mem_limit;      // max # of bytes in arrays for rebalance and reordering
   int mem_limit_grid_flag;   // 1 if using size of grid as memory limit
+  void set_mem_limit_grid();
 
   int copymode;          // 1 if copy of class (prevents deallocation of
                          //  base class when child copy is destroyed)
@@ -211,6 +212,10 @@ E: Cannot set global surfmax when surfaces already exist
 
 This setting must be made before any surfac elements are
 read via the read_surf command.
+
+E: Global mem/limit setting cannot exceed 2GB
+
+Self-expanatory, prevents 32-bit interger overflow
 
 E: Timestep must be >= 0
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -175,7 +175,7 @@ void WriteRestart::multiproc_options(int multiproc_caller,
 void WriteRestart::write(char *file)
 {
   if (update->mem_limit_grid_flag)
-    update->global_mem_limit = grid->nlocal*sizeof(Grid::ChildCell);
+    update->set_mem_limit_grid();
   if (update->global_mem_limit > 0 || 
       (update->mem_limit_grid_flag && !grid->nlocal))
     return write_less_memory(file);


### PR DESCRIPTION
## Purpose

Add check for `global mem/limit` greater than 2GB in order to prevent 32-bit integer overflow.

## Author(s)

Stan Moore (SNL)