### PR TITLE
Finalize Kokkos on error exit

### DIFF
--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -60,12 +60,16 @@ class KokkosSPARTA {
   //int neigh_count(int) {return 0;}
 };
 
+class Kokkos {
+ public:
+  static void finalize() {}
+};
+
 class UpdateKokkos : public Update {
  public:
   UpdateKokkos(class SPARTA *sparta) : Update(sparta) {}
   ~UpdateKokkos() {}
 };
-
 
 class ParticleKokkos : public Particle {
  public:

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -18,6 +18,7 @@
 #include "universe.h"
 #include "output.h"
 #include "memory.h"
+#include "accelerator_kokkos.h"
 
 using namespace SPARTA_NS;
 
@@ -48,6 +49,7 @@ void Error::universe_all(const char *file, int line, const char *str)
   }
   if (universe->ulogfile) fclose(universe->ulogfile);
 
+  if (sparta->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(1);
 }
@@ -87,6 +89,7 @@ void Error::all(const char *file, int line, const char *str)
   if (screen && screen != stdout) fclose(screen);
   if (logfile) fclose(logfile);
 
+  if (sparta->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(1);
 }
@@ -150,6 +153,7 @@ void Error::done()
   if (screen && screen != stdout) fclose(screen);
   if (logfile) fclose(logfile);
 
+  if (sparta->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(1);
 }


### PR DESCRIPTION
## Purpose

Finalize Kokkos on error exit, otherwise Kokkos throws an error that can confuse users. See https://github.com/lammps/lammps/pull/1908

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

No issues.