### PR TITLE
Allow read/write of restart files larger than 2 GB

### DIFF
--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1395,6 +1395,20 @@ int Particle::size_restart()
 }
 
 /* ----------------------------------------------------------------------
+   return size of particle restart info for this proc
+------------------------------------------------------------------------- */
+
+bigint Particle::size_restart_big()
+{
+  bigint n = sizeof(int);
+  n = BIROUNDUP(n);
+  n += nlocal * sizeof(OnePartRestart);
+  n += nlocal * sizeof_custom();
+  n = BIROUNDUP(n);
+  return n;
+}
+
+/* ----------------------------------------------------------------------
    pack my particle info into buf
    use OnePartRestart data struct for permanent info and to encode cell ID
    include per-particle custom attributes if defined

--- a/src/particle.h
+++ b/src/particle.h
@@ -160,6 +160,7 @@ class Particle : protected Pointers {
   void read_restart_mixture(FILE *fp);
 
   int size_restart();
+  bigint size_restart_big();
   int pack_restart(char *);
   int pack_restart(char *, int, int);
   int unpack_restart(char *);

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -41,6 +41,7 @@ namespace SPARTA_NS {
 
 #define ROUNDUP(A) (char *) (((uint64_t) (A) + 7) & ~7);
 #define IROUNDUP(A) ((((int) (A) + 7) / 8) * 8);
+#define BIROUNDUP(A) ((((bigint) (A) + 7) / 8) * 8);
 
 class Pointers {
  public:

--- a/src/read_restart.h
+++ b/src/read_restart.h
@@ -65,7 +65,7 @@ class ReadRestart : protected Pointers {
   char *read_string();
   void read_int_vec(int, int *);
   void read_double_vec(int, double *);
-  void read_char_vec(int, char *);
+  void read_char_vec(bigint, char *);
 };
 
 }

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -356,8 +356,8 @@ void WriteRestart::write_less_memory(char *file)
   // max_size = largest buffer needed by any proc
 
   int grid_send_size = grid->size_restart();
-  int particle_send_size = particle->size_restart();
-  int send_size = grid_send_size + particle_send_size;
+  bigint particle_send_size = particle->size_restart_big();
+  bigint send_size = grid_send_size + particle_send_size;
 
   int max_size = MAX(grid_send_size,update->global_mem_limit);
   max_size = MAX(max_size,sizeof(Particle::OnePartRestart));
@@ -373,7 +373,8 @@ void WriteRestart::write_less_memory(char *file)
 
   // all procs write file layout info which may include per-proc sizes
 
-  file_layout(send_size);
+  int dummy = 0;
+  file_layout(dummy);
 
   // header info is complete
   // if multiproc output:
@@ -419,11 +420,11 @@ void WriteRestart::write_less_memory(char *file)
   MPI_Request request;
   
   if (filewriter) {
-    int total_recv_size = 0;
+    bigint total_recv_size = 0;
     int npasses = 0;
     for (int iproc = 0; iproc < nclusterprocs; iproc++) {
       if (iproc) {
-        MPI_Recv(&total_recv_size,1,MPI_INT,me+iproc,0,world,&status);
+        MPI_Recv(&total_recv_size,1,MPI_SPARTA_BIGINT,me+iproc,0,world,&status);
         MPI_Recv(&npasses,1,MPI_INT,me+iproc,0,world,&status);
       } else {
         total_recv_size = send_size;
@@ -453,7 +454,7 @@ void WriteRestart::write_less_memory(char *file)
     fclose(fp);
 
   } else {
-    MPI_Isend(&send_size,1,MPI_INT,fileproc,0,world,&request);
+    MPI_Isend(&send_size,1,MPI_SPARTA_BIGINT,fileproc,0,world,&request);
     MPI_Isend(&my_npasses,1,MPI_INT,fileproc,0,world,&request);
     for (int i = 0; i < my_npasses; i++) {
       int n = 0;
@@ -683,10 +684,10 @@ void WriteRestart::write_double_vec(int flag, int n, double *vec)
    write a flag and vector of N chars into restart file
 ------------------------------------------------------------------------- */
 
-void WriteRestart::write_char_vec(int flag, int n, char *vec)
+void WriteRestart::write_char_vec(int flag, bigint n, char *vec)
 {
   fwrite(&flag,sizeof(int),1,fp);
-  fwrite(&n,sizeof(int),1,fp);
+  fwrite(&n,sizeof(bigint),1,fp);
   fwrite(vec,sizeof(char),n,fp);
 }
 
@@ -694,10 +695,10 @@ void WriteRestart::write_char_vec(int flag, int n, char *vec)
    write a flag and vector of N chars into restart file
 ------------------------------------------------------------------------- */
 
-void WriteRestart::write_char_vec(int flag, int total, int n, char *vec)
+void WriteRestart::write_char_vec(int flag, bigint total, int n, char *vec)
 {
   fwrite(&flag,sizeof(int),1,fp);
-  fwrite(&total,sizeof(int),1,fp);
+  fwrite(&total,sizeof(bigint),1,fp);
   fwrite(vec,sizeof(char),n,fp);
 }
 

--- a/src/write_restart.h
+++ b/src/write_restart.h
@@ -62,8 +62,8 @@ class WriteRestart : protected Pointers {
   void write_string(int, char *);
   void write_int_vec(int, int, int *);
   void write_double_vec(int, int, double *);
-  void write_char_vec(int, int, char *);
-  void write_char_vec(int, int, int, char *);
+  void write_char_vec(int, bigint, char *);
+  void write_char_vec(int, bigint, int, char *);
   void write_char_vec(int, char *);
 };
 


### PR DESCRIPTION
## Purpose

Allow read/write of restart files larger than 2 GB (when the `global mem/limit` command is also used).

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

This will break backward compatibility of restart files.
