### PR TITLE
Fix segfault issue in collide.cpp

### DIFF
--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -1581,8 +1581,8 @@ void CollideVSSKokkos::adapt_grid()
 
 void CollideVSSKokkos::grow_percell(int n)
 {
-  if (nglocal+n < nglocalmax) return;
-  nglocalmax += DELTAGRID;
+  if (nglocal+n < nglocalmax || !ngroups) return;
+  while (nglocal+n < nglocalmax) nglocalmax += DELTAGRID;
 
   this->sync(Device,ALL_MASK); // force resize on device
 

--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -1688,7 +1688,7 @@ void Collide::adapt_grid()
 void Collide::grow_percell(int n)
 {
   if (nglocal+n < nglocalmax || !ngroups) return;
-  nglocalmax += DELTAGRID;
+  while (nglocal+n < nglocalmax) nglocalmax += DELTAGRID;
   memory->grow(vremax,nglocalmax,ngroups,ngroups,"collide:vremax");
   if (remainflag) 
     memory->grow(remain,nglocalmax,ngroups,ngroups,"collide:remain");

--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -1687,7 +1687,7 @@ void Collide::adapt_grid()
 
 void Collide::grow_percell(int n)
 {
-  if (nglocal+n < nglocalmax) return;
+  if (nglocal+n < nglocalmax || !ngroups) return;
   nglocalmax += DELTAGRID;
   memory->grow(vremax,nglocalmax,ngroups,ngroups,"collide:vremax");
   if (remainflag) 


### PR DESCRIPTION
## Purpose

`read_surf` calls `collide.cpp:1692`. The issue is that the Collide class is only initialized for a run command, not for read_surf, so `ngroups` is zero in the grow() command, leading to segmentation fault crash. This is similar to #105.

## Author(s)

Stan Moore (SNL), reported by Savio Poovathingal (University of Kentucky)

## Backward Compatibility

No issues.