### PR TITLE
added Kokkos compute distsurf/grid capability

### DIFF
--- a/doc/Section_commands.txt
+++ b/doc/Section_commands.txt
@@ -406,7 +406,7 @@ letters in parenthesis: k = KOKKOS.
 
 "boundary (k)"_compute_boundary.html,
 "count (k)"_compute_count.html,
-"distsurf/grid"_compute_distsurf_grid.html,
+"distsurf/grid (k)"_compute_distsurf_grid.html,
 "eflux/grid (k)"_compute_eflux_grid.html,
 "fft/grid"_compute_fft_grid.html,
 "grid (k)"_compute_grid.html,

--- a/doc/compute_distsurf_grid.txt
+++ b/doc/compute_distsurf_grid.txt
@@ -7,6 +7,7 @@
 :line
 
 compute distsurf/grid command :h3
+compute distsurf/grid/kk command :h3
 
 [Syntax:]
 
@@ -115,6 +116,31 @@ for an overview of SPARTA output options.
 
 The per-grid array values for the vector will be in distance
 "units"_units.html.
+
+:line
+
+Styles with a {kk} suffix are functionally the same as the
+corresponding style without the suffix.  They have been optimized to
+run faster, depending on your available hardware, as discussed in the
+"Accelerating SPARTA"_Section_accelerate.html section of the manual.
+The accelerated styles take the same arguments and should produce the
+same results, except for different random number, round-off and
+precision issues.
+
+These accelerated styles are part of the KOKKOS package. They are only
+enabled if SPARTA was built with that package.  See the "Making
+SPARTA"_Section_start.html#start_3 section for more info.
+
+You can specify the accelerated styles explicitly in your input script
+by including their suffix, or you can use the "-suffix command-line
+switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+use the "suffix"_suffix.html command in your input script.
+
+See the "Accelerating SPARTA"_Section_accelerate.html section of the
+manual for more instructions on how to use the accelerated styles
+effectively.
+
+:line
 
 [Restrictions:] None
 

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -51,6 +51,8 @@ action compute_boundary_kokkos.cpp
 action compute_boundary_kokkos.h
 action compute_count_kokkos.cpp
 action compute_count_kokkos.h
+action compute_distsurf_grid_kokkos.cpp
+action compute_distsurf_grid_kokkos.h
 action compute_eflux_grid_kokkos.cpp
 action compute_eflux_grid_kokkos.h
 action compute_grid_kokkos.cpp

--- a/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
@@ -58,6 +58,8 @@ void ComputeDistSurfGridKokkos::compute_per_grid()
     ComputeDistSurfGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
+    k_vector_grid.modify<DeviceType>();
+    k_vector_grid.sync<SPAHostType>();
   }
 }
 

--- a/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
@@ -1,0 +1,251 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing author: Alan Stagg (Sandia)
+------------------------------------------------------------------------- */
+
+#include "compute_distsurf_grid_kokkos.h"
+#include "update.h"
+#include "grid_kokkos.h"
+#include "surf_kokkos.h"
+#include "domain.h"
+#include "geometry_kokkos.h"
+#include "math_extra_kokkos.h"
+#include "memory_kokkos.h"
+#include "kokkos.h"
+#include "sparta_masks.h"
+
+using namespace SPARTA_NS;
+
+#define BIG 1.0e20
+
+/* ---------------------------------------------------------------------- */
+
+ComputeDistSurfGridKokkos::
+ComputeDistSurfGridKokkos(SPARTA *sparta, int narg, char **arg) :
+  ComputeDistSurfGrid(sparta, narg, arg)
+{
+  kokkos_flag = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeDistSurfGridKokkos::~ComputeDistSurfGridKokkos()
+{
+  if (copymode) return;
+
+  memoryKK->destroy_kokkos(k_vector_grid,vector_grid);
+  vector_grid = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeDistSurfGridKokkos::compute_per_grid()
+{
+  if (sparta->kokkos->prewrap) {
+    ComputeDistSurfGrid::compute_per_grid();
+  } else {
+    compute_per_grid_kokkos();
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeDistSurfGridKokkos::compute_per_grid_kokkos()
+{
+  SurfKokkos* surf_kk = (SurfKokkos*) surf;
+  surf_kk->sync(Device,ALL_MASK);
+  d_lines = surf_kk->k_lines.d_view;
+  d_tris = surf_kk->k_tris.d_view;
+  Surf::Line *lines = surf->lines;
+  Surf::Tri *tris = surf->tris;
+  int ntotal = surf_kk->nlocal;
+
+  k_eflag = DAT::tdual_int_1d("compute/distsurf/grid:eflag",ntotal);
+  k_slist = DAT::tdual_int_1d("compute/distsurf/grid:slist",ntotal);
+  h_eflag = k_eflag.h_view;
+  h_slist = k_slist.h_view;
+  d_slist = k_slist.d_view;
+  d_eflag = k_eflag.d_view;
+
+  invoked_per_grid = update->ntimestep;
+  dim = domain->dimension;
+
+  nsurf = 0;
+  if (dim == 2) {
+    for (int i = 0; i < ntotal; i++) {
+      h_eflag[i] = 0;
+      if (!(lines[i].mask & sgroupbit)) continue;
+      if (MathExtraKokkos::dot3(lines[i].norm,sdir) <= 0.0) {
+	h_eflag[i] = 1;
+	h_slist[nsurf++] = i;
+      }
+    }
+  } else {
+    for (int i = 0; i < ntotal; i++) {
+      h_eflag[i] = 0;
+      if (!(tris[i].mask & sgroupbit)) continue;
+      if (MathExtraKokkos::dot3(tris[i].norm,sdir) <= 0.0) {
+	h_eflag[i] = 1;
+	h_slist[nsurf++] = i;
+      }
+    }
+  }
+  k_eflag.modify<SPAHostType>();
+  k_slist.modify<SPAHostType>();
+
+  k_eflag.sync<DeviceType>();
+  k_slist.sync<DeviceType>();
+
+  d_sctr = DAT::t_float_1d_3("compute/distsurf/grid:sctr",nsurf);
+
+  // pre-compute center point of each eligible surf
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeDistSurfGrid_surf_centroid>(0,nsurf),*this);
+  DeviceType::fence();
+  copymode = 0;
+
+  // loop over my unsplit/split grid cells
+  // if surfs in cell and any are eligible, dist = 0.0
+  // else loop over eligible surfs in slist:
+  //   if vector from cell center to surf center is against surf norm, skip it
+  //   compute distance from cell to surf via Geometry method
+  //   dist = minimum distance to any eligible surf
+  // if assign dist to split cell, also assign dist to all its sub cells
+  GridKokkos* grid_kk = ((GridKokkos*)grid);
+  d_cells = grid_kk->k_cells.d_view;
+  d_cinfo = grid_kk->k_cinfo.d_view;
+  d_csurfs = grid_kk->d_csurfs;
+  d_csubs = grid_kk->d_csubs;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeDistSurfGrid_surf_distance>(0,nglocal),*this);
+  DeviceType::fence();
+  copymode = 0;
+
+  memoryKK->destroy_kokkos(k_eflag);
+  memoryKK->destroy_kokkos(k_slist);
+  d_sctr = DAT::t_float_1d_3();
+}
+
+/* ---------------------------------------------------------------------- */
+
+KOKKOS_INLINE_FUNCTION
+void ComputeDistSurfGridKokkos::operator()(TagComputeDistSurfGrid_surf_centroid, const int &i) const {
+
+  // compute surf centroids
+  double invthird = 1.0/3.0;
+  double *p1,*p2,*p3;
+
+  int m = d_slist[i];
+  if (dim == 2) {
+    p1 = d_lines[m].p1;
+    p2 = d_lines[m].p2;
+    d_sctr(i,0) = 0.5 * (p1[0] + p2[0]);
+    d_sctr(i,1) = 0.5 * (p1[1] + p2[1]);
+    d_sctr(i,2) = 0.0;
+  } else {
+    p1 = d_tris[m].p1;
+    p2 = d_tris[m].p2;
+    p3 = d_tris[m].p3;
+    d_sctr(i,0) = invthird * (p1[0] + p2[0] + p3[0]);
+    d_sctr(i,1) = invthird * (p1[1] + p2[1] + p3[1]);
+    d_sctr(i,2) = invthird * (p1[2] + p2[2] + p3[2]);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+KOKKOS_INLINE_FUNCTION
+void ComputeDistSurfGridKokkos::operator()(TagComputeDistSurfGrid_surf_distance, const int &icell) const {
+  int i,m,n;
+  double dist,mindist;
+  double *lo,*hi;
+  double cctr[3],cell2surf[3];
+
+  if (!(d_cinfo[icell].mask & groupbit)) return;
+  if (d_cells[icell].nsplit < 1) return;
+
+  if (d_cells[icell].nsurf) {
+    n = d_cells[icell].nsurf;
+    auto csurfs_begin = d_csurfs.row_map(icell);
+    for (i = 0; i < n; i++) {
+      m = d_csurfs.entries(csurfs_begin + i);
+      if (d_eflag[m]) break;
+    }
+
+    // cell is overlapped, set dist = 0.0 and return
+    // if split cell, also set vector_grid = 0.0 for sub-cells
+
+    if (i < n) {
+      d_vector[icell] = 0.0;
+      if (d_cells[icell].nsplit > 1) {
+	n = d_cells[icell].nsplit;
+	int isplit = d_cells[icell].isplit;
+	auto csubs_begin = d_csubs.row_map(isplit);
+	for (i = 0; i < n; i++) {
+	  m = d_csubs.entries(csubs_begin + i);
+	  d_vector[m] = 0.0;
+	}
+      }
+      return;
+    }
+  }
+
+  lo = d_cells[icell].lo;
+  hi = d_cells[icell].hi;
+  cctr[0] = 0.5 * (lo[0]+hi[0]);
+  cctr[1] = 0.5 * (lo[1]+hi[1]);
+  if (dim == 3) cctr[2] = 0.5 * (lo[2]+hi[2]);
+  else cctr[2] = 0.0;
+
+  mindist = BIG;
+  for (i = 0; i < nsurf; i++) {
+    m = d_slist[i];
+
+    cell2surf[0] = d_sctr(i,0) - cctr[0];
+    cell2surf[1] = d_sctr(i,1) - cctr[1];
+    cell2surf[2] = d_sctr(i,2) - cctr[2];
+
+    if (dim == 2) {
+      if (MathExtraKokkos::dot3(cell2surf,d_lines[m].norm) > 0.0) continue;
+      dist = GeometryKokkos::dist_line_quad(d_lines[m].p1,d_lines[m].p2,lo,hi);
+    } else {
+      if (MathExtraKokkos::dot3(cell2surf,d_tris[m].norm) > 0.0) continue;
+      dist = GeometryKokkos::dist_tri_hex(d_tris[m].p1,d_tris[m].p2,d_tris[m].p3,
+					  d_tris[m].norm,lo,hi);
+    }
+    mindist = MIN(mindist,dist);
+  }
+
+  d_vector[icell] = mindist;
+}
+
+/* ----------------------------------------------------------------------
+   reallocate vector if nglocal has changed
+   called by init() and load balancer
+------------------------------------------------------------------------- */
+
+void ComputeDistSurfGridKokkos::reallocate()
+{
+  if (grid->nlocal == nglocal) return;
+
+  memoryKK->destroy_kokkos(k_vector_grid,vector_grid);
+
+  memory->destroy(vector_grid);
+  nglocal = grid->nlocal;
+  memoryKK->create_kokkos(k_vector_grid,vector_grid,nglocal,"distsurf/grid:vector_grid");
+  d_vector = k_vector_grid.d_view;
+}

--- a/src/KOKKOS/compute_distsurf_grid_kokkos.h
+++ b/src/KOKKOS/compute_distsurf_grid_kokkos.h
@@ -1,0 +1,82 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+ComputeStyle(distsurf/grid/kk,ComputeDistSurfGridKokkos)
+
+#else
+
+#ifndef SPARTA_COMPUTE_DISTSURF_GRID_KOKKOS_H
+#define SPARTA_COMPUTE_DISTSURF_GRID_KOKKOS_H
+
+#include "compute_distsurf_grid.h"
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+namespace SPARTA_NS {
+
+struct TagComputeDistSurfGrid_surf_centroid{};
+struct TagComputeDistSurfGrid_surf_distance{};
+
+ class ComputeDistSurfGridKokkos : public ComputeDistSurfGrid, public KokkosBase {
+ public:
+  ComputeDistSurfGridKokkos(class SPARTA *, int, char **);
+  ~ComputeDistSurfGridKokkos();
+  void compute_per_grid();
+  void compute_per_grid_kokkos();
+  void reallocate();
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagComputeDistSurfGrid_surf_centroid, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagComputeDistSurfGrid_surf_distance, const int&) const;
+
+  DAT::tdual_float_1d k_vector_grid;
+
+ private:
+
+  DAT::tdual_int_1d k_eflag;
+  DAT::tdual_int_1d k_slist;
+  DAT::t_int_1d d_eflag;
+  DAT::t_int_1d d_slist;
+  HAT::t_int_1d h_eflag;
+  HAT::t_int_1d h_slist;
+  DAT::t_float_1d_3 d_sctr;
+  t_cinfo_1d d_cinfo;
+  t_cell_1d d_cells;
+  Kokkos::Crs<int, SPADeviceType, void, int> d_csurfs;
+  Kokkos::Crs<int, SPADeviceType, void, int> d_csubs;
+
+  t_line_1d d_lines;
+  t_tri_1d d_tris;
+  int dim;
+  int nsurf;
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running SPARTA to see the offending line.
+
+*/

--- a/src/compute_distsurf_grid.cpp
+++ b/src/compute_distsurf_grid.cpp
@@ -47,7 +47,7 @@ ComputeDistSurfGrid(SPARTA *sparta, int narg, char **arg) :
   igroup = surf->find_group(arg[3]);
   if (igroup < 0)
     error->all(FLERR,"Compute distsurf/grid command surface group "
-	       "does not exist");
+               "does not exist");
   sgroupbit = surf->bitmask[igroup];
 
   // optional args
@@ -62,7 +62,7 @@ ComputeDistSurfGrid(SPARTA *sparta, int narg, char **arg) :
       sdir[1] = input->numeric(FLERR,arg[iarg+2]);
       sdir[2] = input->numeric(FLERR,arg[iarg+3]);
       if (domain->dimension == 2 && sdir[2] != 0.0)
-	error->all(FLERR,"Illegal adapt command");
+        error->all(FLERR,"Illegal adapt command");
       iarg += 4;
     } else error->all(FLERR,"Illegal compute distsurf/grid command");
   }
@@ -120,8 +120,8 @@ void ComputeDistSurfGrid::compute_per_grid()
       eflag[i] = 0;
       if (!(lines[i].mask & sgroupbit)) continue;
       if (MathExtra::dot3(lines[i].norm,sdir) <= 0.0) {
-	eflag[i] = 1;
-	slist[nsurf++] = i;
+        eflag[i] = 1;
+        slist[nsurf++] = i;
       }
     }
   } else {
@@ -131,8 +131,8 @@ void ComputeDistSurfGrid::compute_per_grid()
       eflag[i] = 0;
       if (!(tris[i].mask & sgroupbit)) continue;
       if (MathExtra::dot3(tris[i].norm,sdir) <= 0.0) {
-	eflag[i] = 1;
-	slist[nsurf++] = i;
+        eflag[i] = 1;
+        slist[nsurf++] = i;
       }
     }
   }
@@ -181,24 +181,24 @@ void ComputeDistSurfGrid::compute_per_grid()
       n = cells[icell].nsurf;
       csurfs = cells[icell].csurfs;
       for (i = 0; i < n; i++) {
-	m = csurfs[i];
-	if (eflag[m]) break;
+        m = csurfs[i];
+        if (eflag[m]) break;
       }
 
       // cell is overlapped, set dist = 0.0 and return
       // if split cell, also set vector_grid = 0.0 for sub-cells
 
       if (i < n) {
-	vector_grid[icell] = 0.0;
-	if (cells[icell].nsplit > 1) {
-	  n = cells[icell].nsplit;
-	  csubs = sinfo[cells[icell].isplit].csubs;
-	  for (i = 0; i < n; i++) {
-	    m = csubs[i];
-	    vector_grid[m] = 0.0;
-	  }
-	}
-	continue;
+        vector_grid[icell] = 0.0;
+        if (cells[icell].nsplit > 1) {
+          n = cells[icell].nsplit;
+          csubs = sinfo[cells[icell].isplit].csubs;
+          for (i = 0; i < n; i++) {
+            m = csubs[i];
+            vector_grid[m] = 0.0;
+          }
+        }
+        continue;
       }
     }
 
@@ -218,12 +218,12 @@ void ComputeDistSurfGrid::compute_per_grid()
       cell2surf[2] = sctr[i][2] - cctr[2];
 
       if (dim == 2) {
-	if (MathExtra::dot3(cell2surf,lines[m].norm) > 0.0) continue;
-	dist = Geometry::dist_line_quad(lines[m].p1,lines[m].p2,lo,hi);
+        if (MathExtra::dot3(cell2surf,lines[m].norm) > 0.0) continue;
+        dist = Geometry::dist_line_quad(lines[m].p1,lines[m].p2,lo,hi);
       } else {
-	if (MathExtra::dot3(cell2surf,tris[m].norm) > 0.0) continue;
-	dist = Geometry::dist_tri_hex(tris[m].p1,tris[m].p2,tris[m].p3,
-				      tris[m].norm,lo,hi);
+        if (MathExtra::dot3(cell2surf,tris[m].norm) > 0.0) continue;
+        dist = Geometry::dist_tri_hex(tris[m].p1,tris[m].p2,tris[m].p3,
+                                      tris[m].norm,lo,hi);
       }
 
       mindist = MIN(mindist,dist);

--- a/src/compute_distsurf_grid.cpp
+++ b/src/compute_distsurf_grid.cpp
@@ -6,7 +6,7 @@
 
    Copyright (2014) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under 
+   certain rights in this software.  This software is distributed under
    the GNU General Public License.
 
    See the README file in the top-level SPARTA directory.
@@ -40,14 +40,14 @@ ComputeDistSurfGrid(SPARTA *sparta, int narg, char **arg) :
   size_per_grid_cols = 0;
 
   int igroup = grid->find_group(arg[2]);
-  if (igroup < 0) 
+  if (igroup < 0)
     error->all(FLERR,"Compute distsurf/grid group ID does not exist");
   groupbit = grid->bitmask[igroup];
 
   igroup = surf->find_group(arg[3]);
   if (igroup < 0)
     error->all(FLERR,"Compute distsurf/grid command surface group "
-               "does not exist");
+	       "does not exist");
   sgroupbit = surf->bitmask[igroup];
 
   // optional args
@@ -61,8 +61,8 @@ ComputeDistSurfGrid(SPARTA *sparta, int narg, char **arg) :
       sdir[0] = input->numeric(FLERR,arg[iarg+1]);
       sdir[1] = input->numeric(FLERR,arg[iarg+2]);
       sdir[2] = input->numeric(FLERR,arg[iarg+3]);
-      if (domain->dimension == 2 && sdir[2] != 0.0) 
-        error->all(FLERR,"Illegal adapt command");
+      if (domain->dimension == 2 && sdir[2] != 0.0)
+	error->all(FLERR,"Illegal adapt command");
       iarg += 4;
     } else error->all(FLERR,"Illegal compute distsurf/grid command");
   }
@@ -77,6 +77,7 @@ ComputeDistSurfGrid(SPARTA *sparta, int narg, char **arg) :
 
 ComputeDistSurfGrid::~ComputeDistSurfGrid()
 {
+  if (copymode) return;
   memory->destroy(vector_grid);
 }
 
@@ -119,8 +120,8 @@ void ComputeDistSurfGrid::compute_per_grid()
       eflag[i] = 0;
       if (!(lines[i].mask & sgroupbit)) continue;
       if (MathExtra::dot3(lines[i].norm,sdir) <= 0.0) {
-        eflag[i] = 1;
-        slist[nsurf++] = i;
+	eflag[i] = 1;
+	slist[nsurf++] = i;
       }
     }
   } else {
@@ -130,8 +131,8 @@ void ComputeDistSurfGrid::compute_per_grid()
       eflag[i] = 0;
       if (!(tris[i].mask & sgroupbit)) continue;
       if (MathExtra::dot3(tris[i].norm,sdir) <= 0.0) {
-        eflag[i] = 1;
-        slist[nsurf++] = i;
+	eflag[i] = 1;
+	slist[nsurf++] = i;
       }
     }
   }
@@ -180,24 +181,24 @@ void ComputeDistSurfGrid::compute_per_grid()
       n = cells[icell].nsurf;
       csurfs = cells[icell].csurfs;
       for (i = 0; i < n; i++) {
-        m = csurfs[i];
-        if (eflag[m]) break;
+	m = csurfs[i];
+	if (eflag[m]) break;
       }
 
       // cell is overlapped, set dist = 0.0 and return
       // if split cell, also set vector_grid = 0.0 for sub-cells
 
       if (i < n) {
-        vector_grid[icell] = 0.0;
-        if (cells[icell].nsplit > 1) {
-          n = cells[icell].nsplit;
-          csubs = sinfo[cells[icell].isplit].csubs;
-          for (i = 0; i < n; i++) {
-            m = csubs[i];
-            vector_grid[m] = 0.0;
-          }
-        }
-        continue;
+	vector_grid[icell] = 0.0;
+	if (cells[icell].nsplit > 1) {
+	  n = cells[icell].nsplit;
+	  csubs = sinfo[cells[icell].isplit].csubs;
+	  for (i = 0; i < n; i++) {
+	    m = csubs[i];
+	    vector_grid[m] = 0.0;
+	  }
+	}
+	continue;
       }
     }
 
@@ -211,23 +212,23 @@ void ComputeDistSurfGrid::compute_per_grid()
     mindist = BIG;
     for (i = 0; i < nsurf; i++) {
       m = slist[i];
-      
+
       cell2surf[0] = sctr[i][0] - cctr[0];
       cell2surf[1] = sctr[i][1] - cctr[1];
       cell2surf[2] = sctr[i][2] - cctr[2];
 
       if (dim == 2) {
-        if (MathExtra::dot3(cell2surf,lines[m].norm) > 0.0) continue;
-        dist = Geometry::dist_line_quad(lines[m].p1,lines[m].p2,lo,hi);
+	if (MathExtra::dot3(cell2surf,lines[m].norm) > 0.0) continue;
+	dist = Geometry::dist_line_quad(lines[m].p1,lines[m].p2,lo,hi);
       } else {
-        if (MathExtra::dot3(cell2surf,tris[m].norm) > 0.0) continue;
-        dist = Geometry::dist_tri_hex(tris[m].p1,tris[m].p2,tris[m].p3,
-                                      tris[m].norm,lo,hi);
+	if (MathExtra::dot3(cell2surf,tris[m].norm) > 0.0) continue;
+	dist = Geometry::dist_tri_hex(tris[m].p1,tris[m].p2,tris[m].p3,
+				      tris[m].norm,lo,hi);
       }
 
       mindist = MIN(mindist,dist);
     }
-    
+
     vector_grid[icell] = mindist;
   }
 

--- a/src/compute_distsurf_grid.h
+++ b/src/compute_distsurf_grid.h
@@ -6,7 +6,7 @@
 
    Copyright (2014) Sandia Corporation.  Under the terms of Contract
    DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
-   certain rights in this software.  This software is distributed under 
+   certain rights in this software.  This software is distributed under
    the GNU General Public License.
 
    See the README file in the top-level SPARTA directory.
@@ -34,7 +34,7 @@ class ComputeDistSurfGrid : public Compute {
   void reallocate();
   bigint memory_usage();
 
- private:
+ protected:
   int nglocal,groupbit,sgroupbit;
   double sdir[3];
 };


### PR DESCRIPTION
## Purpose

Added Kokkos for compute distsurf/grid command.

## Author(s)

Alan Stagg, Sandia National Laboratories.

## Backward Compatibility

No changes affect backward compatibility.

## Implementation Notes

Changes implemented via addition of KOKKOS/compute_distsurf_grid_kokkos.* files.  Correctness verified by comparing surface distances in output files via addition of the following compute, fix, and dump commands:

compute 1 distsurf/grid all all
fix 1 ave/grid all 1000 1 1000 c_1 ave running
dump 1 grid all 1000 distsurf.grid id f_1[*]

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [X] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


