### PR TITLE
Fix compile warnings in Kokkos surf_collide styles

### DIFF
--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -57,7 +57,6 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
   SurfCollideDiffuseKokkos(class SPARTA *);
   ~SurfCollideDiffuseKokkos();
 
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int) { return NULL; }
   void pre_collide();
 
 #ifndef SPARTA_KOKKOS_EXACT

--- a/src/KOKKOS/surf_collide_piston_kokkos.h
+++ b/src/KOKKOS/surf_collide_piston_kokkos.h
@@ -35,7 +35,6 @@ class SurfCollidePistonKokkos : public SurfCollidePiston {
   SurfCollidePistonKokkos(class SPARTA *);
   ~SurfCollidePistonKokkos() {}
 
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int) { return NULL; }
   void init();
 
   /* ----------------------------------------------------------------------

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -34,7 +34,6 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
   SurfCollideSpecularKokkos(class SPARTA *, int, char **);
   SurfCollideSpecularKokkos(class SPARTA *);
   ~SurfCollideSpecularKokkos() {}
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int) { return NULL; }
 
   /* ----------------------------------------------------------------------
      particle collision with surface with optional chemistry

--- a/src/KOKKOS/surf_collide_transparent_kokkos.h
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.h
@@ -33,7 +33,6 @@ class SurfCollideTransparentKokkos : public SurfCollideTransparent {
   SurfCollideTransparentKokkos(class SPARTA *, int, char **);
   SurfCollideTransparentKokkos(class SPARTA *);
   ~SurfCollideTransparentKokkos() {}
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int) { return NULL; }
 
   DAT::tdual_int_scalar k_nsingle;
   typename AT::t_int_scalar d_nsingle;

--- a/src/KOKKOS/surf_collide_vanish_kokkos.h
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.h
@@ -33,7 +33,6 @@ class SurfCollideVanishKokkos : public SurfCollideVanish {
   SurfCollideVanishKokkos(class SPARTA *, int, char **);
   SurfCollideVanishKokkos(class SPARTA *);
   ~SurfCollideVanishKokkos() {}
-  Particle::OnePart *collide(Particle::OnePart *&, double *, double &, int) { return NULL; }
 
   DAT::tdual_int_scalar k_nsingle;
   typename AT::t_int_scalar d_nsingle;


### PR DESCRIPTION
## Purpose

Fix compile warnings in Kokkos surf_collide styles

## Author(s)

Stan Moore (Sandia)

## Backward Compatibility

No issues.