### PR TITLE
Fix restart with large cellmax

### DIFF
--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -2283,6 +2283,7 @@ void Grid::read_restart(FILE *fp)
   // if so, need to reallocate surf arrays to correct max length
 
   if (maxsurfpercell != MAXSURFPERCELL) allocate_surf_arrays();
+  if (maxcellpersurf != MAXCELLPERSURF) allocate_cell_arrays();
 
   if (me == 0) fread(&nparent,sizeof(int),1,fp);
   MPI_Bcast(&nparent,1,MPI_INT,0,world);

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -45,9 +45,9 @@ enum{VERSION,SMALLINT,CELLINT,BIGINT,
      DIMENSION,AXISYMMETRIC,BOXLO,BOXHI,BFLAG,
      NPARTICLE,NUNSPLIT,NSPLIT,NSUB,NPOINT,NSURF,
      SPECIES,MIXTURE,PARTICLE_CUSTOM,GRID,SURF,
-     MULTIPROC,PROCSPERFILE,PERPROC};    // new fields added after PERPROC
+     MULTIPROC,PROCSPERFILE,PERPROC, CELLMAX};    // new fields added after PERPROC
 
-/* ---------------------------------------------------------------------- */
+/*------------------------------------------------------------------------*/
 
 ReadRestart::ReadRestart(SPARTA *spa) : Pointers(spa) {}
 
@@ -1029,6 +1029,9 @@ void ReadRestart::header(int incompatible)
       nsub_file = read_int();
     } else if (flag == NSURF) {
       nsurf_file = read_bigint();
+    } else if (flag == CELLMAX) {
+      grid->maxcellpersurf = read_int();
+
 
     } else error->all(FLERR,"Invalid flag in header section of restart file");
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -42,7 +42,7 @@ enum{VERSION,SMALLINT,CELLINT,BIGINT,
      DIMENSION,AXISYMMETRIC,BOXLO,BOXHI,BFLAG,
      NPARTICLE,NUNSPLIT,NSPLIT,NSUB,NPOINT,NSURF,
      SPECIES,MIXTURE,PARTICLE_CUSTOM,GRID,SURF,
-     MULTIPROC,PROCSPERFILE,PERPROC};    // new fields added after PERPROC
+     MULTIPROC,PROCSPERFILE,PERPROC, CELLMAX};    // new fields added after PERPROC
 
 /* ---------------------------------------------------------------------- */
 
@@ -522,6 +522,7 @@ void WriteRestart::header()
   write_int(NSPLIT,grid->nsplit);
   write_int(NSUB,grid->nsub);
   write_bigint(NSURF,surf->nsurf);
+  write_int(CELLMAX, grid->maxcellpersurf);
 
   // -1 flag signals end of header
 


### PR DESCRIPTION
## Purpose

Fixing restart with large number of surfaces overlapping cells. When you set the cellmax something higher than 100 the code couldn't restart and i was getting an error message to set the cellmax value in the global command although the cellmax was already set.

## Author(s)

Angelos Klothakis (Technical University of Crete)

## Backward Compatibility

Is backward compatible with version 7May2020, should also be compatible with April and January versions.

## Implementation Notes

Changes were made to grid.cpp, read_restart.cpp, write_restart.cpp. After the changes the code seems to restart and work fine. A review of the changes by the authors is required for verification.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


