### PR TITLE
bug fix in way vibrational modes are handled, with modes

### DIFF
--- a/src/compute_tvib_grid.cpp
+++ b/src/compute_tvib_grid.cpp
@@ -273,7 +273,9 @@ void ComputeTvibGrid::compute_per_grid()
 
   Grid::ChildInfo *cinfo = grid->cinfo;
   Particle::OnePart *particles = particle->particles;
+  Particle::Species *species = particle->species;
   int *s2g = particle->mixture[imix]->species2group;
+  double boltz = update->boltz;
   int nlocal = particle->nlocal;
 
   int i,j,ispecies,igroup,icell,imode,nmode;
@@ -290,8 +292,8 @@ void ComputeTvibGrid::compute_per_grid()
 
   if (modeflag == 0) {
     for (i = 0; i < nlocal; i++) {
-      if (particles[i].evib == 0) continue;
       ispecies = particles[i].ispecies;
+      if (!species[ispecies].vibdof) continue;
       igroup = s2g[ispecies];
       if (igroup < 0) continue;
       icell = particles[i].icell;
@@ -308,6 +310,7 @@ void ComputeTvibGrid::compute_per_grid()
 
     for (i = 0; i < nlocal; i++) {
       ispecies = particles[i].ispecies;
+      if (!species[ispecies].vibdof) continue;
       igroup = s2g[ispecies];
       if (igroup < 0) continue;
       icell = particles[i].icell;
@@ -317,9 +320,10 @@ void ComputeTvibGrid::compute_per_grid()
 
       nmode = particle->species[ispecies].nvibmode;
       for (imode = 0; imode < nmode; imode++) {
-        if (vibmode[i][imode] == 0) continue;
         j = s2t_mode[ispecies][imode];
-        tally[icell][j] += vibmode[i][imode];
+        if (nmode > 1) tally[icell][j] += vibmode[i][imode];
+        else tally[icell][j] +=
+	       particles[i].evib / (boltz*species[ispecies].vibtemp[0]);
         tally[icell][j+1] += 1.0;
       }
     }
@@ -445,7 +449,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
     int nsp = nmap[index] / maxmode / 2;
     int **vibmode = 
       particle->eiarray[particle->ewhich[index_vibmode]];
-
+      
     for (int icell = lo; icell < hi; icell++) {
       evib = emap[0];
       count = evib+1;
@@ -503,7 +507,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
     imode = index % maxmode;
     int **vibmode = 
       particle->eiarray[particle->ewhich[index_vibmode]];
-
+      
     for (int icell = lo; icell < hi; icell++) {
       evib = emap[2*imode];
       count = evib+1;

--- a/src/compute_tvib_grid.cpp
+++ b/src/compute_tvib_grid.cpp
@@ -449,7 +449,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
     int nsp = nmap[index] / maxmode / 2;
     int **vibmode = 
       particle->eiarray[particle->ewhich[index_vibmode]];
-      
+
     for (int icell = lo; icell < hi; icell++) {
       evib = emap[0];
       count = evib+1;
@@ -507,7 +507,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
     imode = index % maxmode;
     int **vibmode = 
       particle->eiarray[particle->ewhich[index_vibmode]];
-      
+
     for (int icell = lo; icell < hi; icell++) {
       evib = emap[2*imode];
       count = evib+1;


### PR DESCRIPTION
## Purpose

Fix a bug that was introduced a few months ago in compute trib/grid.  Some particles were incorrectly excluded from the computation and their range of modes not accounted for correctly.  This should close issue #158 

## Author(s)

Arnaud Borner (NASA Ames)

## Backward Compatibility

The example using compute tvib/grid needs to be re-blessed.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


