### PR TITLE
Fix issue in write_restart

### DIFF
--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -225,8 +225,11 @@ void WriteRestart::write(char *file)
   // communication buffer for my per-proc info = child grid cells and particles
   // max_size = largest buffer needed by any proc
 
-  int send_size = grid->size_restart();
-  send_size += particle->size_restart();
+  bigint send_size_big = grid->size_restart();
+  send_size_big += particle->size_restart_big();
+  if (send_size_big > MAXSMALLINT)
+    error->one(FLERR,"Restart file write buffer too large, use global mem/limit");
+  int send_size = send_size_big;
 
   int max_size;
   MPI_Allreduce(&send_size,&max_size,1,MPI_INT,MPI_MAX,world);


### PR DESCRIPTION
## Purpose

Fix type mismatch in some MPI calls in `write_restart` (`MPI_INT` vs `MPI_SPARTA_BIGINT`). Also put in error check if buffer size is too large.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes