### PR TITLE
Fix indexing issue in compute_tvib_grid

### DIFF
--- a/src/compute_tvib_grid.cpp
+++ b/src/compute_tvib_grid.cpp
@@ -402,7 +402,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
       evib = emap[0];
       count = evib+1;
       for (isp = 0; isp < nsp; isp++) {
-        ispecies = t2s[evib];
+        ispecies = t2s[evib-emap[0]];
         theta = species[ispecies].vibtemp[0];
         if (theta == 0.0 || etally[icell][count] == 0.0) {
           tspecies[isp] = 0.0;
@@ -454,7 +454,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
       evib = emap[0];
       count = evib+1;
       for (isp = 0; isp < nsp; isp++) {
-        ispecies = t2s_mode[evib];
+        ispecies = t2s_mode[evib-emap[0]];
         for (imode = 0; imode < maxmode; imode++) {
           theta = species[ispecies].vibtemp[imode];
           if (theta == 0.0 || etally[icell][count] == 0.0) {
@@ -512,7 +512,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
       evib = emap[2*imode];
       count = evib+1;
       for (isp = 0; isp < nsp; isp++) {
-        ispecies = t2s_mode[evib];
+        ispecies = t2s_mode[evib-emap[0]];
         theta = species[ispecies].vibtemp[imode];
         if (theta == 0.0 || etally[icell][count] == 0.0) {
           tspecies_mode[isp][imode] = 0.0;
@@ -540,7 +540,7 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
       numer = denom = 0.0;
       count = emap[2*imode+1];
       for (isp = 0; isp < nsp; isp++) {
-        ispecies = t2s[evib];
+        ispecies = t2s[evib-emap[0]];
         numer += tspecies_mode[isp][imode]*etally[icell][count];
         denom += etally[icell][count];
         count += 2*maxmode;


### PR DESCRIPTION
## Purpose

Fix indexing issue in `compute_tvib_grid` when used with `fix ave/grid`. The `t2s` array was allocated on a local index in `compute_tvib_grid`, but a global index from  `fix ave/grid` was being used in `post_process_grid`. Closes #5.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes