### PR TITLE
Kokkos refactor: reduce templates

### DIFF
--- a/src/KOKKOS/collide_vss_kokkos.h
+++ b/src/KOKKOS/collide_vss_kokkos.h
@@ -66,7 +66,6 @@ struct TagCollideCollisionsOne{};
 
 class CollideVSSKokkos : public CollideVSS {
  public:
-  typedef ArrayTypes<DeviceType> AT;
   typedef COLLIDE_REDUCE value_type;
 
   CollideVSSKokkos(class SPARTA *, int, char **);
@@ -128,49 +127,49 @@ class CollideVSSKokkos : public CollideVSS {
 
   t_particle_1d d_particles;
   t_species_1d_const d_species;
-  typename AT::t_int_2d d_plist;
+  DAT::t_int_2d d_plist;
 
   DAT::tdual_float_2d k_vremax_initial;
-  typename AT::t_float_2d d_vremax_initial;
+  DAT::t_float_2d d_vremax_initial;
   DAT::tdual_float_3d k_vremax;
-  typename AT::t_float_3d d_vremax;
+  DAT::t_float_3d d_vremax;
   DAT::tdual_float_3d k_remain;
-  typename AT::t_float_3d d_remain;
+  DAT::t_float_3d d_remain;
 
-  typedef Kokkos::DualView<int[10], SPADeviceType::array_layout, SPADeviceType> tdual_int_10;
+  typedef Kokkos::DualView<int[10], DeviceType::array_layout, DeviceType> tdual_int_10;
   typedef tdual_int_10::t_dev t_int_10;
   typedef tdual_int_10::t_host t_host_int_10;
   t_int_10 d_scalars;
   t_host_int_10 h_scalars;
 
-  typename AT::t_int_scalar d_nattempt_one;
+  DAT::t_int_scalar d_nattempt_one;
   HAT::t_int_scalar h_nattempt_one;
 
-  typename AT::t_int_scalar d_ncollide_one;
+  DAT::t_int_scalar d_ncollide_one;
   HAT::t_int_scalar h_ncollide_one;
 
-  typename AT::t_int_scalar d_nreact_one;
+  DAT::t_int_scalar d_nreact_one;
   HAT::t_int_scalar h_nreact_one;
 
-  typename AT::t_int_scalar d_error_flag;
+  DAT::t_int_scalar d_error_flag;
   HAT::t_int_scalar h_error_flag;
 
-  typename AT::t_int_scalar d_retry;
+  DAT::t_int_scalar d_retry;
   HAT::t_int_scalar h_retry;
 
-  typename AT::t_int_scalar d_maxdelete;
+  DAT::t_int_scalar d_maxdelete;
   HAT::t_int_scalar h_maxdelete;
 
-  typename AT::t_int_scalar d_maxcellcount;
+  DAT::t_int_scalar d_maxcellcount;
   HAT::t_int_scalar h_maxcellcount;
 
-  typename AT::t_int_scalar d_part_grow;
+  DAT::t_int_scalar d_part_grow;
   HAT::t_int_scalar h_part_grow;
 
-  typename AT::t_int_scalar d_ndelete;
+  DAT::t_int_scalar d_ndelete;
   HAT::t_int_scalar h_ndelete;
 
-  typename AT::t_int_scalar d_nlocal;
+  DAT::t_int_scalar d_nlocal;
   HAT::t_int_scalar h_nlocal;
 
   DAT::tdual_int_1d k_dellist;
@@ -178,14 +177,14 @@ class CollideVSSKokkos : public CollideVSS {
 
   DAT::t_float_2d d_recomb_ijflag;
 
-  typename AT::t_int_2d d_nn_last_partner;
+  DAT::t_int_2d d_nn_last_partner;
 
   template < int NEARCP > void collisions_one(COLLIDE_REDUCE&);
 
   // VSS specific
 
   DAT::tdual_float_2d k_prefactor;
-  typename AT::t_float_2d d_prefactor;
+  DAT::t_float_2d d_prefactor;
 
   typedef Kokkos::
     DualView<Params*, Kokkos::LayoutRight, DeviceType> tdual_params_1d;
@@ -233,10 +232,10 @@ class CollideVSSKokkos : public CollideVSS {
   void restore();
 
   t_particle_1d d_particles_backup;
-  typename AT::t_int_2d d_plist_backup;
-  typename AT::t_float_3d d_vremax_backup;
-  typename AT::t_float_3d d_remain_backup;
-  typename AT::t_int_2d d_nn_last_partner_backup;
+  DAT::t_int_2d d_plist_backup;
+  DAT::t_float_3d d_vremax_backup;
+  DAT::t_float_3d d_remain_backup;
+  DAT::t_int_2d d_nn_last_partner_backup;
   RanPark* random_backup;
   RanPark* react_random_backup;
 };

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -39,7 +39,7 @@ CommKokkos::CommKokkos(SPARTA *sparta) : Comm(sparta)
   iparticle = new IrregularKokkos(sparta);
 
   k_nsend = DAT::tdual_int_scalar("comm:nsend");
-  d_nsend = k_nsend.view<DeviceType>();
+  d_nsend = k_nsend.d_view;
   h_nsend = k_nsend.h_view;
   d_nlocal = DAT::t_int_scalar("comm:nlocal");
 }
@@ -127,8 +127,8 @@ int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d d_plis
   //int offset = 0;
 
   h_nsend() = 0;
-  k_nsend.modify<SPAHostType>();
-  k_nsend.sync<DeviceType>();
+  k_nsend.modify_host();
+  k_nsend.sync_device();
 
   particle_kk->sync(Device,PARTICLE_MASK);
   grid_kk->sync(Device,CELL_MASK);
@@ -167,8 +167,8 @@ int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d d_plis
 
   Kokkos::deep_copy(h_pproc,d_pproc);
 
-  k_nsend.modify<DeviceType>();
-  k_nsend.sync<SPAHostType>();
+  k_nsend.modify_device();
+  k_nsend.sync_host();
   nsend = h_nsend();
 
   // compress my list of particles

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -30,7 +30,6 @@ struct TagCommMigrateUnpackParticles{};
 
 class CommKokkos : public Comm {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   CommKokkos(class SPARTA *);
   ~CommKokkos();

--- a/src/KOKKOS/compute_boundary_kokkos.cpp
+++ b/src/KOKKOS/compute_boundary_kokkos.cpp
@@ -88,11 +88,11 @@ void ComputeBoundaryKokkos::compute_array()
   if (sparta->kokkos->gpu_direct_flag) {
     MPI_Allreduce(d_myarray.data(),d_array.data(),nrow*ntotal,
                   MPI_DOUBLE,MPI_SUM,world);
-    k_array.modify<DeviceType>();
-    k_array.sync<SPAHostType>();
+    k_array.modify_device();
+    k_array.sync_host();
   } else {
-    k_myarray.modify<DeviceType>();
-    k_myarray.sync<SPAHostType>();
+    k_myarray.modify_device();
+    k_myarray.sync_host();
     MPI_Allreduce(k_myarray.h_view.data(),k_array.h_view.data(),nrow*ntotal,
                   MPI_DOUBLE,MPI_SUM,world);
   }
@@ -125,7 +125,7 @@ void ComputeBoundaryKokkos::pre_boundary_tally()
   ParticleKokkos* particle_kk = (ParticleKokkos*) particle;
   particle_kk->sync(Device,PARTICLE_MASK|SPECIES_MASK);
   d_species = particle_kk->k_species.d_view;
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
 
   need_dup = sparta->kokkos->need_dup<DeviceType>();
   if (need_dup)

--- a/src/KOKKOS/compute_count_kokkos.cpp
+++ b/src/KOKKOS/compute_count_kokkos.cpp
@@ -92,8 +92,8 @@ double ComputeCountKokkos::compute_scalar()
   invoked_scalar = update->ntimestep;
 
   per_species_tally_kokkos();
-  k_count.modify<DeviceType>();
-  k_count.sync<SPAHostType>();
+  k_count.modify_device();
+  k_count.sync_host();
   for (int m=0; m<maxspecies; ++m)
     count[m] = k_count.h_view(m);
 
@@ -122,8 +122,8 @@ void ComputeCountKokkos::compute_vector()
   invoked_scalar = update->ntimestep;
 
   per_species_tally_kokkos();
-  k_count.modify<DeviceType>();
-  k_count.sync<SPAHostType>();
+  k_count.modify_device();
+  k_count.sync_host();
   for (int m=0; m<maxspecies; ++m)
     count[m] = k_count.h_view(m);
 

--- a/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
@@ -58,8 +58,8 @@ void ComputeDistSurfGridKokkos::compute_per_grid()
     ComputeDistSurfGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
-    k_vector_grid.modify<DeviceType>();
-    k_vector_grid.sync<SPAHostType>();
+    k_vector_grid.modify_device();
+    k_vector_grid.sync_host();
   }
 }
 
@@ -105,11 +105,11 @@ void ComputeDistSurfGridKokkos::compute_per_grid_kokkos()
       }
     }
   }
-  k_eflag.modify<SPAHostType>();
-  k_slist.modify<SPAHostType>();
+  k_eflag.modify_host();
+  k_slist.modify_host();
 
-  k_eflag.sync<DeviceType>();
-  k_slist.sync<DeviceType>();
+  k_eflag.sync_device();
+  k_slist.sync_device();
 
   d_sctr = DAT::t_float_1d_3("compute/distsurf/grid:sctr",nsurf);
 

--- a/src/KOKKOS/compute_distsurf_grid_kokkos.h
+++ b/src/KOKKOS/compute_distsurf_grid_kokkos.h
@@ -57,8 +57,8 @@ struct TagComputeDistSurfGrid_surf_distance{};
   DAT::t_float_1d_3 d_sctr;
   t_cinfo_1d d_cinfo;
   t_cell_1d d_cells;
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csurfs;
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csubs;
+  Kokkos::Crs<int, DeviceType, void, int> d_csurfs;
+  Kokkos::Crs<int, DeviceType, void, int> d_csubs;
 
   t_line_1d d_lines;
   t_tri_1d d_tris;

--- a/src/KOKKOS/compute_eflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.cpp
@@ -55,8 +55,8 @@ ComputeEFluxGridKokkos::ComputeEFluxGridKokkos(SPARTA *sparta, int narg, char **
   k_unique = DAT::tdual_int_1d("compute/eflux/grid:unique",npergroup);
   for (int m = 0; m < npergroup; m++)
     k_unique.h_view(m) = unique[m];
-  k_unique.modify<SPAHostType>();
-  k_unique.sync<DeviceType>();
+  k_unique.modify_host();
+  k_unique.sync_device();
   d_unique = k_unique.d_view;
 }
 
@@ -80,8 +80,8 @@ void ComputeEFluxGridKokkos::compute_per_grid()
     ComputeEFluxGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
-    k_tally.modify<DeviceType>();
-    k_tally.sync<SPAHostType>();
+    k_tally.modify_device();
+    k_tally.sync_host();
   }
 }
 
@@ -102,7 +102,7 @@ void ComputeEFluxGridKokkos::compute_per_grid_kokkos()
   grid_kk->sync(Device,CINFO_MASK);
   d_cinfo = grid_kk->k_cinfo.d_view;
 
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
   int nlocal = particle->nlocal;
 
   // zero all accumulators

--- a/src/KOKKOS/compute_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_grid_kokkos.cpp
@@ -51,8 +51,8 @@ ComputeGridKokkos::ComputeGridKokkos(SPARTA *sparta, int narg, char **arg) :
   k_unique = DAT::tdual_int_1d("compute/grid:unique",npergroup);
   for (int m = 0; m < npergroup; m++)
     k_unique.h_view(m) = unique[m];
-  k_unique.modify<SPAHostType>();
-  k_unique.sync<DeviceType>();
+  k_unique.modify_host();
+  k_unique.sync_device();
   d_unique = k_unique.d_view;
 }
 
@@ -76,8 +76,8 @@ void ComputeGridKokkos::compute_per_grid()
     ComputeGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
-    k_tally.modify<DeviceType>();
-    k_tally.sync<SPAHostType>();
+    k_tally.modify_device();
+    k_tally.sync_host();
   }
 }
 
@@ -98,7 +98,7 @@ void ComputeGridKokkos::compute_per_grid_kokkos()
   grid_kk->sync(Device,CINFO_MASK);
   d_cinfo = grid_kk->k_cinfo.d_view;
 
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
   int nlocal = particle->nlocal;
 
   // zero all accumulators

--- a/src/KOKKOS/compute_lambda_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_lambda_grid_kokkos.cpp
@@ -166,11 +166,11 @@ void ComputeLambdaGridKokkos::compute_per_grid_kokkos()
   copymode = 0;
 
   if (kflag == KNONE) {
-    k_vector_grid.modify<DeviceType>();
-    k_vector_grid.sync<SPAHostType>();
+    k_vector_grid.modify_device();
+    k_vector_grid.sync_host();
   } else {
-    k_array_grid.modify<DeviceType>();
-    k_array_grid.sync<SPAHostType>();
+    k_array_grid.modify_device();
+    k_array_grid.sync_host();
   }
 }
 

--- a/src/KOKKOS/compute_pflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.cpp
@@ -52,8 +52,8 @@ ComputePFluxGridKokkos::ComputePFluxGridKokkos(SPARTA *sparta, int narg, char **
   k_unique = DAT::tdual_int_1d("compute/pflux/grid:unique",npergroup);
   for (int m = 0; m < npergroup; m++)
     k_unique.h_view(m) = unique[m];
-  k_unique.modify<SPAHostType>();
-  k_unique.sync<DeviceType>();
+  k_unique.modify_host();
+  k_unique.sync_device();
   d_unique = k_unique.d_view;
 }
 
@@ -77,8 +77,8 @@ void ComputePFluxGridKokkos::compute_per_grid()
     ComputePFluxGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
-    k_tally.modify<DeviceType>();
-    k_tally.sync<SPAHostType>();
+    k_tally.modify_device();
+    k_tally.sync_host();
   }
 }
 
@@ -99,7 +99,7 @@ void ComputePFluxGridKokkos::compute_per_grid_kokkos()
   grid_kk->sync(Device,CINFO_MASK);
   d_cinfo = grid_kk->k_cinfo.d_view;
 
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
   int nlocal = particle->nlocal;
 
   // zero all accumulators

--- a/src/KOKKOS/compute_property_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_property_grid_kokkos.cpp
@@ -40,8 +40,8 @@ ComputePropertyGridKokkos::ComputePropertyGridKokkos(SPARTA *sparta, int narg, c
   for (int n = 0; n < nvalues; n++){
     k_index.h_view(n) = index[n];
   }
-  k_index.modify<SPAHostType>();
-  k_index.sync<DeviceType>();
+  k_index.modify_host();
+  k_index.sync_device();
   d_index = k_index.d_view;
 }
 
@@ -67,11 +67,11 @@ void ComputePropertyGridKokkos::compute_per_grid()
   } else {
     compute_per_grid_kokkos();
     if (nvalues == 1) {
-      k_vector_grid.modify<DeviceType>();
-      k_vector_grid.sync<SPAHostType>();
+      k_vector_grid.modify_device();
+      k_vector_grid.sync_host();
     } else {
-      k_array_grid.modify<DeviceType>();
-      k_array_grid.sync<SPAHostType>();
+      k_array_grid.modify_device();
+      k_array_grid.sync_host();
     }
   }
 }

--- a/src/KOKKOS/compute_sonine_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.cpp
@@ -51,13 +51,13 @@ ComputeSonineGridKokkos::ComputeSonineGridKokkos(SPARTA *sparta, int narg, char 
     k_moment.h_view(n) = moment[n];
     k_order.h_view(n) = order[n];
   }
-  k_which.modify<SPAHostType>();
-  k_moment.modify<SPAHostType>();
-  k_order.modify<SPAHostType>();
+  k_which.modify_host();
+  k_moment.modify_host();
+  k_order.modify_host();
 
-  k_which.sync<DeviceType>();
-  k_moment.sync<DeviceType>();
-  k_order.sync<DeviceType>();
+  k_which.sync_device();
+  k_moment.sync_device();
+  k_order.sync_device();
 
   d_which = k_which.d_view;
   d_moment = k_moment.d_view;
@@ -84,8 +84,8 @@ void ComputeSonineGridKokkos::compute_per_grid()
     ComputeSonineGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
-    k_tally.modify<DeviceType>();
-    k_tally.sync<SPAHostType>();
+    k_tally.modify_device();
+    k_tally.sync_host();
   }
 }
 
@@ -104,7 +104,7 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
   d_plist = grid_kk->d_plist;
   grid_kk->sync(Device,CINFO_MASK);
   d_cinfo = grid_kk->k_cinfo.d_view;
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
   int nlocal = particle->nlocal;
 
   // zero all accumulators

--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -129,7 +129,7 @@ void ComputeSurfKokkos::pre_surf_tally()
   ParticleKokkos* particle_kk = (ParticleKokkos*) particle;
   particle_kk->sync(Device,SPECIES_MASK);
   d_species = particle_kk->k_species.d_view;
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
 
   SurfKokkos* surf_kk = (SurfKokkos*) surf;
   surf_kk->sync(Device,ALL_MASK);
@@ -152,8 +152,8 @@ void ComputeSurfKokkos::post_surf_tally()
     dup_array_surf_tally = decltype(dup_array_surf_tally)(); // free duplicated memory
   }
 
-  k_tally2surf.modify<DeviceType>();
-  k_array_surf_tally.modify<DeviceType>();
+  k_tally2surf.modify_device();
+  k_array_surf_tally.modify_device();
 }
 
 /* ----------------------------------------------------------------------
@@ -162,10 +162,10 @@ void ComputeSurfKokkos::post_surf_tally()
 
 int ComputeSurfKokkos::tallyinfo(surfint *&ptr)
 {
-  k_tally2surf.sync<SPAHostType>();
+  k_tally2surf.sync_host();
   ptr = tally2surf;
 
-  k_array_surf_tally.sync<SPAHostType>();
+  k_array_surf_tally.sync_host();
 
   auto h_ntally = Kokkos::create_mirror_view(d_ntally);
   Kokkos::deep_copy(h_ntally,d_ntally);

--- a/src/KOKKOS/compute_thermal_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_thermal_grid_kokkos.cpp
@@ -64,8 +64,8 @@ void ComputeThermalGridKokkos::compute_per_grid()
     ComputeThermalGrid::compute_per_grid();
   } else {
     compute_per_grid_kokkos();
-    k_tally.modify<DeviceType>();
-    k_tally.sync<SPAHostType>();
+    k_tally.modify_device();
+    k_tally.sync_host();
   }
 }
 
@@ -86,7 +86,7 @@ void ComputeThermalGridKokkos::compute_per_grid_kokkos()
   grid_kk->sync(Device,CINFO_MASK);
   d_cinfo = grid_kk->k_cinfo.d_view;
 
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
   int nlocal = particle->nlocal;
 
   // zero all accumulators

--- a/src/KOKKOS/create_particles_kokkos.cpp
+++ b/src/KOKKOS/create_particles_kokkos.cpp
@@ -141,7 +141,7 @@ void CreateParticlesKokkos::create_local(bigint np)
 
   double vstream_variable[3];
 
-  Kokkos::View<int*, SPADeviceType> d_npercell("npercell", nglocal);
+  Kokkos::View<int*, DeviceType> d_npercell("npercell", nglocal);
   auto h_npercell = Kokkos::create_mirror_view(d_npercell);
 
   for (int i = 0; i < nglocal; i++) {
@@ -184,16 +184,16 @@ void CreateParticlesKokkos::create_local(bigint np)
   auto h_cells2cands = Kokkos::create_mirror_view(d_cells2cands);
   Kokkos::deep_copy(h_cells2cands, d_cells2cands);
 
-  Kokkos::View<int*, SPADeviceType> d_keep("cand_keep", ncands);
-  Kokkos::View<int*, SPADeviceType> d_isp("cand_x", ncands);
-  Kokkos::View<double*[3], SPADeviceType> d_x("cand_x", ncands);
-  Kokkos::View<double*, SPADeviceType> d_vn("cand_vn", ncands);
-  Kokkos::View<double*, SPADeviceType> d_vr("cand_vr", ncands);
-  Kokkos::View<double*[2], SPADeviceType> d_theta("cand_theta", ncands);
-  Kokkos::View<double*, SPADeviceType> d_erot("cand_erot", ncands);
-  Kokkos::View<double*, SPADeviceType> d_evib("cand_evib", ncands);
-  Kokkos::View<int*, SPADeviceType> d_id("cand_id", ncands);
-  Kokkos::View<double*[3], SPADeviceType> d_v("cand_v", ncands);
+  Kokkos::View<int*, DeviceType> d_keep("cand_keep", ncands);
+  Kokkos::View<int*, DeviceType> d_isp("cand_x", ncands);
+  Kokkos::View<double*[3], DeviceType> d_x("cand_x", ncands);
+  Kokkos::View<double*, DeviceType> d_vn("cand_vn", ncands);
+  Kokkos::View<double*, DeviceType> d_vr("cand_vr", ncands);
+  Kokkos::View<double*[2], DeviceType> d_theta("cand_theta", ncands);
+  Kokkos::View<double*, DeviceType> d_erot("cand_erot", ncands);
+  Kokkos::View<double*, DeviceType> d_evib("cand_evib", ncands);
+  Kokkos::View<int*, DeviceType> d_id("cand_id", ncands);
+  Kokkos::View<double*[3], DeviceType> d_v("cand_v", ncands);
   auto h_keep = Kokkos::create_mirror_view(d_keep);
   auto h_isp = Kokkos::create_mirror_view(d_isp);
   auto h_x = Kokkos::create_mirror_view(d_x);
@@ -287,8 +287,8 @@ void CreateParticlesKokkos::create_local(bigint np)
   auto particleKK = dynamic_cast<ParticleKokkos*>(particle);
   particleKK->grow(nnew);
   particleKK->sync(Device, PARTICLE_MASK | SPECIES_MASK);
-  auto d_particles = particleKK->k_particles.view<SPADeviceType>();
-  Kokkos::View<int*, SPADeviceType> d_species("species", nspecies);
+  auto d_particles = particleKK->k_particles.d_view;
+  Kokkos::View<int*, DeviceType> d_species("species", nspecies);
   auto h_species = Kokkos::create_mirror_view(d_species);
   for (int i = 0; i < nspecies; ++i) h_species(i) = species[i];
   Kokkos::deep_copy(d_species, h_species);

--- a/src/KOKKOS/fix_ave_grid_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_grid_kokkos.cpp
@@ -89,16 +89,16 @@ FixAveGridKokkos::FixAveGridKokkos(SPARTA *sparta, int narg, char **arg) :
       k_uomap.h_view(i,j) = uomap[i][j];
     }
   }
-  k_numap.modify<SPAHostType>();
-  k_numap.sync<DeviceType>();
+  k_numap.modify_host();
+  k_numap.sync_device();
   d_numap = k_numap.d_view;
 
-  k_umap.modify<SPAHostType>();
-  k_umap.sync<DeviceType>();
+  k_umap.modify_host();
+  k_umap.sync_device();
   d_umap = k_umap.d_view;
 
-  k_uomap.modify<SPAHostType>();
-  k_uomap.sync<DeviceType>();
+  k_uomap.modify_host();
+  k_uomap.sync_device();
   d_uomap = k_uomap.d_view;
 }
 
@@ -300,11 +300,11 @@ void FixAveGridKokkos::end_of_step()
   }
 
   if (nvalues == 1) {
-    k_vector_grid.modify<DeviceType>();
-    k_vector_grid.sync<SPAHostType>();
+    k_vector_grid.modify_device();
+    k_vector_grid.sync_host();
   } else {
-    k_array_grid.modify<DeviceType>();
-    k_array_grid.sync<SPAHostType>();
+    k_array_grid.modify_device();
+    k_array_grid.sync_host();
   }
 
   // set values for grid cells not in group to zero
@@ -413,11 +413,11 @@ void FixAveGridKokkos::grow_percell(int nnew)
   if (nvalues == 1) {
     memoryKK->grow_kokkos(k_vector_grid,vector_grid,n,"ave/grid:vector_grid");
     d_vector = k_vector_grid.d_view;
-    k_vector_grid.sync<SPAHostType>();
+    k_vector_grid.sync_host();
   } else {
     memoryKK->grow_kokkos(k_array_grid,array_grid,n,nvalues,"ave/grid:array_grid");
     d_array_grid = k_array_grid.d_view;
-    k_array_grid.sync<SPAHostType>();
+    k_array_grid.sync_host();
   }
 
   memoryKK->grow_kokkos(k_tally,tally,n,ntotal,"ave/grid:tally");

--- a/src/KOKKOS/fix_ave_histo_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_kokkos.cpp
@@ -137,19 +137,19 @@ void FixAveHistoKokkos::end_of_step()
   particle_kk->sync(Device, PARTICLE_MASK|SPECIES_MASK);
   d_particles = particle_kk->k_particles.d_view;
 
-  d_s2g = particle_kk->k_species2group.view<DeviceType>();
+  d_s2g = particle_kk->k_species2group.d_view;
 
   copymode = 1;
 
   // zero if first step
   if (irepeat == 0) {
     for (int i=0; i<4; i++) k_stats.h_view(i) = 0.0;
-    k_stats.modify<SPAHostType>();
-    k_stats.sync<DeviceType>();
+    k_stats.modify_host();
+    k_stats.sync_device();
 
     for (int i=0; i<nbins; i++) k_bin.h_view(i) = 0.0;
-    k_bin.modify<SPAHostType>();
-    k_bin.sync<DeviceType>();
+    k_bin.modify_host();
+    k_bin.sync_device();
   }
 
   minmax_type::value_type minmax;
@@ -323,11 +323,11 @@ void FixAveHistoKokkos::end_of_step()
     }
   }
 
-  k_stats.modify<DeviceType>();
-  k_stats.sync<SPAHostType>();
+  k_stats.modify_device();
+  k_stats.sync_host();
 
-  k_bin.modify<DeviceType>();
-  k_bin.sync<SPAHostType>();
+  k_bin.modify_device();
+  k_bin.sync_host();
 
   // Copy data back
   stats[0] = k_stats.h_view(0);

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -91,15 +91,15 @@ FixEmitFaceKokkos::~FixEmitFaceKokkos()
 
 void FixEmitFaceKokkos::init()
 {
-  k_tasks.sync<SPAHostType>();
-  if (perspecies) k_ntargetsp.sync<SPAHostType>();
-  if (subsonic_style == PONLY) k_vscale.sync<SPAHostType>();
+  k_tasks.sync_host();
+  if (perspecies) k_ntargetsp.sync_host();
+  if (subsonic_style == PONLY) k_vscale.sync_host();
 
   FixEmitFace::init();
 
-  k_tasks.modify<SPAHostType>();
-  if (perspecies) k_ntargetsp.modify<SPAHostType>();
-  if (subsonic_style == PONLY) k_vscale.modify<SPAHostType>();
+  k_tasks.modify_host();
+  if (perspecies) k_ntargetsp.modify_host();
+  if (subsonic_style == PONLY) k_vscale.modify_host();
 
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.init(random);
@@ -123,9 +123,9 @@ void FixEmitFaceKokkos::init()
     h_species(isp) = particle->mixture[imix]->species[isp];
   }
 
-  k_mix_vscale .modify<SPAHostType>();
-  k_cummulative.modify<SPAHostType>();
-  k_species    .modify<SPAHostType>();
+  k_mix_vscale .modify_host();
+  k_cummulative.modify_host();
+  k_species    .modify_host();
 }
 
 /* ----------------------------------------------------------------------
@@ -136,9 +136,9 @@ void FixEmitFaceKokkos::init()
 void FixEmitFaceKokkos::create_task(int icell)
 {
   FixEmitFace::create_task(icell);
-  k_tasks.modify<SPAHostType>();
-  k_ntargetsp.modify<SPAHostType>();
-  k_vscale.modify<SPAHostType>();
+  k_tasks.modify_host();
+  k_ntargetsp.modify_host();
+  k_vscale.modify_host();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -161,8 +161,8 @@ void FixEmitFaceKokkos::perform_task()
 
   // copy needed task data to device
 
-  if (perspecies) k_ntargetsp.sync<SPADeviceType>();
-  else k_tasks.sync<SPADeviceType>();
+  if (perspecies) k_ntargetsp.sync_device();
+  else k_tasks.sync_device();
 
   auto ninsert_dim1 = perspecies ? nspecies : 1;
   if (d_ninsert.extent(0) < ntask * ninsert_dim1)
@@ -222,17 +222,17 @@ void FixEmitFaceKokkos::perform_task()
 
   // copy needed task data to device
 
-  k_tasks.sync<DeviceType>();
-  if (perspecies) k_ntargetsp.sync<DeviceType>();
-  if (subsonic_style == PONLY) k_vscale.sync<DeviceType>();
+  k_tasks.sync_device();
+  if (perspecies) k_ntargetsp.sync_device();
+  if (subsonic_style == PONLY) k_vscale.sync_device();
   auto ld_tasks = d_tasks;
   auto ld_vscale = d_vscale;
 
   // copy needed mixture data to device
 
-  k_mix_vscale .sync<SPADeviceType>();
-  k_species    .sync<SPADeviceType>();
-  k_cummulative.sync<SPADeviceType>();
+  k_mix_vscale .sync_device();
+  k_species    .sync_device();
+  k_cummulative.sync_device();
 
   auto ld_mix_vscale = d_mix_vscale;
   auto ld_species    = d_species   ;
@@ -257,7 +257,7 @@ void FixEmitFaceKokkos::perform_task()
   auto nlocal_before = particleKK->nlocal;
   particleKK->grow(nnew);
   particleKK->sync(SPARTA_NS::Device, PARTICLE_MASK);
-  auto ld_particles = particleKK->k_particles.view<SPADeviceType>();
+  auto ld_particles = particleKK->k_particles.d_view;
 
   Kokkos::parallel_for(ncands, SPARTA_LAMBDA(int cand) {
     if (!ld_keep(cand)) return;
@@ -319,7 +319,7 @@ void FixEmitFaceKokkos::perform_task()
 
     // copy needed task data to host
 
-    k_tasks.sync<SPAHostType>();
+    k_tasks.sync_host();
 
     auto h_cands2new = Kokkos::create_mirror_view(ld_cands2new);
     Kokkos::deep_copy(h_cands2new, ld_cands2new);
@@ -499,8 +499,8 @@ void FixEmitFaceKokkos::grow_task()
   if (tasks == NULL)
     k_tasks = tdual_task_1d("emit/face:tasks",ntaskmax);
   else {
-    k_tasks.sync<SPAHostType>();
-    k_tasks.modify<SPAHostType>(); // force resize on host
+    k_tasks.sync_host();
+    k_tasks.modify_host(); // force resize on host
     k_tasks.resize(ntaskmax);
   }
   d_tasks = k_tasks.d_view;
@@ -514,8 +514,8 @@ void FixEmitFaceKokkos::grow_task()
   // allocate vectors in each new task or set to NULL
 
   if (perspecies) {
-    k_ntargetsp.sync<SPAHostType>();
-    k_ntargetsp.modify<SPAHostType>(); // force resize on host
+    k_ntargetsp.sync_host();
+    k_ntargetsp.modify_host(); // force resize on host
     k_ntargetsp.resize(ntaskmax,nspecies);
     d_ntargetsp = k_ntargetsp.d_view;
     for (int i = 0; i < ntaskmax; i++)
@@ -523,8 +523,8 @@ void FixEmitFaceKokkos::grow_task()
   }
   
   if (subsonic_style == PONLY) {
-    k_vscale.modify<SPAHostType>(); // force resize on host
-    k_vscale.sync<SPAHostType>();
+    k_vscale.modify_host(); // force resize on host
+    k_vscale.sync_host();
     k_vscale.resize(ntaskmax,nspecies);
     d_vscale = k_vscale.d_view;
     for (int i = 0; i < ntaskmax; i++)

--- a/src/KOKKOS/fix_emit_face_kokkos.h
+++ b/src/KOKKOS/fix_emit_face_kokkos.h
@@ -61,7 +61,7 @@ class FixEmitFaceKokkos : public FixEmitFace {
  private:
   KKCopy<ParticleKokkos> particle_kk_copy;
 
-  typedef Kokkos::DualView<Task*, SPADeviceType::array_layout, DeviceType> tdual_task_1d;
+  typedef Kokkos::DualView<Task*, DeviceType::array_layout, DeviceType> tdual_task_1d;
   typedef tdual_task_1d::t_dev t_task_1d;
   tdual_task_1d k_tasks;
   t_task_1d d_tasks;
@@ -72,7 +72,7 @@ class FixEmitFaceKokkos : public FixEmitFace {
   DAT::t_float_2d_lr d_vscale;
 
   DAT::tdual_int_1d k_ninsert;
-  Kokkos::View<int*, SPADeviceType> d_ninsert;
+  Kokkos::View<int*, DeviceType> d_ninsert;
   DAT::t_int_1d d_task2cand;
 
   DAT::t_float_2d d_x;
@@ -85,7 +85,7 @@ class FixEmitFaceKokkos : public FixEmitFace {
   DAT::t_int_1d   d_id;
   DAT::t_int_1d   d_isp;
   DAT::t_int_1d   d_task;
-  Kokkos::View<int*, SPADeviceType> d_keep; // won't compile with DAT::t_int_1d type
+  Kokkos::View<int*, DeviceType> d_keep; // won't compile with DAT::t_int_1d type
 
   DAT::tdual_float_1d k_mix_vscale;
   DAT::tdual_float_1d k_cummulative;

--- a/src/KOKKOS/fix_grid_check_kokkos.cpp
+++ b/src/KOKKOS/fix_grid_check_kokkos.cpp
@@ -46,14 +46,14 @@ void FixGridCheckKokkos::end_of_step()
   if (update->ntimestep % nevery) return;
 
   auto particleKK = dynamic_cast<ParticleKokkos*>(particle);
-  particleKK->k_particles.sync<SPADeviceType>();
+  particleKK->k_particles.sync_device();
   auto d_particles = particleKK->k_particles.d_view;
   auto gridKK = dynamic_cast<GridKokkos*>(grid);
-  gridKK->k_cells.sync<SPADeviceType>();
+  gridKK->k_cells.sync_device();
   auto d_cells = gridKK->k_cells.d_view;
-  gridKK->k_cinfo.sync<SPADeviceType>();
+  gridKK->k_cinfo.sync_device();
   auto d_cinfo = gridKK->k_cinfo.d_view;
-  gridKK->k_sinfo.sync<SPADeviceType>();
+  gridKK->k_sinfo.sync_device();
   auto d_sinfo = gridKK->k_sinfo.d_view;
   int nglocal = grid->nlocal;
   int nlocal = particle->nlocal;

--- a/src/KOKKOS/grid_kokkos.cpp
+++ b/src/KOKKOS/grid_kokkos.cpp
@@ -240,8 +240,8 @@ void GridKokkos::wrap_kokkos()
 
   if (cells != k_cells.h_view.data()) {
     memoryKK->wrap_kokkos(k_cells,cells,maxcell,"grid:cells");
-    k_cells.modify<SPAHostType>();
-    k_cells.sync<DeviceType>();
+    k_cells.modify_host();
+    k_cells.sync_device();
     memory->sfree(cells);
     cells = k_cells.h_view.data();
   }
@@ -250,8 +250,8 @@ void GridKokkos::wrap_kokkos()
 
   if (cinfo != k_cinfo.h_view.data()) {
     memoryKK->wrap_kokkos(k_cinfo,cinfo,maxlocal,"grid:cinfo");
-    k_cinfo.modify<SPAHostType>();
-    k_cinfo.sync<DeviceType>();
+    k_cinfo.modify_host();
+    k_cinfo.sync_device();
     memory->sfree(cinfo);
     cinfo = k_cinfo.h_view.data();
   }
@@ -260,8 +260,8 @@ void GridKokkos::wrap_kokkos()
 
   if (sinfo != k_sinfo.h_view.data()) {
     memoryKK->wrap_kokkos(k_sinfo,sinfo,maxsplit,"grid:sinfo");
-    k_sinfo.modify<SPAHostType>();
-    k_sinfo.sync<DeviceType>();
+    k_sinfo.modify_host();
+    k_sinfo.sync_device();
     memory->sfree(sinfo);
     sinfo = k_sinfo.h_view.data();
   }
@@ -272,8 +272,8 @@ void GridKokkos::wrap_kokkos()
 
   if (pcells != k_pcells.h_view.data()) {
     memoryKK->wrap_kokkos(k_pcells,pcells,maxparent,"grid:pcells");
-    k_pcells.modify<SPAHostType>();
-    k_pcells.sync<DeviceType>();
+    k_pcells.modify_host();
+    k_pcells.sync_device();
     memory->sfree(pcells);
     pcells = k_pcells.h_view.data();
   }
@@ -293,15 +293,15 @@ void GridKokkos::sync(ExecutionSpace space, unsigned int mask)
   if (space == Device) {
     if (sparta->kokkos->auto_sync)
       modify(Host,mask);
-    if (mask & CELL_MASK) k_cells.sync<SPADeviceType>();
-    if (mask & CINFO_MASK) k_cinfo.sync<SPADeviceType>();
-    if (mask & PCELL_MASK) k_pcells.sync<SPADeviceType>();
-    if (mask & SINFO_MASK) k_sinfo.sync<SPADeviceType>();
+    if (mask & CELL_MASK) k_cells.sync_device();
+    if (mask & CINFO_MASK) k_cinfo.sync_device();
+    if (mask & PCELL_MASK) k_pcells.sync_device();
+    if (mask & SINFO_MASK) k_sinfo.sync_device();
   } else {
-    if (mask & CELL_MASK) k_cells.sync<SPAHostType>();
-    if (mask & CINFO_MASK) k_cinfo.sync<SPAHostType>();
-    if (mask & PCELL_MASK) k_pcells.sync<SPAHostType>();
-    if (mask & SINFO_MASK) k_sinfo.sync<SPAHostType>();
+    if (mask & CELL_MASK) k_cells.sync_host();
+    if (mask & CINFO_MASK) k_cinfo.sync_host();
+    if (mask & PCELL_MASK) k_pcells.sync_host();
+    if (mask & SINFO_MASK) k_sinfo.sync_host();
   }
 }
 
@@ -317,16 +317,16 @@ void GridKokkos::modify(ExecutionSpace space, unsigned int mask)
   }
 
   if (space == Device) {
-    if (mask & CELL_MASK) k_cells.modify<SPADeviceType>();
-    if (mask & CINFO_MASK) k_cinfo.modify<SPADeviceType>();
-    if (mask & PCELL_MASK) k_pcells.modify<SPADeviceType>();
-    if (mask & SINFO_MASK) k_sinfo.modify<SPADeviceType>();
+    if (mask & CELL_MASK) k_cells.modify_device();
+    if (mask & CINFO_MASK) k_cinfo.modify_device();
+    if (mask & PCELL_MASK) k_pcells.modify_device();
+    if (mask & SINFO_MASK) k_sinfo.modify_device();
     if (sparta->kokkos->auto_sync)
       sync(Host,mask);
   } else {
-    if (mask & CELL_MASK) k_cells.modify<SPAHostType>();
-    if (mask & CINFO_MASK) k_cinfo.modify<SPAHostType>();
-    if (mask & PCELL_MASK) k_pcells.modify<SPAHostType>();
-    if (mask & SINFO_MASK) k_sinfo.modify<SPAHostType>();
+    if (mask & CELL_MASK) k_cells.modify_host();
+    if (mask & CINFO_MASK) k_cinfo.modify_host();
+    if (mask & PCELL_MASK) k_pcells.modify_host();
+    if (mask & SINFO_MASK) k_sinfo.modify_host();
   }
 }

--- a/src/KOKKOS/grid_kokkos.h
+++ b/src/KOKKOS/grid_kokkos.h
@@ -23,7 +23,6 @@ namespace SPARTA_NS {
 
 class GridKokkos : public Grid {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   // make into a view
   //ChildCell *cells;           // list of owned and ghost child cells
@@ -103,12 +102,12 @@ class GridKokkos : public Grid {
   tdual_sinfo_1d k_sinfo;
   tdual_pcell_1d k_pcells;
 
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csurfs;
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csplits;
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csubs;
+  Kokkos::Crs<int, DeviceType, void, int> d_csurfs;
+  Kokkos::Crs<int, DeviceType, void, int> d_csplits;
+  Kokkos::Crs<int, DeviceType, void, int> d_csubs;
 
-  typename AT::t_int_1d d_cellcount;
-  typename AT::t_int_2d d_plist;
+  DAT::t_int_1d d_cellcount;
+  DAT::t_int_2d d_plist;
 
  private:
   void grow_cells(int, int);

--- a/src/KOKKOS/irregular_kokkos.cpp
+++ b/src/KOKKOS/irregular_kokkos.cpp
@@ -381,16 +381,16 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
   // pack buf with list of datums
   // m = index of datum in sendbuf
 
-  k_index_send.modify<SPAHostType>();
-  k_index_send.sync<DeviceType>();
+  k_index_send.modify_host();
+  k_index_send.sync_device();
 
-  k_index_self.modify<SPAHostType>();
-  k_index_self.sync<DeviceType>();
+  k_index_self.modify_host();
+  k_index_self.sync_device();
 
   k_n.h_view() = 0;
-  k_n.modify<SPAHostType>();
-  k_n.sync<DeviceType>();
-  d_n = k_n.view<DeviceType>();
+  k_n.modify_host();
+  k_n.sync_device();
+  d_n = k_n.d_view;
 
   for (int isend = 0; isend < nsend; isend++) {
     count = num_send[isend];

--- a/src/KOKKOS/irregular_kokkos.h
+++ b/src/KOKKOS/irregular_kokkos.h
@@ -27,7 +27,6 @@ struct TagIrregularUnpackBuffer{};
 
 class IrregularKokkos : public Irregular {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   IrregularKokkos(class SPARTA *);
   ~IrregularKokkos();
@@ -52,7 +51,7 @@ class IrregularKokkos : public Irregular {
   DAT::t_int_1d d_index_self;
 
   DAT::tdual_int_scalar k_n;
-  typename AT::t_int_scalar d_n;
+  DAT::t_int_scalar d_n;
   HAT::t_int_scalar h_n;
 
   DAT::t_char_1d d_sendbuf;

--- a/src/KOKKOS/kokkos_scan.cpp
+++ b/src/KOKKOS/kokkos_scan.cpp
@@ -50,8 +50,8 @@ Kokkos::View<int*, Device> offset_scan(Kokkos::View<int*, Device> in, int& total
 template Kokkos::View<int*, SPAHostType> offset_scan(
     Kokkos::View<int*, SPAHostType> in, int& total);
 #ifdef KOKKOS_ENABLE_CUDA
-template Kokkos::View<int*, SPADeviceType> offset_scan(
-    Kokkos::View<int*, SPADeviceType> in, int& total);
+template Kokkos::View<int*, DeviceType> offset_scan(
+    Kokkos::View<int*, DeviceType> in, int& total);
 #endif
 
 }

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -103,11 +103,9 @@
     double x, y, z, w;
   };
 #endif
-// set SPAHostype and SPADeviceType from Kokkos Default Types
-typedef Kokkos::DefaultExecutionSpace SPADeviceType;
+// set SPAHostype and DeviceType from Kokkos Default Types
+typedef Kokkos::DefaultExecutionSpace DeviceType;
 typedef Kokkos::HostSpace::execution_space SPAHostType;
-
-typedef SPADeviceType DeviceType;
 
 // set ExecutionSpace stuct with variable "space"
 
@@ -376,43 +374,43 @@ typedef double4 K_FLOAT4;
 namespace SPARTA_NS {
 
   typedef Kokkos::
-    DualView<Particle::OnePart*, SPADeviceType::array_layout, DeviceType> tdual_particle_1d;
+    DualView<Particle::OnePart*, DeviceType::array_layout, DeviceType> tdual_particle_1d;
   typedef tdual_particle_1d::t_dev t_particle_1d;
   typedef tdual_particle_1d::t_host t_host_particle_1d;
 
   typedef Kokkos::
-    DualView<Particle::Species*, SPADeviceType::array_layout, DeviceType> tdual_species_1d;
+    DualView<Particle::Species*, DeviceType::array_layout, DeviceType> tdual_species_1d;
   typedef tdual_species_1d::t_dev t_species_1d;
   typedef tdual_species_1d::t_dev_const t_species_1d_const;
   typedef tdual_species_1d::t_host t_host_species_1d;
   
   typedef Kokkos::
-    DualView<Grid::ChildCell*, SPADeviceType::array_layout, DeviceType> tdual_cell_1d;
+    DualView<Grid::ChildCell*, DeviceType::array_layout, DeviceType> tdual_cell_1d;
   typedef tdual_cell_1d::t_dev t_cell_1d;
   typedef tdual_cell_1d::t_host t_host_cell_1d;
   
   typedef Kokkos::
-    DualView<Grid::ChildInfo*, SPADeviceType::array_layout, DeviceType> tdual_cinfo_1d;
+    DualView<Grid::ChildInfo*, DeviceType::array_layout, DeviceType> tdual_cinfo_1d;
   typedef tdual_cinfo_1d::t_dev t_cinfo_1d;
   typedef tdual_cinfo_1d::t_host t_host_cinfo_1d;
 
   typedef Kokkos::
-    DualView<Grid::SplitInfo*, SPADeviceType::array_layout, DeviceType> tdual_sinfo_1d;
+    DualView<Grid::SplitInfo*, DeviceType::array_layout, DeviceType> tdual_sinfo_1d;
   typedef tdual_sinfo_1d::t_dev t_sinfo_1d;
   typedef tdual_sinfo_1d::t_host t_host_sinfo_1d;
 
   typedef Kokkos::
-    DualView<Grid::ParentCell*, SPADeviceType::array_layout, DeviceType> tdual_pcell_1d;
+    DualView<Grid::ParentCell*, DeviceType::array_layout, DeviceType> tdual_pcell_1d;
   typedef tdual_pcell_1d::t_dev t_pcell_1d;
   typedef tdual_pcell_1d::t_host t_host_pcell_1d;
 
   typedef Kokkos::
-    DualView<Surf::Line*, SPADeviceType::array_layout, DeviceType> tdual_line_1d;
+    DualView<Surf::Line*, DeviceType::array_layout, DeviceType> tdual_line_1d;
   typedef tdual_line_1d::t_dev t_line_1d;
   typedef tdual_line_1d::t_host t_host_line_1d;
 
   typedef Kokkos::
-    DualView<Surf::Tri*, SPADeviceType::array_layout, DeviceType> tdual_tri_1d;
+    DualView<Surf::Tri*, DeviceType::array_layout, DeviceType> tdual_tri_1d;
   typedef tdual_tri_1d::t_dev t_tri_1d;
   typedef tdual_tri_1d::t_host t_host_tri_1d;
 }
@@ -421,19 +419,19 @@ template <class DeviceType>
 struct ArrayTypes;
 
 template <>
-struct ArrayTypes<SPADeviceType> {
+struct ArrayTypes<DeviceType> {
 
 // scalar types
 
 typedef Kokkos::
-  DualView<int, SPADeviceType::array_layout, SPADeviceType> tdual_int_scalar;
+  DualView<int, DeviceType::array_layout, DeviceType> tdual_int_scalar;
 typedef tdual_int_scalar::t_dev t_int_scalar;
 typedef tdual_int_scalar::t_dev_const t_int_scalar_const;
 typedef tdual_int_scalar::t_dev_um t_int_scalar_um;
 typedef tdual_int_scalar::t_dev_const_um t_int_scalar_const_um;
 
 typedef Kokkos::
-  DualView<SPARTA_FLOAT, SPADeviceType::array_layout, SPADeviceType> 
+  DualView<SPARTA_FLOAT, DeviceType::array_layout, DeviceType> 
   tdual_float_scalar;
 typedef tdual_float_scalar::t_dev t_float_scalar;
 typedef tdual_float_scalar::t_dev_const t_float_scalar_const;
@@ -443,7 +441,7 @@ typedef tdual_float_scalar::t_dev_const_um t_float_scalar_const_um;
 // generic array types
 
 typedef Kokkos::
-  DualView<char*, SPADeviceType::array_layout, SPADeviceType> tdual_char_1d;
+  DualView<char*, DeviceType::array_layout, DeviceType> tdual_char_1d;
 typedef tdual_char_1d::t_dev t_char_1d;
 typedef tdual_char_1d::t_dev_const t_char_1d_const;
 typedef tdual_char_1d::t_dev_um t_char_1d_um;
@@ -451,7 +449,7 @@ typedef tdual_char_1d::t_dev_const_um t_char_1d_const_um;
 typedef tdual_char_1d::t_dev_const_randomread t_char_1d_randomread;
 
 typedef Kokkos::
-  DualView<int*, SPADeviceType::array_layout, SPADeviceType> tdual_int_1d;
+  DualView<int*, DeviceType::array_layout, DeviceType> tdual_int_1d;
 typedef tdual_int_1d::t_dev t_int_1d;
 typedef tdual_int_1d::t_dev_const t_int_1d_const;
 typedef tdual_int_1d::t_dev_um t_int_1d_um;
@@ -459,7 +457,7 @@ typedef tdual_int_1d::t_dev_const_um t_int_1d_const_um;
 typedef tdual_int_1d::t_dev_const_randomread t_int_1d_randomread;
 
 typedef Kokkos::
-  DualView<int*[3], Kokkos::LayoutRight, SPADeviceType> tdual_int_1d_3;
+  DualView<int*[3], Kokkos::LayoutRight, DeviceType> tdual_int_1d_3;
 typedef tdual_int_1d_3::t_dev t_int_1d_3;
 typedef tdual_int_1d_3::t_dev_const t_int_1d_3_const;
 typedef tdual_int_1d_3::t_dev_um t_int_1d_3_um;
@@ -467,7 +465,7 @@ typedef tdual_int_1d_3::t_dev_const_um t_int_1d_3_const_um;
 typedef tdual_int_1d_3::t_dev_const_randomread t_int_1d_3_randomread;
 
 typedef Kokkos::
-  DualView<int**, Kokkos::LayoutRight, SPADeviceType> tdual_int_2d;
+  DualView<int**, Kokkos::LayoutRight, DeviceType> tdual_int_2d;
 typedef tdual_int_2d::t_dev t_int_2d;
 typedef tdual_int_2d::t_dev_const t_int_2d_const;
 typedef tdual_int_2d::t_dev_um t_int_2d_um;
@@ -475,7 +473,7 @@ typedef tdual_int_2d::t_dev_const_um t_int_2d_const_um;
 typedef tdual_int_2d::t_dev_const_randomread t_int_2d_randomread;
 
 typedef Kokkos::
-  DualView<SPARTA_NS::cellint*, SPADeviceType::array_layout, SPADeviceType>
+  DualView<SPARTA_NS::cellint*, DeviceType::array_layout, DeviceType>
   tdual_cellint_1d;
 typedef tdual_cellint_1d::t_dev t_cellint_1d;
 typedef tdual_cellint_1d::t_dev_const t_cellint_1d_const;
@@ -484,7 +482,7 @@ typedef tdual_cellint_1d::t_dev_const_um t_cellint_1d_const_um;
 typedef tdual_cellint_1d::t_dev_const_randomread t_cellint_1d_randomread;
 
 typedef Kokkos::
-  DualView<SPARTA_NS::cellint**, Kokkos::LayoutRight, SPADeviceType>
+  DualView<SPARTA_NS::cellint**, Kokkos::LayoutRight, DeviceType>
   tdual_cellint_2d;
 typedef tdual_cellint_2d::t_dev t_cellint_2d;
 typedef tdual_cellint_2d::t_dev_const t_cellint_2d_const;
@@ -493,7 +491,7 @@ typedef tdual_cellint_2d::t_dev_const_um t_cellint_2d_const_um;
 typedef tdual_cellint_2d::t_dev_const_randomread t_cellint_2d_randomread;
 
 typedef Kokkos::
-  DualView<SPARTA_NS::surfint*, SPADeviceType::array_layout, SPADeviceType>
+  DualView<SPARTA_NS::surfint*, DeviceType::array_layout, DeviceType>
   tdual_surfint_1d;
 typedef tdual_surfint_1d::t_dev t_surfint_1d;
 typedef tdual_surfint_1d::t_dev_const t_surfint_1d_const;
@@ -502,7 +500,7 @@ typedef tdual_surfint_1d::t_dev_const_um t_surfint_1d_const_um;
 typedef tdual_surfint_1d::t_dev_const_randomread t_surfint_1d_randomread;
 
 typedef Kokkos::
-  DualView<SPARTA_NS::surfint**, Kokkos::LayoutRight, SPADeviceType>
+  DualView<SPARTA_NS::surfint**, Kokkos::LayoutRight, DeviceType>
   tdual_surfint_2d;
 typedef tdual_surfint_2d::t_dev t_surfint_2d;
 typedef tdual_surfint_2d::t_dev_const t_surfint_2d_const;
@@ -511,7 +509,7 @@ typedef tdual_surfint_2d::t_dev_const_um t_surfint_2d_const_um;
 typedef tdual_surfint_2d::t_dev_const_randomread t_surfint_2d_randomread;
 
 typedef Kokkos::
-  DualView<double*, Kokkos::LayoutRight, SPADeviceType> tdual_double_1d;
+  DualView<double*, Kokkos::LayoutRight, DeviceType> tdual_double_1d;
 typedef tdual_double_1d::t_dev t_double_1d;
 typedef tdual_double_1d::t_dev_const t_double_1d_const;
 typedef tdual_double_1d::t_dev_um t_double_1d_um;
@@ -519,7 +517,7 @@ typedef tdual_double_1d::t_dev_const_um t_double_1d_const_um;
 typedef tdual_double_1d::t_dev_const_randomread t_double_1d_randomread;
 
 typedef Kokkos::
-  DualView<double**, Kokkos::LayoutRight, SPADeviceType> tdual_double_2d;
+  DualView<double**, Kokkos::LayoutRight, DeviceType> tdual_double_2d;
 typedef tdual_double_2d::t_dev t_double_2d;
 typedef tdual_double_2d::t_dev_const t_double_2d_const;
 typedef tdual_double_2d::t_dev_um t_double_2d_um;
@@ -528,7 +526,7 @@ typedef tdual_double_2d::t_dev_const_randomread t_double_2d_randomread;
 
 // 1d float array n
 
-typedef Kokkos::DualView<SPARTA_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_float_1d;
+typedef Kokkos::DualView<SPARTA_FLOAT*, DeviceType::array_layout, DeviceType> tdual_float_1d;
 typedef tdual_float_1d::t_dev t_float_1d;
 typedef tdual_float_1d::t_dev_const t_float_1d_const;
 typedef tdual_float_1d::t_dev_um t_float_1d_um;
@@ -537,7 +535,7 @@ typedef tdual_float_1d::t_dev_const_randomread t_float_1d_randomread;
 
 // 1d float array n[3]
 
-typedef Kokkos::DualView<SPARTA_FLOAT*[3], SPADeviceType::array_layout, SPADeviceType> tdual_float_1d_3;
+typedef Kokkos::DualView<SPARTA_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_float_1d_3;
 typedef tdual_float_1d_3::t_dev t_float_1d_3;
 typedef tdual_float_1d_3::t_dev_const t_float_1d_3_const;
 typedef tdual_float_1d_3::t_dev_um t_float_1d_3_um;
@@ -545,7 +543,7 @@ typedef tdual_float_1d_3::t_dev_const_um t_float_1d_3_const_um;
 typedef tdual_float_1d_3::t_dev_const_randomread t_float_1d_3_randomread;
 
 //2d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT**, SPADeviceType::array_layout, SPADeviceType> tdual_float_2d;
+typedef Kokkos::DualView<SPARTA_FLOAT**, DeviceType::array_layout, DeviceType> tdual_float_2d;
 typedef tdual_float_2d::t_dev t_float_2d;
 typedef tdual_float_2d::t_dev_const t_float_2d_const;
 typedef tdual_float_2d::t_dev_um t_float_2d_um;
@@ -553,7 +551,7 @@ typedef tdual_float_2d::t_dev_const_um t_float_2d_const_um;
 typedef tdual_float_2d::t_dev_const_randomread t_float_2d_randomread;
 
 //3d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT***, SPADeviceType::array_layout, SPADeviceType> tdual_float_3d;
+typedef Kokkos::DualView<SPARTA_FLOAT***, DeviceType::array_layout, DeviceType> tdual_float_3d;
 typedef tdual_float_3d::t_dev t_float_3d;
 typedef tdual_float_3d::t_dev_const t_float_3d_const;
 typedef tdual_float_3d::t_dev_um t_float_3d_um;
@@ -562,7 +560,7 @@ typedef tdual_float_3d::t_dev_const_randomread t_float_3d_randomread;
 
 //Position Types
 //1d X_FLOAT array n
-typedef Kokkos::DualView<X_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_xfloat_1d;
+typedef Kokkos::DualView<X_FLOAT*, DeviceType::array_layout, DeviceType> tdual_xfloat_1d;
 typedef tdual_xfloat_1d::t_dev t_xfloat_1d;
 typedef tdual_xfloat_1d::t_dev_const t_xfloat_1d_const;
 typedef tdual_xfloat_1d::t_dev_um t_xfloat_1d_um;
@@ -570,7 +568,7 @@ typedef tdual_xfloat_1d::t_dev_const_um t_xfloat_1d_const_um;
 typedef tdual_xfloat_1d::t_dev_const_randomread t_xfloat_1d_randomread;
 
 //2d X_FLOAT array n*m
-typedef Kokkos::DualView<X_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_xfloat_2d;
+typedef Kokkos::DualView<X_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_xfloat_2d;
 typedef tdual_xfloat_2d::t_dev t_xfloat_2d;
 typedef tdual_xfloat_2d::t_dev_const t_xfloat_2d_const;
 typedef tdual_xfloat_2d::t_dev_um t_xfloat_2d_um;
@@ -579,9 +577,9 @@ typedef tdual_xfloat_2d::t_dev_const_randomread t_xfloat_2d_randomread;
 
 //2d X_FLOAT array n*4 
 #ifdef SPARTA_KOKKOS_NO_LEGACY
-typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutLeft, SPADeviceType> tdual_x_array;
+typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutLeft, DeviceType> tdual_x_array;
 #else
-typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_x_array;
+typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_x_array;
 #endif
 typedef tdual_x_array::t_dev t_x_array;
 typedef tdual_x_array::t_dev_const t_x_array_const;
@@ -591,7 +589,7 @@ typedef tdual_x_array::t_dev_const_randomread t_x_array_randomread;
 
 //Velocity Types
 //1d V_FLOAT array n
-typedef Kokkos::DualView<V_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_vfloat_1d;
+typedef Kokkos::DualView<V_FLOAT*, DeviceType::array_layout, DeviceType> tdual_vfloat_1d;
 typedef tdual_vfloat_1d::t_dev t_vfloat_1d;
 typedef tdual_vfloat_1d::t_dev_const t_vfloat_1d_const;
 typedef tdual_vfloat_1d::t_dev_um t_vfloat_1d_um;
@@ -599,7 +597,7 @@ typedef tdual_vfloat_1d::t_dev_const_um t_vfloat_1d_const_um;
 typedef tdual_vfloat_1d::t_dev_const_randomread t_vfloat_1d_randomread;
 
 //2d V_FLOAT array n*m
-typedef Kokkos::DualView<V_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_vfloat_2d;
+typedef Kokkos::DualView<V_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_vfloat_2d;
 typedef tdual_vfloat_2d::t_dev t_vfloat_2d;
 typedef tdual_vfloat_2d::t_dev_const t_vfloat_2d_const;
 typedef tdual_vfloat_2d::t_dev_um t_vfloat_2d_um;
@@ -607,8 +605,8 @@ typedef tdual_vfloat_2d::t_dev_const_um t_vfloat_2d_const_um;
 typedef tdual_vfloat_2d::t_dev_const_randomread t_vfloat_2d_randomread;
 
 //2d V_FLOAT array n*3
-typedef Kokkos::DualView<V_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_v_array;
-//typedef Kokkos::DualView<V_FLOAT*[3], SPADeviceType::array_layout, SPADeviceType> tdual_v_array;
+typedef Kokkos::DualView<V_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_v_array;
+//typedef Kokkos::DualView<V_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_v_array;
 typedef tdual_v_array::t_dev t_v_array;
 typedef tdual_v_array::t_dev_const t_v_array_const;
 typedef tdual_v_array::t_dev_um t_v_array_um;
@@ -618,7 +616,7 @@ typedef tdual_v_array::t_dev_const_randomread t_v_array_randomread;
 //Force Types
 //1d F_FLOAT array n
 
-typedef Kokkos::DualView<F_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_ffloat_1d;
+typedef Kokkos::DualView<F_FLOAT*, DeviceType::array_layout, DeviceType> tdual_ffloat_1d;
 typedef tdual_ffloat_1d::t_dev t_ffloat_1d;
 typedef tdual_ffloat_1d::t_dev_const t_ffloat_1d_const;
 typedef tdual_ffloat_1d::t_dev_um t_ffloat_1d_um;
@@ -627,7 +625,7 @@ typedef tdual_ffloat_1d::t_dev_const_randomread t_ffloat_1d_randomread;
 
 //2d F_FLOAT array n*m
 
-typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_float_2d_lr;
+typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_float_2d_lr;
 typedef tdual_float_2d_lr::t_dev t_float_2d_lr;
 typedef tdual_float_2d_lr::t_dev_const t_float_2d_lr_const;
 typedef tdual_float_2d_lr::t_dev_um t_float_2d_lr_um;
@@ -636,8 +634,8 @@ typedef tdual_float_2d_lr::t_dev_const_randomread t_float_2d_lr_randomread;
 
 //2d F_FLOAT array n*3
 
-typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_f_array;
-//typedef Kokkos::DualView<F_FLOAT*[3], SPADeviceType::array_layout, SPADeviceType> tdual_f_array;
+typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_f_array;
+//typedef Kokkos::DualView<F_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_f_array;
 typedef tdual_f_array::t_dev t_f_array;
 typedef tdual_f_array::t_dev_const t_f_array_const;
 typedef tdual_f_array::t_dev_um t_f_array_um;
@@ -646,7 +644,7 @@ typedef tdual_f_array::t_dev_const_randomread t_f_array_randomread;
 
 //2d F_FLOAT array n*6 (for virial)
 
-typedef Kokkos::DualView<F_FLOAT*[6], Kokkos::LayoutRight, SPADeviceType> tdual_virial_array;
+typedef Kokkos::DualView<F_FLOAT*[6], Kokkos::LayoutRight, DeviceType> tdual_virial_array;
 typedef tdual_virial_array::t_dev t_virial_array;
 typedef tdual_virial_array::t_dev_const t_virial_array_const;
 typedef tdual_virial_array::t_dev_um t_virial_array_um;
@@ -656,7 +654,7 @@ typedef tdual_virial_array::t_dev_const_randomread t_virial_array_randomread;
 //Energy Types
 //1d E_FLOAT array n
 
-typedef Kokkos::DualView<E_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_efloat_1d;
+typedef Kokkos::DualView<E_FLOAT*, DeviceType::array_layout, DeviceType> tdual_efloat_1d;
 typedef tdual_efloat_1d::t_dev t_efloat_1d;
 typedef tdual_efloat_1d::t_dev_const t_efloat_1d_const;
 typedef tdual_efloat_1d::t_dev_um t_efloat_1d_um;
@@ -665,7 +663,7 @@ typedef tdual_efloat_1d::t_dev_const_randomread t_efloat_1d_randomread;
 
 //2d E_FLOAT array n*m
 
-typedef Kokkos::DualView<E_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_efloat_2d;
+typedef Kokkos::DualView<E_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_efloat_2d;
 typedef tdual_efloat_2d::t_dev t_efloat_2d;
 typedef tdual_efloat_2d::t_dev_const t_efloat_2d_const;
 typedef tdual_efloat_2d::t_dev_um t_efloat_2d_um;
@@ -674,7 +672,7 @@ typedef tdual_efloat_2d::t_dev_const_randomread t_efloat_2d_randomread;
 
 //2d E_FLOAT array n*3 
 
-typedef Kokkos::DualView<E_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_e_array;
+typedef Kokkos::DualView<E_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_e_array;
 typedef tdual_e_array::t_dev t_e_array;
 typedef tdual_e_array::t_dev_const t_e_array_const;
 typedef tdual_e_array::t_dev_um t_e_array_um;
@@ -683,7 +681,7 @@ typedef tdual_e_array::t_dev_const_randomread t_e_array_randomread;
 
 //Neighbor Types
 
-typedef Kokkos::DualView<int**, SPADeviceType::array_layout, SPADeviceType> tdual_neighbors_2d;
+typedef Kokkos::DualView<int**, DeviceType::array_layout, DeviceType> tdual_neighbors_2d;
 typedef tdual_neighbors_2d::t_dev t_neighbors_2d;
 typedef tdual_neighbors_2d::t_dev_const t_neighbors_2d_const;
 typedef tdual_neighbors_2d::t_dev_um t_neighbors_2d_um;
@@ -701,13 +699,13 @@ struct ArrayTypes<SPAHostType> {
 
 //Scalar Types
 
-typedef Kokkos::DualView<int, SPADeviceType::array_layout, SPADeviceType> tdual_int_scalar;
+typedef Kokkos::DualView<int, DeviceType::array_layout, DeviceType> tdual_int_scalar;
 typedef tdual_int_scalar::t_host t_int_scalar;
 typedef tdual_int_scalar::t_host_const t_int_scalar_const;
 typedef tdual_int_scalar::t_host_um t_int_scalar_um;
 typedef tdual_int_scalar::t_host_const_um t_int_scalar_const_um;
 
-typedef Kokkos::DualView<SPARTA_FLOAT, SPADeviceType::array_layout, SPADeviceType> tdual_float_scalar;
+typedef Kokkos::DualView<SPARTA_FLOAT, DeviceType::array_layout, DeviceType> tdual_float_scalar;
 typedef tdual_float_scalar::t_host t_float_scalar;
 typedef tdual_float_scalar::t_host_const t_float_scalar_const;
 typedef tdual_float_scalar::t_host_um t_float_scalar_um;
@@ -715,35 +713,35 @@ typedef tdual_float_scalar::t_host_const_um t_float_scalar_const_um;
 
 //Generic ArrayTypes
 typedef Kokkos::
-  DualView<char*, SPADeviceType::array_layout, SPADeviceType> tdual_char_1d;
+  DualView<char*, DeviceType::array_layout, DeviceType> tdual_char_1d;
 typedef tdual_char_1d::t_host t_char_1d;
 typedef tdual_char_1d::t_host_const t_char_1d_const;
 typedef tdual_char_1d::t_host_um t_char_1d_um;
 typedef tdual_char_1d::t_host_const_um t_char_1d_const_um;
 typedef tdual_char_1d::t_host_const_randomread t_char_1d_randomread;
 
-typedef Kokkos::DualView<int*, SPADeviceType::array_layout, SPADeviceType> tdual_int_1d;
+typedef Kokkos::DualView<int*, DeviceType::array_layout, DeviceType> tdual_int_1d;
 typedef tdual_int_1d::t_host t_int_1d;
 typedef tdual_int_1d::t_host_const t_int_1d_const;
 typedef tdual_int_1d::t_host_um t_int_1d_um;
 typedef tdual_int_1d::t_host_const_um t_int_1d_const_um;
 typedef tdual_int_1d::t_host_const_randomread t_int_1d_randomread;
 
-typedef Kokkos::DualView<int*[3], Kokkos::LayoutRight, SPADeviceType> tdual_int_1d_3;
+typedef Kokkos::DualView<int*[3], Kokkos::LayoutRight, DeviceType> tdual_int_1d_3;
 typedef tdual_int_1d_3::t_host t_int_1d_3;
 typedef tdual_int_1d_3::t_host_const t_int_1d_3_const;
 typedef tdual_int_1d_3::t_host_um t_int_1d_3_um;
 typedef tdual_int_1d_3::t_host_const_um t_int_1d_3_const_um;
 typedef tdual_int_1d_3::t_host_const_randomread t_int_1d_3_randomread;
 
-typedef Kokkos::DualView<int**, Kokkos::LayoutRight, SPADeviceType> tdual_int_2d;
+typedef Kokkos::DualView<int**, Kokkos::LayoutRight, DeviceType> tdual_int_2d;
 typedef tdual_int_2d::t_host t_int_2d;
 typedef tdual_int_2d::t_host_const t_int_2d_const;
 typedef tdual_int_2d::t_host_um t_int_2d_um;
 typedef tdual_int_2d::t_host_const_um t_int_2d_const_um;
 typedef tdual_int_2d::t_host_const_randomread t_int_2d_randomread;
 
-typedef Kokkos::DualView<SPARTA_NS::cellint*, SPADeviceType::array_layout, SPADeviceType> tdual_cellint_1d;
+typedef Kokkos::DualView<SPARTA_NS::cellint*, DeviceType::array_layout, DeviceType> tdual_cellint_1d;
 typedef tdual_cellint_1d::t_host t_cellint_1d;
 typedef tdual_cellint_1d::t_host_const t_cellint_1d_const;
 typedef tdual_cellint_1d::t_host_um t_cellint_1d_um;
@@ -751,7 +749,7 @@ typedef tdual_cellint_1d::t_host_const_um t_cellint_1d_const_um;
 typedef tdual_cellint_1d::t_host_const_randomread t_cellint_1d_randomread;
 
 typedef Kokkos::
-  DualView<SPARTA_NS::cellint**, Kokkos::LayoutRight, SPADeviceType>
+  DualView<SPARTA_NS::cellint**, Kokkos::LayoutRight, DeviceType>
   tdual_cellint_2d;
 typedef tdual_cellint_2d::t_host t_cellint_2d;
 typedef tdual_cellint_2d::t_host_const t_cellint_2d_const;
@@ -759,7 +757,7 @@ typedef tdual_cellint_2d::t_host_um t_cellint_2d_um;
 typedef tdual_cellint_2d::t_host_const_um t_cellint_2d_const_um;
 typedef tdual_cellint_2d::t_host_const_randomread t_cellint_2d_randomread;
 
-typedef Kokkos::DualView<SPARTA_NS::surfint*, SPADeviceType::array_layout, SPADeviceType> tdual_surfint_1d;
+typedef Kokkos::DualView<SPARTA_NS::surfint*, DeviceType::array_layout, DeviceType> tdual_surfint_1d;
 typedef tdual_surfint_1d::t_host t_surfint_1d;
 typedef tdual_surfint_1d::t_host_const t_surfint_1d_const;
 typedef tdual_surfint_1d::t_host_um t_surfint_1d_um;
@@ -767,7 +765,7 @@ typedef tdual_surfint_1d::t_host_const_um t_surfint_1d_const_um;
 typedef tdual_surfint_1d::t_host_const_randomread t_surfint_1d_randomread;
 
 typedef Kokkos::
-  DualView<SPARTA_NS::surfint**, Kokkos::LayoutRight, SPADeviceType>
+  DualView<SPARTA_NS::surfint**, Kokkos::LayoutRight, DeviceType>
   tdual_surfint_2d;
 typedef tdual_surfint_2d::t_host t_surfint_2d;
 typedef tdual_surfint_2d::t_host_const t_surfint_2d_const;
@@ -776,7 +774,7 @@ typedef tdual_surfint_2d::t_host_const_um t_surfint_2d_const_um;
 typedef tdual_surfint_2d::t_host_const_randomread t_surfint_2d_randomread;
 
 typedef Kokkos::
-  DualView<double*, Kokkos::LayoutRight, SPADeviceType> tdual_double_1d;
+  DualView<double*, Kokkos::LayoutRight, DeviceType> tdual_double_1d;
 typedef tdual_double_1d::t_host t_double_1d;
 typedef tdual_double_1d::t_host_const t_double_1d_const;
 typedef tdual_double_1d::t_host_um t_double_1d_um;
@@ -784,7 +782,7 @@ typedef tdual_double_1d::t_host_const_um t_double_1d_const_um;
 typedef tdual_double_1d::t_host_const_randomread t_double_1d_randomread;
 
 typedef Kokkos::
-  DualView<double**, Kokkos::LayoutRight, SPADeviceType> tdual_double_2d;
+  DualView<double**, Kokkos::LayoutRight, DeviceType> tdual_double_2d;
 typedef tdual_double_2d::t_host t_double_2d;
 typedef tdual_double_2d::t_host_const t_double_2d_const;
 typedef tdual_double_2d::t_host_um t_double_2d_um;
@@ -792,7 +790,7 @@ typedef tdual_double_2d::t_host_const_um t_double_2d_const_um;
 typedef tdual_double_2d::t_host_const_randomread t_double_2d_randomread;
 
 //1d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_float_1d;
+typedef Kokkos::DualView<SPARTA_FLOAT*, DeviceType::array_layout, DeviceType> tdual_float_1d;
 typedef tdual_float_1d::t_host t_float_1d;
 typedef tdual_float_1d::t_host_const t_float_1d_const;
 typedef tdual_float_1d::t_host_um t_float_1d_um;
@@ -800,7 +798,7 @@ typedef tdual_float_1d::t_host_const_um t_float_1d_const_um;
 typedef tdual_float_1d::t_host_const_randomread t_float_1d_randomread;
 
 //1d float array n[3]
-typedef Kokkos::DualView<SPARTA_FLOAT*[3], SPADeviceType::array_layout, SPADeviceType> tdual_float_1d_3;
+typedef Kokkos::DualView<SPARTA_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_float_1d_3;
 typedef tdual_float_1d_3::t_host t_float_1d_3;
 typedef tdual_float_1d_3::t_host_const t_float_1d_3_const;
 typedef tdual_float_1d_3::t_host_um t_float_1d_3_um;
@@ -808,7 +806,7 @@ typedef tdual_float_1d_3::t_host_const_um t_float_1d_3_const_um;
 typedef tdual_float_1d_3::t_host_const_randomread t_float_1d_3_randomread;
 
 //2d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT**, SPADeviceType::array_layout, SPADeviceType> tdual_float_2d;
+typedef Kokkos::DualView<SPARTA_FLOAT**, DeviceType::array_layout, DeviceType> tdual_float_2d;
 typedef tdual_float_2d::t_host t_float_2d;
 typedef tdual_float_2d::t_host_const t_float_2d_const;
 typedef tdual_float_2d::t_host_um t_float_2d_um;
@@ -816,7 +814,7 @@ typedef tdual_float_2d::t_host_const_um t_float_2d_const_um;
 typedef tdual_float_2d::t_host_const_randomread t_float_2d_randomread;
 
 //3d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT***, SPADeviceType::array_layout, SPADeviceType> tdual_float_3d;
+typedef Kokkos::DualView<SPARTA_FLOAT***, DeviceType::array_layout, DeviceType> tdual_float_3d;
 typedef tdual_float_3d::t_host t_float_3d;
 typedef tdual_float_3d::t_host_const t_float_3d_const;
 typedef tdual_float_3d::t_host_um t_float_3d_um;
@@ -826,7 +824,7 @@ typedef tdual_float_3d::t_host_const_randomread t_float_3d_randomread;
 
 //Position Types
 //1d X_FLOAT array n
-typedef Kokkos::DualView<X_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_xfloat_1d;
+typedef Kokkos::DualView<X_FLOAT*, DeviceType::array_layout, DeviceType> tdual_xfloat_1d;
 typedef tdual_xfloat_1d::t_host t_xfloat_1d;
 typedef tdual_xfloat_1d::t_host_const t_xfloat_1d_const;
 typedef tdual_xfloat_1d::t_host_um t_xfloat_1d_um;
@@ -834,7 +832,7 @@ typedef tdual_xfloat_1d::t_host_const_um t_xfloat_1d_const_um;
 typedef tdual_xfloat_1d::t_host_const_randomread t_xfloat_1d_randomread;
 
 //2d X_FLOAT array n*m
-typedef Kokkos::DualView<X_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_xfloat_2d;
+typedef Kokkos::DualView<X_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_xfloat_2d;
 typedef tdual_xfloat_2d::t_host t_xfloat_2d;
 typedef tdual_xfloat_2d::t_host_const t_xfloat_2d_const;
 typedef tdual_xfloat_2d::t_host_um t_xfloat_2d_um;
@@ -842,7 +840,7 @@ typedef tdual_xfloat_2d::t_host_const_um t_xfloat_2d_const_um;
 typedef tdual_xfloat_2d::t_host_const_randomread t_xfloat_2d_randomread;
 
 //2d X_FLOAT array n*3
-typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_x_array;
+typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_x_array;
 typedef tdual_x_array::t_host t_x_array;
 typedef tdual_x_array::t_host_const t_x_array_const;
 typedef tdual_x_array::t_host_um t_x_array_um;
@@ -851,7 +849,7 @@ typedef tdual_x_array::t_host_const_randomread t_x_array_randomread;
 
 //Velocity Types
 //1d V_FLOAT array n
-typedef Kokkos::DualView<V_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_vfloat_1d;
+typedef Kokkos::DualView<V_FLOAT*, DeviceType::array_layout, DeviceType> tdual_vfloat_1d;
 typedef tdual_vfloat_1d::t_host t_vfloat_1d;
 typedef tdual_vfloat_1d::t_host_const t_vfloat_1d_const;
 typedef tdual_vfloat_1d::t_host_um t_vfloat_1d_um;
@@ -859,7 +857,7 @@ typedef tdual_vfloat_1d::t_host_const_um t_vfloat_1d_const_um;
 typedef tdual_vfloat_1d::t_host_const_randomread t_vfloat_1d_randomread;
 
 //2d V_FLOAT array n*m
-typedef Kokkos::DualView<V_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_vfloat_2d;
+typedef Kokkos::DualView<V_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_vfloat_2d;
 typedef tdual_vfloat_2d::t_host t_vfloat_2d;
 typedef tdual_vfloat_2d::t_host_const t_vfloat_2d_const;
 typedef tdual_vfloat_2d::t_host_um t_vfloat_2d_um;
@@ -867,8 +865,8 @@ typedef tdual_vfloat_2d::t_host_const_um t_vfloat_2d_const_um;
 typedef tdual_vfloat_2d::t_host_const_randomread t_vfloat_2d_randomread;
 
 //2d V_FLOAT array n*3
-typedef Kokkos::DualView<V_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_v_array;
-//typedef Kokkos::DualView<V_FLOAT*[3], SPADeviceType::array_layout, SPADeviceType> tdual_v_array;
+typedef Kokkos::DualView<V_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_v_array;
+//typedef Kokkos::DualView<V_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_v_array;
 typedef tdual_v_array::t_host t_v_array;
 typedef tdual_v_array::t_host_const t_v_array_const;
 typedef tdual_v_array::t_host_um t_v_array_um;
@@ -877,7 +875,7 @@ typedef tdual_v_array::t_host_const_randomread t_v_array_randomread;
 
 //Force Types
 //1d F_FLOAT array n
-typedef Kokkos::DualView<F_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_ffloat_1d;
+typedef Kokkos::DualView<F_FLOAT*, DeviceType::array_layout, DeviceType> tdual_ffloat_1d;
 typedef tdual_ffloat_1d::t_host t_ffloat_1d;
 typedef tdual_ffloat_1d::t_host_const t_ffloat_1d_const;
 typedef tdual_ffloat_1d::t_host_um t_ffloat_1d_um;
@@ -885,7 +883,7 @@ typedef tdual_ffloat_1d::t_host_const_um t_ffloat_1d_const_um;
 typedef tdual_ffloat_1d::t_host_const_randomread t_ffloat_1d_randomread;
 
 //2d F_FLOAT array n*m
-typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_float_2d_lr;
+typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_float_2d_lr;
 typedef tdual_float_2d_lr::t_host t_float_2d_lr;
 typedef tdual_float_2d_lr::t_host_const t_float_2d_lr_const;
 typedef tdual_float_2d_lr::t_host_um t_float_2d_lr_um;
@@ -893,8 +891,8 @@ typedef tdual_float_2d_lr::t_host_const_um t_float_2d_lr_const_um;
 typedef tdual_float_2d_lr::t_host_const_randomread t_float_2d_lr_randomread;
 
 //2d F_FLOAT array n*3
-typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_f_array;
-//typedef Kokkos::DualView<F_FLOAT*[3], SPADeviceType::array_layout, SPADeviceType> tdual_f_array;
+typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_f_array;
+//typedef Kokkos::DualView<F_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_f_array;
 typedef tdual_f_array::t_host t_f_array;
 typedef tdual_f_array::t_host_const t_f_array_const;
 typedef tdual_f_array::t_host_um t_f_array_um;
@@ -902,7 +900,7 @@ typedef tdual_f_array::t_host_const_um t_f_array_const_um;
 typedef tdual_f_array::t_host_const_randomread t_f_array_randomread;
 
 //2d F_FLOAT array n*6 (for virial)
-typedef Kokkos::DualView<F_FLOAT*[6], Kokkos::LayoutRight, SPADeviceType> tdual_virial_array;
+typedef Kokkos::DualView<F_FLOAT*[6], Kokkos::LayoutRight, DeviceType> tdual_virial_array;
 typedef tdual_virial_array::t_host t_virial_array;
 typedef tdual_virial_array::t_host_const t_virial_array_const;
 typedef tdual_virial_array::t_host_um t_virial_array_um;
@@ -913,7 +911,7 @@ typedef tdual_virial_array::t_host_const_randomread t_virial_array_randomread;
 
 //Energy Types
 //1d E_FLOAT array n
-typedef Kokkos::DualView<E_FLOAT*, SPADeviceType::array_layout, SPADeviceType> tdual_efloat_1d;
+typedef Kokkos::DualView<E_FLOAT*, DeviceType::array_layout, DeviceType> tdual_efloat_1d;
 typedef tdual_efloat_1d::t_host t_efloat_1d;
 typedef tdual_efloat_1d::t_host_const t_efloat_1d_const;
 typedef tdual_efloat_1d::t_host_um t_efloat_1d_um;
@@ -921,7 +919,7 @@ typedef tdual_efloat_1d::t_host_const_um t_efloat_1d_const_um;
 typedef tdual_efloat_1d::t_host_const_randomread t_efloat_1d_randomread;
 
 //2d E_FLOAT array n*m
-typedef Kokkos::DualView<E_FLOAT**, Kokkos::LayoutRight, SPADeviceType> tdual_efloat_2d;
+typedef Kokkos::DualView<E_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_efloat_2d;
 typedef tdual_efloat_2d::t_host t_efloat_2d;
 typedef tdual_efloat_2d::t_host_const t_efloat_2d_const;
 typedef tdual_efloat_2d::t_host_um t_efloat_2d_um;
@@ -929,7 +927,7 @@ typedef tdual_efloat_2d::t_host_const_um t_efloat_2d_const_um;
 typedef tdual_efloat_2d::t_host_const_randomread t_efloat_2d_randomread;
 
 //2d E_FLOAT array n*3
-typedef Kokkos::DualView<E_FLOAT*[3], Kokkos::LayoutRight, SPADeviceType> tdual_e_array;
+typedef Kokkos::DualView<E_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_e_array;
 typedef tdual_e_array::t_host t_e_array;
 typedef tdual_e_array::t_host_const t_e_array_const;
 typedef tdual_e_array::t_host_um t_e_array_um;
@@ -937,7 +935,7 @@ typedef tdual_e_array::t_host_const_um t_e_array_const_um;
 typedef tdual_e_array::t_host_const_randomread t_e_array_randomread;
 
 //Neighbor Types
-typedef Kokkos::DualView<int**, SPADeviceType::array_layout, SPADeviceType> tdual_neighbors_2d;
+typedef Kokkos::DualView<int**, DeviceType::array_layout, DeviceType> tdual_neighbors_2d;
 typedef tdual_neighbors_2d::t_host t_neighbors_2d;
 typedef tdual_neighbors_2d::t_host_const t_neighbors_2d_const;
 typedef tdual_neighbors_2d::t_host_um t_neighbors_2d_um;
@@ -967,7 +965,7 @@ struct Graph {
 };
 
 //default SPARTA Types
-typedef struct ArrayTypes<SPADeviceType> DAT;
+typedef struct ArrayTypes<DeviceType> DAT;
 typedef struct ArrayTypes<SPAHostType> HAT;
 
 template<class DeviceType, class BufferView, class DualView>
@@ -982,7 +980,7 @@ void buffer_view(BufferView &buf, DualView &view,
                  const size_t n7 = 0) {
 
   buf = BufferView(
-          view.template view<DeviceType>().data(),
+          view.template d_view.data(),
           n0,n1,n2,n3,n4,n5,n6,n7);
 
 }

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -104,8 +104,10 @@
   };
 #endif
 // set SPAHostype and DeviceType from Kokkos Default Types
-typedef Kokkos::DefaultExecutionSpace DeviceType;
+typedef Kokkos::DefaultExecutionSpace SPADeviceType;
 typedef Kokkos::HostSpace::execution_space SPAHostType;
+
+typedef SPADeviceType DeviceType;
 
 // set ExecutionSpace stuct with variable "space"
 

--- a/src/KOKKOS/particle_kokkos.h
+++ b/src/KOKKOS/particle_kokkos.h
@@ -38,7 +38,6 @@ struct TagParticleSort{};
 
 class ParticleKokkos : public Particle {
  public:
-  typedef ArrayTypes<DeviceType> AT;
   typedef int value_type;
 
   // methods
@@ -124,7 +123,7 @@ class ParticleKokkos : public Particle {
   t_species_1d d_species;
   int nParticlesWksp;
   DAT::tdual_int_scalar k_reorder_pass;
-  typename AT::t_int_scalar d_reorder_pass;
+  DAT::t_int_scalar d_reorder_pass;
   HAT::t_int_scalar h_reorder_pass;
 
   int nbytes;
@@ -132,8 +131,8 @@ class ParticleKokkos : public Particle {
   int collide_rot,vibstyle;
   double boltz;
 
-  typename AT::t_int_2d d_plist;
-  typename AT::t_int_1d d_cellcount;
+  DAT::t_int_2d d_plist;
+  DAT::t_int_1d d_cellcount;
 
   DAT::t_int_2d d_lists;
   DAT::t_int_1d d_mlist;
@@ -143,7 +142,7 @@ class ParticleKokkos : public Particle {
   HAT::t_int_1d h_mlist;
   HAT::t_int_1d h_slist;
 
-  typename AT::t_int_scalar d_fail_flag;
+  DAT::t_int_scalar d_fail_flag;
   HAT::t_int_scalar h_fail_flag;
 
   // work memory for reduced memory reordering

--- a/src/KOKKOS/react_bird_kokkos.cpp
+++ b/src/KOKKOS/react_bird_kokkos.cpp
@@ -139,8 +139,8 @@ void ReactBirdKokkos::init()
       Kokkos::deep_copy(k_reactions.h_view(i,j).d_sp2recomb,h_sp2recomb);
     }
   }
-  k_reactions.modify<SPAHostType>();
-  k_reactions.sync<DeviceType>();
+  k_reactions.modify_host();
+  k_reactions.sync_device();
   d_reactions = k_reactions.d_view;
 
 #ifdef SPARTA_KOKKOS_EXACT
@@ -160,11 +160,11 @@ double ReactBirdKokkos::extract_tally(int m)
     if (sparta->kokkos->gpu_direct_flag) {
       MPI_Allreduce(d_tally_reactions.data(),k_tally_reactions_all.d_view.data(),nlist,
                     MPI_INT,MPI_SUM,world);
-      k_tally_reactions_all.modify<DeviceType>();
-      k_tally_reactions_all.sync<SPAHostType>();
+      k_tally_reactions_all.modify_device();
+      k_tally_reactions_all.sync_host();
     } else {
-      k_tally_reactions.modify<DeviceType>();
-      k_tally_reactions.sync<SPAHostType>();
+      k_tally_reactions.modify_device();
+      k_tally_reactions.sync_host();
       MPI_Allreduce(k_tally_reactions.h_view.data(),k_tally_reactions_all.h_view.data(),nlist,
                     MPI_INT,MPI_SUM,world);
     }

--- a/src/KOKKOS/react_bird_kokkos.h
+++ b/src/KOKKOS/react_bird_kokkos.h
@@ -76,14 +76,14 @@ class ReactBirdKokkos : public ReactBird {
  protected:
 
   typedef Kokkos::
-    DualView<OneReactionKokkos*, SPADeviceType::array_layout, DeviceType> tdual_reaction_1d;
+    DualView<OneReactionKokkos*, DeviceType::array_layout, DeviceType> tdual_reaction_1d;
   typedef tdual_reaction_1d::t_dev t_reaction_1d;
   typedef tdual_reaction_1d::t_host t_host_reaction_1d;
 
   t_reaction_1d d_rlist;              // list of all reactions read from file
 
   typedef Kokkos::
-    DualView<ReactionIJKokkos**, SPADeviceType::array_layout, DeviceType> tdual_reactionIJ_2d;
+    DualView<ReactionIJKokkos**, DeviceType::array_layout, DeviceType> tdual_reactionIJ_2d;
   typedef tdual_reactionIJ_2d::t_dev t_reactionIJ_2d;
   typedef tdual_reactionIJ_2d::t_host t_host_reactionIJ_2d;
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -52,7 +52,7 @@ SurfCollideDiffuseKokkos::SurfCollideDiffuseKokkos(SPARTA *sparta, int narg, cha
 #endif
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 
@@ -149,7 +149,7 @@ SurfCollideDiffuseKokkos::SurfCollideDiffuseKokkos(SPARTA *sparta) :
   random = NULL;
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -51,7 +51,6 @@ enum{NONE,DISCRETE,SMOOTH};            // several files
 
 class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   SurfCollideDiffuseKokkos(class SPARTA *, int, char **);
   SurfCollideDiffuseKokkos(class SPARTA *);
@@ -123,7 +122,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
   };
 
   DAT::tdual_int_scalar k_nsingle;
-  typename AT::t_int_scalar d_nsingle;
+  DAT::t_int_scalar d_nsingle;
   HAT::t_int_scalar h_nsingle;
 
  private:

--- a/src/KOKKOS/surf_collide_piston_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_piston_kokkos.cpp
@@ -27,7 +27,7 @@ SurfCollidePistonKokkos::SurfCollidePistonKokkos(SPARTA *sparta, int narg, char 
   SurfCollidePiston(sparta, narg, arg)
 {
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 
@@ -65,7 +65,7 @@ SurfCollidePistonKokkos::SurfCollidePistonKokkos(SPARTA *sparta) :
   allowreact = 1;
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 

--- a/src/KOKKOS/surf_collide_piston_kokkos.h
+++ b/src/KOKKOS/surf_collide_piston_kokkos.h
@@ -29,7 +29,6 @@ namespace SPARTA_NS {
 
 class SurfCollidePistonKokkos : public SurfCollidePiston {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   SurfCollidePistonKokkos(class SPARTA *, int, char **);
   SurfCollidePistonKokkos(class SPARTA *);
@@ -139,7 +138,7 @@ class SurfCollidePistonKokkos : public SurfCollidePiston {
   };
 
   DAT::tdual_int_scalar k_nsingle;
-  typename AT::t_int_scalar d_nsingle;
+  DAT::t_int_scalar d_nsingle;
   HAT::t_int_scalar h_nsingle;
 
 };

--- a/src/KOKKOS/surf_collide_specular_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_specular_kokkos.cpp
@@ -28,7 +28,7 @@ SurfCollideSpecularKokkos::SurfCollideSpecularKokkos(SPARTA *sparta, int narg, c
   SurfCollideSpecular(sparta, narg, arg)
 {
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 
@@ -66,6 +66,6 @@ SurfCollideSpecularKokkos::SurfCollideSpecularKokkos(SPARTA *sparta) :
   allowreact = 1;
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -29,7 +29,6 @@ namespace SPARTA_NS {
 
 class SurfCollideSpecularKokkos : public SurfCollideSpecular {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   SurfCollideSpecularKokkos(class SPARTA *, int, char **);
   SurfCollideSpecularKokkos(class SPARTA *);
@@ -90,7 +89,7 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
   };
 
   DAT::tdual_int_scalar k_nsingle;
-  typename AT::t_int_scalar d_nsingle;
+  DAT::t_int_scalar d_nsingle;
   HAT::t_int_scalar h_nsingle;
 };
 

--- a/src/KOKKOS/surf_collide_transparent_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.cpp
@@ -24,7 +24,7 @@ SurfCollideTransparentKokkos::SurfCollideTransparentKokkos(SPARTA *sparta, int n
   SurfCollideTransparent(sparta, narg, arg)
 {
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 
@@ -62,6 +62,6 @@ SurfCollideTransparentKokkos::SurfCollideTransparentKokkos(SPARTA *sparta) :
   transparent = 1;
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }

--- a/src/KOKKOS/surf_collide_transparent_kokkos.h
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.h
@@ -28,14 +28,13 @@ namespace SPARTA_NS {
 
 class SurfCollideTransparentKokkos : public SurfCollideTransparent {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   SurfCollideTransparentKokkos(class SPARTA *, int, char **);
   SurfCollideTransparentKokkos(class SPARTA *);
   ~SurfCollideTransparentKokkos() {}
 
   DAT::tdual_int_scalar k_nsingle;
-  typename AT::t_int_scalar d_nsingle;
+  DAT::t_int_scalar d_nsingle;
   HAT::t_int_scalar h_nsingle;
 
   /* ----------------------------------------------------------------------

--- a/src/KOKKOS/surf_collide_vanish_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.cpp
@@ -24,7 +24,7 @@ SurfCollideVanishKokkos::SurfCollideVanishKokkos(SPARTA *sparta, int narg, char 
   SurfCollideVanish(sparta, narg, arg)
 {
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }
 
@@ -60,6 +60,6 @@ SurfCollideVanishKokkos::SurfCollideVanishKokkos(SPARTA *sparta) :
   if (narg != 2) error->all(FLERR,"Illegal surf_collide vanish command");
 
   k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.view<DeviceType>();
+  d_nsingle = k_nsingle.d_view;
   h_nsingle = k_nsingle.h_view;
 }

--- a/src/KOKKOS/surf_collide_vanish_kokkos.h
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.h
@@ -28,14 +28,13 @@ namespace SPARTA_NS {
 
 class SurfCollideVanishKokkos : public SurfCollideVanish {
  public:
-  typedef ArrayTypes<DeviceType> AT;
 
   SurfCollideVanishKokkos(class SPARTA *, int, char **);
   SurfCollideVanishKokkos(class SPARTA *);
   ~SurfCollideVanishKokkos() {}
 
   DAT::tdual_int_scalar k_nsingle;
-  typename AT::t_int_scalar d_nsingle;
+  DAT::t_int_scalar d_nsingle;
   HAT::t_int_scalar h_nsingle;
 
   /* ----------------------------------------------------------------------

--- a/src/KOKKOS/surf_kokkos.cpp
+++ b/src/KOKKOS/surf_kokkos.cpp
@@ -70,8 +70,8 @@ void SurfKokkos::wrap_kokkos()
     if (lines != NULL && nmax > 0) {
       if (lines != k_lines.h_view.data()) {
         memoryKK->wrap_kokkos(k_lines,lines,nmax,"surf:lines");
-        k_lines.modify<SPAHostType>();
-        k_lines.sync<DeviceType>();
+        k_lines.modify_host();
+        k_lines.sync_device();
         memory->sfree(lines);
         lines = k_lines.h_view.data();
       }
@@ -79,8 +79,8 @@ void SurfKokkos::wrap_kokkos()
     if (mylines != NULL && nown > 0) {
       if (mylines != k_mylines.h_view.data()) {
         memoryKK->wrap_kokkos(k_mylines,mylines,nown,"surf:lines");
-        k_mylines.modify<SPAHostType>();
-        k_mylines.sync<DeviceType>();
+        k_mylines.modify_host();
+        k_mylines.sync_device();
         memory->sfree(mylines);
         mylines = k_mylines.h_view.data();
       }
@@ -89,8 +89,8 @@ void SurfKokkos::wrap_kokkos()
     if (tris != NULL && nmax > 0) {
       if (tris != k_tris.h_view.data()) {
         memoryKK->wrap_kokkos(k_tris,tris,nmax,"surf:tris");
-        k_tris.modify<SPAHostType>();
-        k_tris.sync<DeviceType>();
+        k_tris.modify_host();
+        k_tris.sync_device();
         memory->sfree(tris);
         tris = k_tris.h_view.data();
       }
@@ -98,8 +98,8 @@ void SurfKokkos::wrap_kokkos()
     if (mytris != NULL && nown > 0) {
       if (mytris != k_mytris.h_view.data()) {
         memoryKK->wrap_kokkos(k_mytris,mytris,nown,"surf:mytris");
-        k_mytris.modify<SPAHostType>();
-        k_mytris.sync<DeviceType>();
+        k_mytris.modify_host();
+        k_mytris.sync_device();
         memory->sfree(mytris);
         mytris = k_mytris.h_view.data();
       }
@@ -186,11 +186,11 @@ void SurfKokkos::sync(ExecutionSpace space, unsigned int mask)
   if (space == Device) {
     if (sparta->kokkos->auto_sync)
       modify(Host,mask);
-    if (mask & LINE_MASK) k_lines.sync<SPADeviceType>();
-    if (mask & TRI_MASK) k_tris.sync<SPADeviceType>();
+    if (mask & LINE_MASK) k_lines.sync_device();
+    if (mask & TRI_MASK) k_tris.sync_device();
   } else {
-    if (mask & LINE_MASK) k_lines.sync<SPAHostType>();
-    if (mask & TRI_MASK) k_tris.sync<SPAHostType>();
+    if (mask & LINE_MASK) k_lines.sync_host();
+    if (mask & TRI_MASK) k_tris.sync_host();
   }
 }
 
@@ -206,12 +206,12 @@ void SurfKokkos::modify(ExecutionSpace space, unsigned int mask)
   }
 
   if (space == Device) {
-    if (mask & LINE_MASK) k_lines.modify<SPADeviceType>();
-    if (mask & TRI_MASK) k_tris.modify<SPADeviceType>();
+    if (mask & LINE_MASK) k_lines.modify_device();
+    if (mask & TRI_MASK) k_tris.modify_device();
     if (sparta->kokkos->auto_sync)
       sync(Host,mask);
   } else {
-    if (mask & LINE_MASK) k_lines.modify<SPAHostType>();
-    if (mask & TRI_MASK) k_tris.modify<SPAHostType>();
+    if (mask & LINE_MASK) k_lines.modify_host();
+    if (mask & TRI_MASK) k_tris.modify_host();
   }
 }

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -287,7 +287,7 @@ void UpdateKokkos::run(int nsteps)
 
     if (nmigrate) {
       k_mlist_small = Kokkos::subview(k_mlist,std::make_pair(0,nmigrate));
-      k_mlist_small.sync<SPAHostType>();
+      k_mlist_small.sync_host();
     }
     auto mlist_small = k_mlist_small.h_view.data();
 
@@ -487,7 +487,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
 
     Kokkos::deep_copy(d_scalars,h_scalars);
 
-    //k_mlist.sync<SPADeviceType>();
+    //k_mlist.sync_device();
     copymode = 1;
     if (!sparta->kokkos->need_atomics)
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,0> >(pstart,pstop),*this);
@@ -502,7 +502,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
     particle_kk->modify(Device,PARTICLE_MASK);
     d_particles = t_particle_1d(); // destroy reference to reduce memory use
 
-    k_mlist.modify<DeviceType>();
+    k_mlist.modify_device();
 
     // END of pstart/pstop loop advecting all particles
 
@@ -557,7 +557,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
     if (any_entryexit) {
       if (nmigrate) {
         k_mlist_small = Kokkos::subview(k_mlist,std::make_pair(0,nmigrate));
-        k_mlist_small.sync<SPAHostType>();
+        k_mlist_small.sync_host();
       }
       auto mlist_small = k_mlist_small.h_view.data();
       timer->stamp(TIME_MOVE);

--- a/src/KOKKOS/update_kokkos.h
+++ b/src/KOKKOS/update_kokkos.h
@@ -84,7 +84,6 @@ struct TagUpdateMove{};
 
 class UpdateKokkos : public Update {
  public:
-  typedef ArrayTypes<DeviceType> AT;
   typedef UPDATE_REDUCE value_type;
 
   DAT::tdual_int_1d k_mlist;
@@ -114,9 +113,9 @@ class UpdateKokkos : public Update {
   t_cell_1d d_cells;
   t_sinfo_1d d_sinfo;
 
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csurfs;
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csplits;
-  Kokkos::Crs<int, SPADeviceType, void, int> d_csubs;
+  Kokkos::Crs<int, DeviceType, void, int> d_csurfs;
+  Kokkos::Crs<int, DeviceType, void, int> d_csplits;
+  Kokkos::Crs<int, DeviceType, void, int> d_csubs;
 
   t_line_1d d_lines;
   t_tri_1d d_tris;
@@ -137,43 +136,43 @@ class UpdateKokkos : public Update {
   KKCopy<ComputeSurfKokkos> slist_active_copy[KOKKOS_MAX_SLIST];
 
 
-  typedef Kokkos::DualView<int[11], SPADeviceType::array_layout, SPADeviceType> tdual_int_11;
+  typedef Kokkos::DualView<int[11], DeviceType::array_layout, DeviceType> tdual_int_11;
   typedef tdual_int_11::t_dev t_int_11;
   typedef tdual_int_11::t_host t_host_int_11;
   t_int_11 d_scalars;
   t_host_int_11 h_scalars;
 
-  typename AT::t_int_scalar d_ntouch_one;
+  DAT::t_int_scalar d_ntouch_one;
   HAT::t_int_scalar h_ntouch_one;
 
-  typename AT::t_int_scalar d_nexit_one;
+  DAT::t_int_scalar d_nexit_one;
   HAT::t_int_scalar h_nexit_one;
 
-  typename AT::t_int_scalar d_nboundary_one;
+  DAT::t_int_scalar d_nboundary_one;
   HAT::t_int_scalar h_nboundary_one;
 
-  typename AT::t_int_scalar d_nmigrate;
+  DAT::t_int_scalar d_nmigrate;
   HAT::t_int_scalar h_nmigrate;
 
-  typename AT::t_int_scalar d_entryexit;
+  DAT::t_int_scalar d_entryexit;
   HAT::t_int_scalar h_entryexit;
 
-  typename AT::t_int_scalar d_ncomm_one;
+  DAT::t_int_scalar d_ncomm_one;
   HAT::t_int_scalar h_ncomm_one;
 
-  typename AT::t_int_scalar d_nscheck_one;
+  DAT::t_int_scalar d_nscheck_one;
   HAT::t_int_scalar h_nscheck_one;
 
-  typename AT::t_int_scalar d_nscollide_one;
+  DAT::t_int_scalar d_nscollide_one;
   HAT::t_int_scalar h_nscollide_one;
 
-  typename AT::t_int_scalar d_nreact_one;
+  DAT::t_int_scalar d_nreact_one;
   HAT::t_int_scalar h_nreact_one;
 
-  typename AT::t_int_scalar d_nstuck;
+  DAT::t_int_scalar d_nstuck;
   HAT::t_int_scalar h_nstuck;
 
-  typename AT::t_int_scalar d_error_flag;
+  DAT::t_int_scalar d_error_flag;
   HAT::t_int_scalar h_error_flag;
 
   void bounce_set(bigint);


### PR DESCRIPTION
## Purpose

There is some unused template code in SPARTA that was copied from LAMMPS. The PR refactors this code for simplicity:

- Removes templates for view `sync` and `modify`
- Replaces `SPADeviceType` with `DeviceType`
- Uses `DAT::` instead of `AT::`

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes