### PR TITLE
earlier error check for valid compute/fix/variable

### DIFF
--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -189,14 +189,20 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
   for (int i = 0; i < nvalues; i++) {
     if (which[i] == X || which[i] == V) kindflag = PERPARTICLE;
     else if (which[i] == COMPUTE) {
-      Compute *compute = modify->compute[modify->find_compute(ids[0])];
+      int icompute = modify->find_compute(ids[i]);
+      if (icompute < 0)
+        error->all(FLERR,"Compute ID for fix ave/histo does not exist");
+      Compute *compute = modify->compute[icompute];
       if (compute->scalar_flag || compute->vector_flag || compute->array_flag)
         kindflag = GLOBAL;
       else if (compute->per_particle_flag) kindflag = PERPARTICLE;
       else if (compute->per_grid_flag) kindflag = PERGRID;
       else error->all(FLERR,"Fix ave/histo input is invalid compute");
     } else if (which[i] == FIX) {
-      Fix *fix = modify->fix[modify->find_fix(ids[0])];
+      int ifix = modify->find_fix(ids[i]);
+      if (ifix < 0)
+        error->all(FLERR,"Fix ID for fix ave/histo does not exist");
+      Fix *fix = modify->fix[ifix];
       if (fix->scalar_flag || fix->vector_flag || fix->array_flag)
         kindflag = GLOBAL;
       else if (fix->per_particle_flag) kindflag = PERPARTICLE;
@@ -204,6 +210,8 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
       else error->all(FLERR,"Fix ave/histo input is invalid fix");
     } else if (which[i] == VARIABLE) {
       int ivariable = input->variable->find(ids[i]);
+      if (ivariable < 0)
+        error->all(FLERR,"Variable name for fix ave/histo does not exist");
       if (input->variable->equal_style(ivariable)) kindflag = GLOBAL;
       else if (input->variable->particle_style(ivariable)) 
         kindflag = PERPARTICLE;
@@ -226,8 +234,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
   for (int i = 0; i < nvalues; i++) {
     if (which[i] == COMPUTE && kind == GLOBAL && mode == SCALAR) {
       int icompute = modify->find_compute(ids[i]);
-      if (icompute < 0)
-        error->all(FLERR,"Compute ID for fix ave/histo does not exist");
       if (argindex[i] == 0 && modify->compute[icompute]->scalar_flag == 0)
         error->all(FLERR,
                    "Fix ave/histo compute does not calculate a global scalar");
@@ -240,8 +246,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == COMPUTE && kind == GLOBAL && mode == VECTOR) {
       int icompute = modify->find_compute(ids[i]);
-      if (icompute < 0)
-        error->all(FLERR,"Compute ID for fix ave/histo does not exist");
       if (argindex[i] == 0 && modify->compute[icompute]->vector_flag == 0)
         error->all(FLERR,
                    "Fix ave/histo compute does not calculate a global vector");
@@ -255,8 +259,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == COMPUTE && kind == PERPARTICLE) {
       int icompute = modify->find_compute(ids[i]);
-      if (icompute < 0)
-        error->all(FLERR,"Compute ID for fix ave/histo does not exist");
       if (modify->compute[icompute]->per_particle_flag == 0)
         error->all(FLERR,"Fix ave/histo compute does not "
                    "calculate per-particle values");
@@ -274,8 +276,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == COMPUTE && kind == PERGRID) {
       int icompute = modify->find_compute(ids[i]);
-      if (icompute < 0)
-        error->all(FLERR,"Compute ID for fix ave/histo does not exist");
       if (modify->compute[icompute]->per_grid_flag == 0)
         error->all(FLERR,"Fix ave/histo compute does not "
                    "calculate per-grid values");
@@ -293,8 +293,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == FIX && kind == GLOBAL && mode == SCALAR) {
       int ifix = modify->find_fix(ids[i]);
-      if (ifix < 0)
-        error->all(FLERR,"Fix ID for fix ave/histo does not exist");
       if (argindex[i] == 0 && modify->fix[ifix]->scalar_flag == 0)
         error->all(FLERR,
                    "Fix ave/histo fix does not calculate a global scalar");
@@ -309,8 +307,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == FIX && kind == GLOBAL && mode == VECTOR) {
       int ifix = modify->find_fix(ids[i]);
-      if (ifix < 0)
-        error->all(FLERR,"Fix ID for fix ave/histo does not exist");
       if (argindex[i] == 0 && modify->fix[ifix]->vector_flag == 0)
         error->all(FLERR,
                    "Fix ave/histo fix does not calculate a global vector");
@@ -324,8 +320,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == FIX && kind == PERPARTICLE) {
       int ifix = modify->find_fix(ids[i]);
-      if (ifix < 0)
-        error->all(FLERR,"Fix ID for fix ave/histo does not exist");
       if (modify->fix[ifix]->per_particle_flag == 0)
         error->all(FLERR,
                    "Fix ave/histo fix does not calculate per-particle values");
@@ -345,8 +339,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == FIX && kind == PERGRID) {
       int ifix = modify->find_fix(ids[i]);
-      if (ifix < 0)
-        error->all(FLERR,"Fix ID for fix ave/histo does not exist");
       if (modify->fix[ifix]->per_grid_flag == 0)
         error->all(FLERR,
                    "Fix ave/histo fix does not calculate per-grid values");
@@ -366,8 +358,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == VARIABLE && kind == GLOBAL && mode == SCALAR) {
       int ivariable = input->variable->find(ids[i]);
-      if (ivariable < 0)
-        error->all(FLERR,"Variable name for fix ave/histo does not exist");
       if (input->variable->equal_style(ivariable) == 0)
         error->all(FLERR,"Fix ave/histo variable is not equal-style variable");
       if (argindex[i])
@@ -375,8 +365,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == VARIABLE && kind == PERPARTICLE) {
       int ivariable = input->variable->find(ids[i]);
-      if (ivariable < 0)
-        error->all(FLERR,"Variable name for fix ave/histo does not exist");
       if (argindex[i] == 0 && input->variable->particle_style(ivariable) == 0)
         error->all(FLERR,
                    "Fix ave/histo variable is not particle-style variable");
@@ -385,8 +373,6 @@ FixAveHisto::FixAveHisto(SPARTA *spa, int narg, char **arg) :
 
     } else if (which[i] == VARIABLE && kind == PERGRID) {
       int ivariable = input->variable->find(ids[i]);
-      if (ivariable < 0)
-        error->all(FLERR,"Variable name for fix ave/histo does not exist");
       if (argindex[i] == 0 && input->variable->grid_style(ivariable) == 0)
         error->all(FLERR,
                    "Fix ave/histo variable is not grid-style variable");


### PR DESCRIPTION
## Purpose

Fix ave/histo can crash if the ID of a specified fix, compute, variable is invalid, due to current
ordering of logic.  The error check for this needs to come earlier.

## Author(s)

Steve

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

N/A

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


