### PR TITLE
Delete unused variable in compute_tvib_grid

### DIFF
--- a/src/compute_tvib_grid.cpp
+++ b/src/compute_tvib_grid.cpp
@@ -540,7 +540,6 @@ void ComputeTvibGrid::post_process_grid(int index, int nsample,
       numer = denom = 0.0;
       count = emap[2*imode+1];
       for (isp = 0; isp < nsp; isp++) {
-        ispecies = t2s[evib-emap[0]];
         numer += tspecies_mode[isp][imode]*etally[icell][count];
         denom += etally[icell][count];
         count += 2*maxmode;


### PR DESCRIPTION
## Purpose

Delete unused variable in `compute_tvib_grid`. Fixes segfault, supersedes PR #182.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes