### PR TITLE
tools/paraview/grid2paraview: Fix bugs

### DIFF
--- a/tools/paraview/grid2paraview.py
+++ b/tools/paraview/grid2paraview.py
@@ -928,18 +928,16 @@ def write_pvd_file(time_steps_dict, file_name, num_chunks):
       fh.write('    <DataSet timestep="' + str(time) + '" group="" part="0"   \n')
       filepath = os.path.join(file_name, file_name + '_'  + str(time) + '.pvtu')
       fh.write('             file="' + filepath + '"/>\n')
+      array_names = []
       file_list = time_steps_dict[time]
       if file_list:
         try:
           afh = open(file_list[0], "r")
+          read_array_names(afh, array_names)
+          afh.close()
         except IOError:
           print("Unable to open SPARTA result file: ", f)
           return
-      else:
-          return
-      array_names = []
-      read_array_names(afh, array_names)
-      afh.close()
       write_pvtu_file(array_names, file_name, num_chunks, time)
   fh.write('   </Collection>    \n')
   fh.write('</VTKFile>    \n')


### PR DESCRIPTION
## Purpose

This pull request fixes two issues in the grid2paraview python tool.
commit 1:
Fix bug where using the command `pvpython grid2paraview.py my_grid sparta2pv` would result in unreadable `.pvd` files if no time grid data file(s) were provided

commit 2:
Fix python `ValueError "Mixing iteration and read methods would lose data."` that occurs when `readline()` is used in a for loop over the lines.

## Author(s)

Tim Teichmann (Institute for Technical Physics, Karlsruhe Institute of Technology)

## Backward Compatibility

should not have any issues

## Implementation Notes

Script does not run at all without 2nd commit (see above, `ValueError`).  Applying the 2nd commit makes the script execute without error with `pvpython` from ParaView 5.4.
However, even then if no time grid data files are provided via the `-r ...` option the script will produce an unreadable `.pvd` files (this happens because the previous `else: return` gets called and the footer of the `.pvd` file is never written). The 1st commit then makes the script produce sane paraview `.pvd` files even if no time grid data is provided.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links


