### PR TITLE
mis-matched free/delete in fix ave/time

### DIFF
--- a/src/fix_ave_time.cpp
+++ b/src/fix_ave_time.cpp
@@ -316,12 +316,12 @@ FixAveTime::FixAveTime(SPARTA *sparta, int narg, char **arg) :
 
 FixAveTime::~FixAveTime()
 {
-  memory->destroy(which);
-  memory->destroy(argindex);
-  memory->destroy(value2index);
-  memory->destroy(offcol);
+  delete [] which;
+  delete [] argindex;
+  delete [] value2index;
+  delete [] offcol;
   for (int i = 0; i < nvalues; i++) delete [] ids[i];
-  memory->sfree(ids);
+  delete [] ids;
 
   if (fp && me == 0) fclose(fp);
 


### PR DESCRIPTION
## Purpose

Mis-match in memory deallocation of some small arrays for free vs delete, in fix ave/time command.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


