### PR TITLE
Fix bug in fix move/surf

### DIFF
--- a/src/fix_move_surf.cpp
+++ b/src/fix_move_surf.cpp
@@ -181,6 +181,10 @@ void FixMoveSurf::end_of_step()
   // set ndeleted for scalar output
 
   if (particle->exist) ndeleted = movesurf->remove_particles();
+
+  // notify all classes that store per-grid data that grid may have changed
+
+  grid->notify_changed();
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

`Fix move/surf` can change the grid structure by creating or destroying split cells. However, other fixes were not being notified of the change, which can lead to particles in the wrong cell, etc. This issue showed up when running `examples/adapt/in.adapt.rotate` on 3 MPI ranks.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes