### PR TITLE
Zero react tally flag in init

### DIFF
--- a/src/react_bird.cpp
+++ b/src/react_bird.cpp
@@ -107,6 +107,7 @@ ReactBird::~ReactBird()
 
 void ReactBird::init()
 {
+  tally_flag = 0;
   for (int i = 0; i < nlist; i++) tally_reactions[i] = 0;
 
   // convert species IDs to species indices


### PR DESCRIPTION
## Purpose

Zero react tally flag in init, fixes #191 where reaction tally was incorrect for multiple runs.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes