### PR TITLE
doc: fix explanation of accommodation coefficient in surf_collide.html

### DIFF
--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -136,7 +136,7 @@ The particle's speed is unchanged.
 <P>The model has 2 parameters set by the <I>Tsurf</I> and <I>acc</I> arguments.
 <I>Tsurf</I> is the temperature of the surface.  <I>Acc</I> is an accommodation
 coefficient from 0.0 to 1.0, which determines what fraction of surface
-collisions are specular.  The rest are diffusive.  Thus a setting of
+collisions are diffusive.  The rest are specular.  Thus a setting of
 <I>acc</I> = 0.0 means all collisions are specular.
 </P>
 <P>Note that setting <I>acc</I> = 0.0, is a way to perform surface reactions

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -124,7 +124,7 @@ The {diffuse} style computes a simple diffusive reflection model.
 The model has 2 parameters set by the {Tsurf} and {acc} arguments.
 {Tsurf} is the temperature of the surface.  {Acc} is an accommodation
 coefficient from 0.0 to 1.0, which determines what fraction of surface
-collisions are specular.  The rest are diffusive.  Thus a setting of
+collisions are diffusive.  The rest are specular.  Thus a setting of
 {acc} = 0.0 means all collisions are specular.
 
 Note that setting {acc} = 0.0, is a way to perform surface reactions


### PR DESCRIPTION
## Purpose

The explanation of the accommodation coefficient in surf_collide was inverted and therefore confusing. This pull request amends that.

## Author(s)

Tim Teichmann (KIT)

## Backward Compatibility

-

## Implementation Notes

trivial

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines