### PR TITLE
Fix mflux

### DIFF
--- a/src/KOKKOS/compute_boundary_kokkos.h
+++ b/src/KOKKOS/compute_boundary_kokkos.h
@@ -168,9 +168,10 @@ void boundary_tally_kk(int iface, int istyle, int reaction,
         a_myarray(iface,k++) += weight;
         break;
       case MFLUX:
-        a_myarray(iface,k++) += origmass;
-        if (ip) a_myarray(iface,k++) -= imass;
-        if (jp) a_myarray(iface,k++) -= jmass;
+        a_myarray(iface,k) += origmass;
+        if (ip) a_myarray(iface,k) -= imass;
+        if (jp) a_myarray(iface,k) -= jmass;
+        k++;
         break;
       case PRESS:
         MathExtraKokkos::scale3(-origmass,vorig,pdelta);

--- a/src/KOKKOS/compute_surf_kokkos.h
+++ b/src/KOKKOS/compute_surf_kokkos.h
@@ -148,11 +148,12 @@ void surf_tally_kk(int isurf, int icell, int reaction,
       a_array_surf_tally(itally,k++) += weight;
       break;
     case MFLUX:
-      a_array_surf_tally(itally,k++) += origmass;
+      a_array_surf_tally(itally,k) += origmass;
       if (!transparent) {
-        if (ip) a_array_surf_tally(itally,k++) -= imass;
-        if (jp) a_array_surf_tally(itally,k++) -= jmass;
+        if (ip) a_array_surf_tally(itally,k) -= imass;
+        if (jp) a_array_surf_tally(itally,k) -= jmass;
       }
+      k++;
       break;
     case FX:
       if (!fflag) {

--- a/src/KOKKOS/compute_surf_kokkos.h
+++ b/src/KOKKOS/compute_surf_kokkos.h
@@ -148,10 +148,10 @@ void surf_tally_kk(int isurf, int icell, int reaction,
       a_array_surf_tally(itally,k++) += weight;
       break;
     case MFLUX:
-      a_array_surf_tally(itally,k) += origmass;
+      a_array_surf_tally(itally,k) += origmass * fluxscale;
       if (!transparent) {
-        if (ip) a_array_surf_tally(itally,k) -= imass;
-        if (jp) a_array_surf_tally(itally,k) -= jmass;
+        if (ip) a_array_surf_tally(itally,k) -= imass * fluxscale;
+        if (jp) a_array_surf_tally(itally,k) -= jmass * fluxscale;
       }
       k++;
       break;

--- a/src/compute_boundary.cpp
+++ b/src/compute_boundary.cpp
@@ -276,9 +276,10 @@ void ComputeBoundary::boundary_tally(int iface, int istyle, int reaction,
         vec[k++] += weight;
         break;
       case MFLUX:
-        vec[k++] += origmass;
-        if (ip) vec[k++] -= imass;
-        if (jp) vec[k++] -= jmass;
+        vec[k] += origmass;
+        if (ip) vec[k] -= imass;
+        if (jp) vec[k] -= jmass;
+        k++;
         break;
       case PRESS:
         MathExtra::scale3(-origmass,vorig,pdelta);

--- a/src/compute_isurf_grid.cpp
+++ b/src/compute_isurf_grid.cpp
@@ -288,9 +288,10 @@ void ComputeISurfGrid::surf_tally(int isurf, int icell, int reaction,
       vec[k++] += weight;
       break;
     case MFLUX:
-      vec[k++] += origmass;
-      if (ip) vec[k++] -= imass;
-      if (jp) vec[k++] -= jmass;
+      vec[k] += origmass;
+      if (ip) vec[k] -= imass;
+      if (jp) vec[k] -= jmass;
+      k++;
       break;
     case FX:
       if (!fflag) {

--- a/src/compute_isurf_grid.cpp
+++ b/src/compute_isurf_grid.cpp
@@ -288,9 +288,9 @@ void ComputeISurfGrid::surf_tally(int isurf, int icell, int reaction,
       vec[k++] += weight;
       break;
     case MFLUX:
-      vec[k] += origmass;
-      if (ip) vec[k] -= imass;
-      if (jp) vec[k] -= jmass;
+      vec[k] += origmass * fluxscale;
+      if (ip) vec[k] -= imass * fluxscale;
+      if (jp) vec[k] -= jmass * fluxscale;
       k++;
       break;
     case FX:

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -298,11 +298,12 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
       vec[k++] += weight;
       break;
     case MFLUX:
-      vec[k++] += origmass;
+      vec[k] += origmass;
       if (!transparent) {
-        if (ip) vec[k++] -= imass;
-        if (jp) vec[k++] -= jmass;
+        if (ip) vec[k] -= imass;
+        if (jp) vec[k] -= jmass;
       }
+      k++;
       break;
     case FX:
       if (!fflag) {

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -298,10 +298,10 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
       vec[k++] += weight;
       break;
     case MFLUX:
-      vec[k] += origmass;
+      vec[k] += origmass * fluxscale;
       if (!transparent) {
-        if (ip) vec[k] -= imass;
-        if (jp) vec[k] -= jmass;
+        if (ip) vec[k] -= imass * fluxscale;
+        if (jp) vec[k] -= jmass * fluxscale;
       }
       k++;
       break;


### PR DESCRIPTION
## Purpose

Currently the computation of the mass flux ("mflux") in compute_{surf,isurf,boundary} is flawed in two ways:

1. in case surface reactions (exchange or dissociation) are involved the wrong fields of the array are updated as the index is incremented erroneously. This pull request remedies this
2. for {surf,isurf}: Contrary to the descriptions in the code and on the manual the commands currently do not calculate a flux but only the sum of the masses of the impinging DSMC particles. This pull request adds the fluxscale to all computations (like for example in case of the kinetic energy).

## Author(s)

Tim Teichmann (Institute for Technical Physics, Karlsruhe Institute of Technology)

## Backward Compatibility

Yes, since results of the involved computes change

## Implementation Notes

- Commit 1: Do not increment the index if surface reactions are considered in the mass flux
- Commit 2: Scale the mass with the fluxscale (FNUM/A/dt) to obtain the mass flux

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

I think the changes are relatively straightforward. However, please let me know if you would like me to upload a small case to demonstrate the effect of these changes.

NOTE: I can currently not test the KOKKOS version. But I do not expect any issues with them.


