### PR TITLE
fix_emit: use MY_PIS instead of sqrt(MY_PI)

### DIFF
--- a/src/fix_emit.cpp
+++ b/src/fix_emit.cpp
@@ -168,8 +168,8 @@ double FixEmit::mol_inflow(double indot, double vscale, double fraction)
   double scosine = indot / vscale;
   if (scosine < -3.0) return 0.0;
   double inward_number_flux = vscale*fraction *
-    (exp(-scosine*scosine) + sqrt(MY_PI)*scosine*(1.0 + erf(scosine))) /
-    (2*sqrt(MY_PI));
+    (exp(-scosine*scosine) + MY_PIS*scosine*(1.0 + erf(scosine))) /
+    (2*MY_PIS);
   return inward_number_flux;
 }
 


### PR DESCRIPTION
## Purpose

fix_emit used `sqrt(MY_PI)` instead of the already existent constant `MY_PIS`. Since it is potentially faster to use the constant directly this pull request changes it. This is the only place in the code where this is the case (checked by `git grep "sqrt(MY_PI)"`).

## Author(s)

Tim Teichmann (KIT, ITEP)

## Backward Compatibility

no issues

## Implementation Notes

Since the constant exists make use of it to potentially speed up the simulation. I don't know how sensitive your regression tests are. This might trigger some due to small numerical differences.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


