### PR TITLE
ParaView modification for grid file changes

### DIFF
--- a/tools/paraview/runIntegrationTests.sh
+++ b/tools/paraview/runIntegrationTests.sh
@@ -59,6 +59,7 @@ test_circle() {
     cp $INPUT_FILE_DIR/circle_slice.txt .
     cp $INPUT_FILE_DIR/circle_read_grid.txt .
     cp $INPUT_FILE_DIR/circle_catalyst_script.py .
+    cp $INPUT_FILE_DIR/in.adapt.static .
 
     CURRENT_TEST="surf2paraview circle"
     echo ""
@@ -176,6 +177,27 @@ test_circle() {
     check_file "RenderView1_8.png"
     check_file "RenderView1_9.png"
     check_file "RenderView1_10.png"
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    echo ""
+    echo "Running Sparta circle adapt static example"
+    echo ""
+    $SPARTA_MPI_EXEC -np 4 $SPARTA_EXECUTABLE < in.adapt.static
+    echo ""
+    echo "Finished"
+    echo ""
+
+    CURRENT_TEST="grid2paraview pvpython circle adapt static"
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    $PARAVIEW_PVPYTHON $GRID2PARAVIEW circle_read_grid.txt \
+        circle_adapt_static_grid_pvpython -xc 10 -yc 10 -r tmp_flow.*
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_adapt_static_grid_pvpython.pvd"
+    check_file "circle_adapt_static_grid_pvpython/circle_adapt_static_grid_pvpython_0_1100.vtu"
+    check_file "circle_adapt_static_grid_pvpython/circle_adapt_static_grid_pvpython_4500.pvtu"
     echo ""
     echo "$CURRENT_TEST test passed"
 

--- a/tools/paraview/tests/input_files/in.adapt.static
+++ b/tools/paraview/tests/input_files/in.adapt.static
@@ -1,0 +1,81 @@
+################################################################################
+# 2d flow around set of circles
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    10 10 1 
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0 
+
+# 7 circles, 4 above, 3 below
+
+read_surf           data.circle origin 5 5 0 trans 1.0 0.5 0.0 &
+                    scale 0.33 0.33 1 group 1
+read_surf           data.circle origin 5 5 0 trans -1.0 1.5 0.0 &
+                    scale 0.33 0.33 1 group 1
+read_surf           data.circle origin 5 5 0 trans 1.0 2.5 0.0 &
+                    scale 0.33 0.33 1 group 1
+read_surf           data.circle origin 5 5 0 trans -1.0 3.5 0.0 &
+                    scale 0.33 0.33 1 group 1
+
+read_surf           data.circle origin 5 5 0 trans -1.5 -1.8 0.0 &
+                    scale 0.33 0.33 1 group 2
+read_surf           data.circle origin 5 5 0 trans 0.5 -2.8 0.0 &
+                    scale 0.33 0.33 1 group 2
+read_surf           data.circle origin 5 5 0 trans -1.5 -3.8 0.0 &
+                    scale 0.33 0.33 1 group 1
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+compute             1 grid all species n u v w usq vsq wsq
+fix                 1 ave/grid all 1 100 100 c_1[*]
+
+fix		    in emit/face air xlo twopass 
+fix		    foo grid/check 1 error
+dump                1 grid all 100 tmp_flow.* id f_1[*]
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 &
+#                    surf one 0.01 size 512 512 zoom 1.75 &
+#                    gline yes 0.005
+#dump_modify	    2 pad 4 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 &
+#                    surf one 0.01 size 512 512 zoom 1.75 &
+#                    gline yes 0.005 grid proc
+#dump_modify	    3 pad 4 scolor * white glinecolor white
+ 
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+run 		    2000
+
+unfix               2
+unfix               5
+
+run                 3000
+
+write_grid          data.grid

--- a/tools/paraview/tests/input_files/in.circle
+++ b/tools/paraview/tests/input_files/in.circle
@@ -30,7 +30,7 @@ dump                2 surf all 100 tmp_surf.* id f_2[*]
 
 fix		    in emit/face air xlo # subsonic 0.1 NULL
 
-write_grid          parent data.grid
+write_grid          data.grid
 
 timestep 	    0.0001
 

--- a/tools/paraview/tests/input_files/in.sphere
+++ b/tools/paraview/tests/input_files/in.sphere
@@ -32,7 +32,7 @@ fix                 1 ave/grid all 1 100 100 c_1[*]
 fix                 2 ave/surf all 1 100 100 c_2[*]
 dump                1 grid all 100 tmp_flow.* id f_1[*]
 dump                2 surf all 100 tmp_surf.* id f_2[*]
-write_grid          parent data.grid
+write_grid          data.grid
 
 timestep 	    0.0001
 


### PR DESCRIPTION
Changed grid2paraview.py to read new Sparta grid file format
that does not have parent information. Parent grid is now
derived from grid file header information and child cell
ids in the child section of the grid file.

## Purpose

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request. If this addresses an open GitHub Issue, mention the issue number, e.g. with `fixes #221` or `closes #135`, so that issue will be automatically closed when the pull request is merged_

## Author(s)

_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


