### PR TITLE
Flip sign of internal FFTs

### DIFF
--- a/doc/accelerate_kokkos.html
+++ b/doc/accelerate_kokkos.html
@@ -424,8 +424,10 @@ KOKKOS_DEVICES=CUDA means an NVIDIA GPU running CUDA will be used.
 <TR><TD >VOLTA70	</TD><TD > GPU </TD><TD >	NVIDIA Volta generation CC 7.0 GPU </TD></TR>
 <TR><TD >VOLTA72	</TD><TD > GPU </TD><TD >	NVIDIA Volta generation CC 7.2 GPU </TD></TR>
 <TR><TD >TURING75	</TD><TD > GPU </TD><TD >	NVIDIA Turing generation CC 7.5 GPU </TD></TR>
+<TR><TD >AMPERE80 </TD><TD > GPU </TD><TD > NVIDIA Ampere generation CC 8.0 GPU </TD></TR>
 <TR><TD >VEGA900	</TD><TD > GPU </TD><TD >	AMD GPU MI25 GFX900 </TD></TR>
-<TR><TD >VEGA906	</TD><TD > GPU </TD><TD >	AMD GPU MI50/MI60 GFX906
+<TR><TD >VEGA906	</TD><TD > GPU </TD><TD >	AMD GPU MI50/MI60 GFX906 </TD></TR>
+<TR><TD >INTEL_GEN </TD><TD > GPU </TD><TD > Intel GPUs Gen9+
 </TD></TR></TABLE></DIV>
 
 <P>The CMake option Kokkos_ENABLE_CUDA_<I>OPTION</I> or the makefile setting KOKKOS_CUDA_OPTIONS=<I>OPTION</I> are 

--- a/doc/compute_fft_grid.html
+++ b/doc/compute_fft_grid.html
@@ -57,7 +57,7 @@ dump 1 grid all 1000 tmp.grid id c_2 f_1
 </PRE>
 <P><B>Description:</B>
 </P>
-<P>Define a computation that performs FFTs on per-grid values.  
+<P>Define a computation that performs forward FFTs on per-grid values.  
 This can be useful, for example, in calculating the energy spectrum
 of a turbulent flow.
 </P>
@@ -75,7 +75,7 @@ different ways.  The values for a single timestep can be output by the
 timesteps can be averaged by the <A HREF = "fix_ave_grid.html">fix ave/grid</A>
 command.
 </P>
-<P>An FFT is perfomed on each input value independently.
+<P>A forward FFT is perfomed on each input value independently.
 </P>
 <P>Each listed input can be the result of a <A HREF = "compute.html">compute</A> or
 <A HREF = "fix.html">fix</A> or the evaluation of a <A HREF = "variable.html">variable</A>, all of
@@ -115,7 +115,9 @@ will be summed together, grid value by grid value, to create
 a single output.
 </P>
 <P>The result of each FFT is scaled by the <I>sfactor</I> value of
-the <I>scale</I> keyword, whose default is 1.0.
+the <I>scale</I> keyword, whose default is 1.0.  Note that forward FFTs do
+not perform any scaling of their own; backward FFTs scale each output
+value by N = # of points in the FFT grid.
 </P>
 <P>If the <I>conjugate</I> keyword is set to <I>no</I>, the result of each FFT is 2
 values for each grid point, the real and imaginary parts of a complex
@@ -126,7 +128,7 @@ is effectively the squared length of the complex 2-vector with real
 and imaginary components.
 </P>
 <P>If one or more of the <I>kx</I>, <I>ky</I>, <I>kz</I>, or <I>kmag</I> keywords are set to
-<I>yes</I>, then one or moer extra columns of per-grid output is generated.
+<I>yes</I>, then one or more extra columns of per-grid output is generated.
 For <I>kx</I> the x-component of the K-space wavevector is generated.
 Similarly for <I>ky</I> and <I>kz</I>.  For <I>kmag</I> the length of each K-space
 wavevector is generated.  These values can be useful, for example, for

--- a/doc/compute_fft_grid.txt
+++ b/doc/compute_fft_grid.txt
@@ -46,7 +46,7 @@ dump 1 grid all 1000 tmp.grid id c_2 f_1 :pre
 
 [Description:]
 
-Define a computation that performs FFTs on per-grid values.  
+Define a computation that performs forward FFTs on per-grid values.  
 This can be useful, for example, in calculating the energy spectrum
 of a turbulent flow.
 
@@ -64,7 +64,7 @@ different ways.  The values for a single timestep can be output by the
 timesteps can be averaged by the "fix ave/grid"_fix_ave_grid.html
 command.
 
-An FFT is perfomed on each input value independently.
+A forward FFT is perfomed on each input value independently.
 
 Each listed input can be the result of a "compute"_compute.html or
 "fix"_fix.html or the evaluation of a "variable"_variable.html, all of
@@ -104,7 +104,9 @@ will be summed together, grid value by grid value, to create
 a single output.
 
 The result of each FFT is scaled by the {sfactor} value of
-the {scale} keyword, whose default is 1.0.
+the {scale} keyword, whose default is 1.0.  Note that forward FFTs do
+not perform any scaling of their own; backward FFTs scale each output
+value by N = # of points in the FFT grid.
 
 If the {conjugate} keyword is set to {no}, the result of each FFT is 2
 values for each grid point, the real and imaginary parts of a complex
@@ -115,7 +117,7 @@ is effectively the squared length of the complex 2-vector with real
 and imaginary components.
 
 If one or more of the {kx}, {ky}, {kz}, or {kmag} keywords are set to
-{yes}, then one or moer extra columns of per-grid output is generated.
+{yes}, then one or more extra columns of per-grid output is generated.
 For {kx} the x-component of the K-space wavevector is generated.
 Similarly for {ky} and {kz}.  For {kmag} the length of each K-space
 wavevector is generated.  These values can be useful, for example, for

--- a/src/FFT/compute_fft_grid.cpp
+++ b/src/FFT/compute_fft_grid.cpp
@@ -39,6 +39,7 @@
 using namespace SPARTA_NS;
 
 enum{COMPUTE,FIX,VARIABLE};
+enum{FORWARD=1,BACWARD=-1};
 
 #define INVOKED_PER_GRID 16
 
@@ -437,10 +438,10 @@ void ComputeFFTGrid::compute_per_grid()
       fft[n+1] = ZEROF;
     }
 
-    // perform FFT
+    // perform forward FFT
 
-    if (dimension == 3) fft3d->compute(fft,fft,1);
-    else fft2d->compute(fft,fft,1);
+    if (dimension == 3) fft3d->compute(fft,fft,FORWARD);
+    else fft2d->compute(fft,fft,FORWARD);
 
     // reverse irregular comm to move results from FFT grid -> SPARTA grid
     // if conjugate set:


### PR DESCRIPTION
## Purpose

Flip the sign internally for performing forward vs backward FFTs.  This is to be compatible with other FFT libraries.  It should not affect results for the compute fft/grid command when the conjugate flag is set (e.g. for energy spectra).  If the result of one or more FFTs is output directly, then the sign of the imaginary term will be flipped.

## Author(s)

Steve

## Backward Compatibility

See above.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


