### PR TITLE
Computes pflux and eflux missing nsample factor for time averaging

### DIFF
--- a/doc/accelerate_kokkos.html
+++ b/doc/accelerate_kokkos.html
@@ -424,8 +424,10 @@ KOKKOS_DEVICES=CUDA means an NVIDIA GPU running CUDA will be used.
 <TR><TD >VOLTA70	</TD><TD > GPU </TD><TD >	NVIDIA Volta generation CC 7.0 GPU </TD></TR>
 <TR><TD >VOLTA72	</TD><TD > GPU </TD><TD >	NVIDIA Volta generation CC 7.2 GPU </TD></TR>
 <TR><TD >TURING75	</TD><TD > GPU </TD><TD >	NVIDIA Turing generation CC 7.5 GPU </TD></TR>
+<TR><TD >AMPERE80 </TD><TD > GPU </TD><TD > NVIDIA Ampere generation CC 8.0 GPU </TD></TR>
 <TR><TD >VEGA900	</TD><TD > GPU </TD><TD >	AMD GPU MI25 GFX900 </TD></TR>
-<TR><TD >VEGA906	</TD><TD > GPU </TD><TD >	AMD GPU MI50/MI60 GFX906
+<TR><TD >VEGA906	</TD><TD > GPU </TD><TD >	AMD GPU MI50/MI60 GFX906 </TD></TR>
+<TR><TD >INTEL_GEN </TD><TD > GPU </TD><TD > Intel GPUs Gen9+
 </TD></TR></TABLE></DIV>
 
 <P>The CMake option Kokkos_ENABLE_CUDA_<I>OPTION</I> or the makefile setting KOKKOS_CUDA_OPTIONS=<I>OPTION</I> are 

--- a/doc/compute_eflux_grid.html
+++ b/doc/compute_eflux_grid.html
@@ -38,7 +38,7 @@
 <PRE>compute 1 eflux/grid all species heatx heaty heatz
 compute 1 eflux/grid subset species heaty 
 </PRE>
-<P>These commands will dump 10 time averaged energy flux densities for
+<P>These commands will dump time averaged energy flux densities for
 each species and each grid cell to a dump file every 1000 steps:
 </P>
 <PRE>compute 1 eflux/grid all species heatx heaty heatz

--- a/doc/compute_eflux_grid.txt
+++ b/doc/compute_eflux_grid.txt
@@ -27,7 +27,7 @@ values = {heatx} or {heaty} or {heatz} :l
 compute 1 eflux/grid all species heatx heaty heatz
 compute 1 eflux/grid subset species heaty :pre
 
-These commands will dump 10 time averaged energy flux densities for
+These commands will dump time averaged energy flux densities for
 each species and each grid cell to a dump file every 1000 steps:
 
 compute 1 eflux/grid all species heatx heaty heatz

--- a/doc/compute_pflux_grid.html
+++ b/doc/compute_pflux_grid.html
@@ -39,7 +39,7 @@
 <PRE>compute 1 pflux/grid all species momxx momyy momzz
 compute 1 pflux/grid subset species momxx momxy 
 </PRE>
-<P>These commands will dump 10 time averaged momentum flux densities for
+<P>These commands will dump time averaged momentum flux densities for
 each species and each grid cell to a dump file every 1000 steps:
 </P>
 <PRE>compute 1 pflux/grid all species momxx momyy momzz

--- a/doc/compute_pflux_grid.txt
+++ b/doc/compute_pflux_grid.txt
@@ -28,7 +28,7 @@ values = {momxx} or {momyy} or {momzz} or {momxy} or {momyz} or {momxz} :l
 compute 1 pflux/grid all species momxx momyy momzz
 compute 1 pflux/grid subset species momxx momxy :pre
 
-These commands will dump 10 time averaged momentum flux densities for
+These commands will dump time averaged momentum flux densities for
 each species and each grid cell to a dump file every 1000 steps:
 
 compute 1 pflux/grid all species momxx momyy momzz

--- a/doc/compute_sonine_grid.html
+++ b/doc/compute_sonine_grid.html
@@ -45,7 +45,7 @@
 <PRE>compute 1 sonine/grid all air a x 5 b xy 5
 compute 1 sonine/grid subset air a x 5 
 </PRE>
-<P>These commands will dump 10 time averaged sonine moments for each
+<P>These commands will dump time averaged sonine moments for each
 species and each grid cell to a dump file every 1000 steps:
 </P>
 <PRE>compute 1 sonine/grid all species a x 5 b xy 5

--- a/doc/compute_sonine_grid.txt
+++ b/doc/compute_sonine_grid.txt
@@ -33,7 +33,7 @@ values = values for specific keyword :l
 compute 1 sonine/grid all air a x 5 b xy 5
 compute 1 sonine/grid subset air a x 5 :pre
 
-These commands will dump 10 time averaged sonine moments for each
+These commands will dump time averaged sonine moments for each
 species and each grid cell to a dump file every 1000 steps:
 
 compute 1 sonine/grid all species a x 5 b xy 5

--- a/doc/compute_thermal_grid.html
+++ b/doc/compute_thermal_grid.html
@@ -39,7 +39,7 @@
 <PRE>compute 1 thermal/grid all species temp
 compute 1 thermal/grid subset air temp press 
 </PRE>
-<P>These commands will dump 10 time averaged thermal temperatures for
+<P>These commands will dump time averaged thermal temperatures for
 each species and each grid cell to a dump file every 1000 steps:
 </P>
 <PRE>compute 1 thermal/grid species temp

--- a/doc/compute_thermal_grid.txt
+++ b/doc/compute_thermal_grid.txt
@@ -28,7 +28,7 @@ value = {temp} or {press} :l
 compute 1 thermal/grid all species temp
 compute 1 thermal/grid subset air temp press :pre
 
-These commands will dump 10 time averaged thermal temperatures for
+These commands will dump time averaged thermal temperatures for
 each species and each grid cell to a dump file every 1000 steps:
 
 compute 1 thermal/grid species temp

--- a/src/KOKKOS/compute_eflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.cpp
@@ -424,7 +424,7 @@ void ComputeEFluxGridKokkos::operator()(TagComputeEFluxGrid_post_process_grid, c
       d_etally(icell,mv)*d_etally(icell,mv2v2)/summass +
       2.0*d_etally(icell,mv)*d_etally(icell,mv2)*d_etally(icell,mv2)/summass/summass;
     wt = 0.5 * fnum * d_cinfo[icell].weight / d_cinfo[icell].volume;
-    d_vec[icell] = wt * (h + h1 + h2);
+    d_vec[icell] = wt/nsample * (h + h1 + h2);
   }
 }
 

--- a/src/KOKKOS/compute_pflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.cpp
@@ -294,6 +294,7 @@ void ComputePFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
   int hi = nglocal;
 
   if (!d_etally.data()) {
+    nsample = 1;
     d_etally = d_tally;
     emap = map[index];
     d_vec = d_vector;
@@ -303,6 +304,7 @@ void ComputePFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
   this->d_etally = d_etally;
   this->d_vec = d_vec;
   this->nstride = nstride;
+  this->nsample = nsample;
 
   // compute normalized final value for each grid cell
   // Vcm = Sum mv / Sum m = (Wx,Wy,Wz)
@@ -360,7 +362,7 @@ void ComputePFluxGridKokkos::operator()(TagComputePFluxGrid_post_process_grid_di
   else{
     wt = fnum * d_cinfo[icell].weight / d_cinfo[icell].volume;
     summv = d_etally(icell,mv);
-    d_vec[icell] = wt * (d_etally(icell,mvv) - summv*summv/summass);
+    d_vec[icell] = wt/nsample * (d_etally(icell,mvv) - summv*summv/summass);
   }
 }
 
@@ -373,8 +375,8 @@ void ComputePFluxGridKokkos::operator()(TagComputePFluxGrid_post_process_grid_of
   if (summass == 0.0) d_vec[icell] = 0.0;
   else{
     wt = fnum * d_cinfo[icell].weight / d_cinfo[icell].volume;
-    d_vec[icell] = wt * (d_etally(icell,mvv) -
-                         d_etally(icell,mv1)*d_etally(icell,mv2)/summass);
+    d_vec[icell] = wt/nsample * (d_etally(icell,mvv) -
+                                 d_etally(icell,mv1)*d_etally(icell,mv2)/summass);
   }
 }
 

--- a/src/compute_eflux_grid.cpp
+++ b/src/compute_eflux_grid.cpp
@@ -367,7 +367,7 @@ void ComputeEFluxGrid::post_process_grid(int index, int nsample,
       h2 = t[mvv2v2] - 2.0*t[mvv2]*t[mv2]/summass - t[mv]*t[mv2v2]/summass +
 	2.0*t[mv]*t[mv2]*t[mv2]/summass/summass;
       wt = 0.5 * fnum * cinfo[icell].weight / cinfo[icell].volume;
-      vec[k] = wt * (h + h1 + h2);
+      vec[k] = wt/nsample * (h + h1 + h2);
     }
     k += nstride;
   }

--- a/src/compute_pflux_grid.cpp
+++ b/src/compute_pflux_grid.cpp
@@ -307,7 +307,7 @@ void ComputePFluxGrid::post_process_grid(int index, int nsample,
         else {
           wt = fnum * cinfo[icell].weight / cinfo[icell].volume;
 	  summv = etally[icell][mv];
-	  vec[k] = wt * (etally[icell][mvv] - summv*summv/summass);
+	  vec[k] = wt/nsample * (etally[icell][mvv] - summv*summv/summass);
 	}
         k += nstride;
       }
@@ -331,8 +331,8 @@ void ComputePFluxGrid::post_process_grid(int index, int nsample,
         if (summass == 0.0) vec[k] = 0.0;
         else {
           wt = fnum * cinfo[icell].weight / cinfo[icell].volume;
-	  vec[k] = wt * (etally[icell][mvv] -
-			 etally[icell][mv1]*etally[icell][mv2]/summass);
+	  vec[k] = wt/nsample * (etally[icell][mvv] -
+				 etally[icell][mv1]*etally[icell][mv2]/summass);
 	}
         k += nstride;
       }


### PR DESCRIPTION
## Purpose

Two per-atom computes pflux and eflux missing nsample normalization for time averaging with fix ave/grid.

## Author(s)

Steve

## Backward Compatibility

Changes outputs of fix ave/grid when using these 2 computes as input.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


