### PR TITLE
Flag particles for deletion with rare axisymmetric move round-off issues

### DIFF
--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -83,8 +83,8 @@ UpdateKokkos::UpdateKokkos(SPARTA *sparta) : Update(sparta),
 
   // use 1D view for scalars to reduce GPU memory operations
 
-  d_scalars = t_int_11("collide:scalars");
-  h_scalars = t_host_int_11("collide:scalars_mirror");
+  d_scalars = t_int_12("collide:scalars");
+  h_scalars = t_host_int_12("collide:scalars_mirror");
 
   d_ncomm_one     = Kokkos::subview(d_scalars,0);
   d_nexit_one     = Kokkos::subview(d_scalars,1);
@@ -96,7 +96,8 @@ UpdateKokkos::UpdateKokkos(SPARTA *sparta) : Update(sparta),
   d_nscollide_one = Kokkos::subview(d_scalars,7);
   d_nreact_one    = Kokkos::subview(d_scalars,8);
   d_nstuck        = Kokkos::subview(d_scalars,9);
-  d_error_flag    = Kokkos::subview(d_scalars,10);
+  d_naxibad       = Kokkos::subview(d_scalars,10);
+  d_error_flag    = Kokkos::subview(d_scalars,11);
 
   h_ncomm_one     = Kokkos::subview(h_scalars,0);
   h_nexit_one     = Kokkos::subview(h_scalars,1);
@@ -108,7 +109,8 @@ UpdateKokkos::UpdateKokkos(SPARTA *sparta) : Update(sparta),
   h_nscollide_one = Kokkos::subview(h_scalars,7);
   h_nreact_one    = Kokkos::subview(h_scalars,8);
   h_nstuck        = Kokkos::subview(h_scalars,9);
-  h_error_flag    = Kokkos::subview(h_scalars,10);
+  h_naxibad       = Kokkos::subview(d_scalars,10);
+  h_error_flag    = Kokkos::subview(h_scalars,11);
 
   nboundary_tally = 0;
 }
@@ -524,6 +526,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
       nscollide_one = h_nscollide_one();
       surf->nreact_one = h_nreact_one();
       nstuck = h_nstuck();
+      naxibad = h_naxibad();
     } else {
       ntouch_one       += reduce.ntouch_one   ;
       nexit_one        += reduce.nexit_one    ;
@@ -533,6 +536,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
       nscollide_one    += reduce.nscollide_one;
       surf->nreact_one += reduce.nreact_one   ;
       nstuck           += reduce.nstuck       ;
+      naxibad          += reduce.nstuck       ;
     }
 
     entryexit = h_entryexit();
@@ -1030,7 +1034,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
               slist_active_copy[m].obj.
                     surf_tally_kk<ATOMIC_REDUCTION>(minsurf,icell,reaction,&iorig,ipart,jpart);
 
-          // nstuck = consective iterations particle is immobile
+          // stuck_iterate = consecutive iterations particle is immobile
 
           if (minparam == 0.0) stuck_iterate++;
           else stuck_iterate = 0;
@@ -1086,6 +1090,12 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
     // no cell crossing
     // set final particle position to xnew, then break from advection loop
     // for axisymmetry, must first remap linear xnew and v
+    // for axisymmetry, check if final particle position is within cell
+    //   can be rare epsilon round-off cases where particle ends up outside
+    //     of final cell curved surf when move logic thinks it is inside
+    //   example is when Geom::axi_horizontal_line() says no crossing of cell edge
+    //     but axi_remap() puts particle outside the cell
+    //   in this case, just DISCARD particle and tally it to naxibad
     // if migrating to another proc,
     //   flag as PDONE so new proc won't move it more on this step
 
@@ -1094,6 +1104,18 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
       x[0] = xnew[0];
       x[1] = xnew[1];
       if (DIM == 3) x[2] = xnew[2];
+      if (DIM == 1) {
+        if (x[1] < lo[1] || x[1] > hi[1]) {
+          particle_i.flag = PDISCARD;
+          if (ATOMIC_REDUCTION == 1)
+            Kokkos::atomic_fetch_add(&d_naxibad(),1);
+          else if (ATOMIC_REDUCTION == 0)
+            d_naxibad()++;
+          else
+            reduce.naxibad++;
+          break;
+        }
+      }
       if (d_cells[icell].proc != me) particle_i.flag = PDONE;
       break;
     }

--- a/src/KOKKOS/update_kokkos.h
+++ b/src/KOKKOS/update_kokkos.h
@@ -40,7 +40,8 @@ namespace SPARTA_NS {
 struct s_UPDATE_REDUCE {
   int ntouch_one,nexit_one,nboundary_one,
       entryexit,ncomm_one,
-      nscheck_one,nscollide_one,nreact_one,nstuck,error_flag;
+      nscheck_one,nscollide_one,nreact_one,nstuck,
+      naxibad,error_flag;
   KOKKOS_INLINE_FUNCTION
   s_UPDATE_REDUCE() {
     ntouch_one    = 0;
@@ -51,6 +52,7 @@ struct s_UPDATE_REDUCE {
     nscollide_one = 0;
     nreact_one    = 0;
     nstuck        = 0;
+    naxibad       = 0;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -63,6 +65,7 @@ struct s_UPDATE_REDUCE {
     nscollide_one += rhs.nscollide_one;
     nreact_one    += rhs.nreact_one   ;
     nstuck        += rhs.nstuck       ;
+    naxibad       += rhs.naxibad      ;
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -75,6 +78,7 @@ struct s_UPDATE_REDUCE {
     nscollide_one += rhs.nscollide_one;
     nreact_one    += rhs.nreact_one   ;
     nstuck        += rhs.nstuck       ;
+    naxibad       += rhs.naxibad      ;
   }
 };
 typedef struct s_UPDATE_REDUCE UPDATE_REDUCE;
@@ -137,11 +141,11 @@ class UpdateKokkos : public Update {
   KKCopy<ComputeSurfKokkos> slist_active_copy[KOKKOS_MAX_SLIST];
 
 
-  typedef Kokkos::DualView<int[11], DeviceType::array_layout, DeviceType> tdual_int_11;
-  typedef tdual_int_11::t_dev t_int_11;
-  typedef tdual_int_11::t_host t_host_int_11;
-  t_int_11 d_scalars;
-  t_host_int_11 h_scalars;
+  typedef Kokkos::DualView<int[12], DeviceType::array_layout, DeviceType> tdual_int_12;
+  typedef tdual_int_12::t_dev t_int_12;
+  typedef tdual_int_12::t_host t_host_int_12;
+  t_int_12 d_scalars;
+  t_host_int_12 h_scalars;
 
   DAT::t_int_scalar d_ntouch_one;
   HAT::t_int_scalar h_ntouch_one;
@@ -172,6 +176,9 @@ class UpdateKokkos : public Update {
 
   DAT::t_int_scalar d_nstuck;
   HAT::t_int_scalar h_nstuck;
+
+  DAT::t_int_scalar d_naxibad;
+  HAT::t_int_scalar h_naxibad;
 
   DAT::t_int_scalar d_error_flag;
   HAT::t_int_scalar h_error_flag;

--- a/src/finish.cpp
+++ b/src/finish.cpp
@@ -149,7 +149,7 @@ void Finish::end(int flag, double time_multiple_runs)
     bigint nattempt_total = 0;
     bigint ncollide_total = 0;
     bigint nreact_total = 0;
-    int stuck_total;
+    int stuck_total,axibad_total;
 
     MPI_Allreduce(&update->nmove_running,&nmove_total,1,
                   MPI_SPARTA_BIGINT,MPI_SUM,world);
@@ -176,6 +176,7 @@ void Finish::end(int flag, double time_multiple_runs)
                     MPI_SPARTA_BIGINT,MPI_SUM,world);
     }
     MPI_Allreduce(&update->nstuck,&stuck_total,1,MPI_INT,MPI_SUM,world);
+    MPI_Allreduce(&update->naxibad,&axibad_total,1,MPI_INT,MPI_SUM,world);
 
     double pms,pmsp,ctps,cis,pfc,pfcwb,pfeb,schps,sclps,srps,caps,cps,rps;
     pms = pmsp = ctps = cis = pfc = pfcwb = pfeb =
@@ -227,6 +228,7 @@ void Finish::end(int flag, double time_multiple_runs)
         fprintf(screen,"Gas reactions     = " BIGINT_FORMAT " %s\n",
                 nreact_total,MathExtra::num2str(nreact_total,str));
         fprintf(screen,"Particles stuck   = %d\n",stuck_total);
+        fprintf(screen,"Axisymm bad moves = %d\n",axibad_total);
 
         fprintf(screen,"\n");
         fprintf(screen,"Particle-moves/CPUsec/proc: %g\n",pmsp);
@@ -268,6 +270,7 @@ void Finish::end(int flag, double time_multiple_runs)
         fprintf(logfile,"Reactions         = " BIGINT_FORMAT " %s\n",
                 nreact_total,MathExtra::num2str(nreact_total,str));
         fprintf(logfile,"Particles stuck   = %d\n",stuck_total);
+        fprintf(logfile,"Axisymm bad moves = %d\n",axibad_total);
 
         fprintf(logfile,"\n");
         fprintf(logfile,"Particle-moves/CPUsec/proc: %g\n",pmsp);

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -794,7 +794,7 @@ template < int DIM, int SURF > void Update::move()
                   slist_active[m]->surf_tally(minsurf,icell,reaction,
                                               &iorig,ipart,jpart);
 
-              // stuck_iterate = consective iterations particle is immobile
+              // stuck_iterate = consecutive iterations particle is immobile
 
               if (minparam == 0.0) stuck_iterate++;
               else stuck_iterate = 0;

--- a/src/update.h
+++ b/src/update.h
@@ -63,7 +63,11 @@ class Update : protected Pointers {
   bigint nscollide_running;
 
   int nstuck;                // # of particles stuck on surfs and deleted
-
+  int naxibad;               // # of particles where axisymm move was bad
+                             // in this case, bad means particle ended up
+                             // outside of final cell curved surf by epsilon
+                             // when move logic thinks it is inside cell
+  
   int reorder_period;        // # of timesteps between particle reordering
   int global_mem_limit;      // max # of bytes in arrays for rebalance and reordering
   int mem_limit_grid_flag;   // 1 if using size of grid as memory limit


### PR DESCRIPTION
## Purpose

Add logic to remove particles which end up epsilon outside a curved cell surface in axisymmetric cells at the end of the move, when the move logic thinks they are inside.  In final run stats, print the number of such removals.

## Author(s)

Steve

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


