### PR TITLE
Fix bug with size of childlist for pre-refined grid

### DIFF
--- a/src/adapt_grid.cpp
+++ b/src/adapt_grid.cpp
@@ -504,7 +504,7 @@ void AdaptGrid::setup(int iter)
   Grid::ParentLevel *plevels = grid->plevels;
 
   int nmax = 0;
-  for (i = minlevel; i < maxlevel; i++)
+  for (int i = minlevel; i < maxlevel; i++)
     nmax = MAX(nmax,plevels[i].nx * plevels[i].ny * plevels[i].nz);
   childlist = new int[nmax];
 

--- a/src/adapt_grid.cpp
+++ b/src/adapt_grid.cpp
@@ -499,8 +499,14 @@ void AdaptGrid::setup(int iter)
   } else random = NULL;
 
   // list of new cell indices for one refined cell
+  // refinement may occur between minlevel and maxlevel-1 inclusive
+  
+  Grid::ParentLevel *plevels = grid->plevels;
 
-  childlist = new int[nx*ny*nz];
+  int nmax = 0;
+  for (i = minlevel; i < maxlevel; i++)
+    nmax = MAX(nmax,plevels[i].nx * plevels[i].ny * plevels[i].nz);
+  childlist = new int[nmax];
 
   // rlist and clist for refine/coarsen
 
@@ -689,12 +695,13 @@ void AdaptGrid::refine_particle()
 
 void AdaptGrid::refine_surf()
 {
-  int j,m,icell,flag,nsurf;
+  int j,m,icell,flag,nsurf,plevel;
   surfint *csurfs;
   double *norm,*lo,*hi;
 
   int dim = domain->dimension;
   Grid::ChildCell *cells = grid->cells;
+  Grid::ParentLevel *plevels = grid->plevels;
   Surf::Line *lines = surf->lines;
   Surf::Tri *tris = surf->tris;
 
@@ -719,10 +726,11 @@ void AdaptGrid::refine_surf()
 
     lo = cells[icell].lo;
     hi = cells[icell].hi;
+    plevel = cells[icell].level;
     flag = 1;
-    if (fabs(hi[0]-lo[0])/nx < surfsize) flag = 0;
-    if (fabs(hi[1]-lo[1])/ny < surfsize) flag = 0;
-    if (dim == 3 && fabs(hi[2]-lo[2])/nz < surfsize) flag = 0;
+    if (fabs(hi[0]-lo[0])/plevels[plevel].nx < surfsize) flag = 0;
+    if (fabs(hi[1]-lo[1])/plevels[plevel].ny < surfsize) flag = 0;
+    if (dim == 3 && fabs(hi[2]-lo[2])/plevels[plevel].nz < surfsize) flag = 0;
     if (flag) rlist[n++] = icell;
   }
   rnum = n;


### PR DESCRIPTION
## Purpose

Fix a bug in adapt_grid (or fix adapt) when a grid was already been refined (e.g. by create_grid).  The size of a childlist vector was assumed to be specified by adapt_grid.  But it could be larger due to previous refinements.

This should fix issue #215

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


