### PR TITLE
Add barrier to prevent too many MPI broadcasts in flight

### DIFF
--- a/src/read_grid.cpp
+++ b/src/read_grid.cpp
@@ -152,7 +152,7 @@ void ReadGrid::read_cells()
   whichproc = 0;
   bigint nread = 0;
 
-  int count = 0;
+  bigint count = 0;
   while (nread < ncell) {
     if (ncell-nread > CHUNK) nchunk = CHUNK;
     else nchunk = ncell-nread;


### PR DESCRIPTION
## Purpose

Add barrier to prevent too many MPI broadcasts in flight, leading to MPI error:

```Exhausted MQ irecv request descriptors, which usually indicates a user program error or insufficient request descriptors``` 

Also fix issue in read_grid where grid cell output was always zero.

## Author(s)

Stan Moore, Steve Plimpton (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes
