### PR TITLE
Fix bug in surf grow() call

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -696,7 +696,8 @@ void Grid::surf2grid_new_algorithm(int outflag)
     surf->nlocal = surf->nghost = 0;
     int nmax_old = surf->nmax;
     surf->nmax = surf->nlocal = nreturn;
-    surf->grow(nmax_old);
+    if (surf->nmax > nmax_old)
+      surf->grow(nmax_old);
 
     if (dim == 2) memcpy(surf->lines,outbuf,nreturn*sizeof(Surf::Line));
     else memcpy(surf->tris,outbuf,nreturn*sizeof(Surf::Tri));


### PR DESCRIPTION
## Purpose

Fix bug in a surf `grow()` call where the old value was larger than the new value, leading to a negative input into memset, causing a crash in the `/heavy/corner_test/in.corner.distributed` regression test.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes.