### PR TITLE
Change reaction tally to bigint to prevent overflow

### DIFF
--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -23,6 +23,7 @@
 #include "particle.h"
 #include "grid.h"
 #include "surf.h"
+#include "spatype.h"
 
 #define MAX_TYPES_STACKPARAMS 12
 #define NeighClusterSize 8
@@ -464,6 +465,14 @@ typedef tdual_int_1d::t_dev_const_um t_int_1d_const_um;
 typedef tdual_int_1d::t_dev_const_randomread t_int_1d_randomread;
 
 typedef Kokkos::
+  DualView<SPARTA_NS::bigint*, DeviceType::array_layout, DeviceType> tdual_bigint_1d;
+typedef tdual_bigint_1d::t_dev t_bigint_1d;
+typedef tdual_bigint_1d::t_dev_const t_bigint_1d_const;
+typedef tdual_bigint_1d::t_dev_um t_bigint_1d_um;
+typedef tdual_bigint_1d::t_dev_const_um t_bigint_1d_const_um;
+typedef tdual_bigint_1d::t_dev_const_randomread t_bigint_1d_randomread;
+
+typedef Kokkos::
   DualView<int*[3], Kokkos::LayoutRight, DeviceType> tdual_int_1d_3;
 typedef tdual_int_1d_3::t_dev t_int_1d_3;
 typedef tdual_int_1d_3::t_dev_const t_int_1d_3_const;
@@ -733,6 +742,13 @@ typedef tdual_int_1d::t_host_const t_int_1d_const;
 typedef tdual_int_1d::t_host_um t_int_1d_um;
 typedef tdual_int_1d::t_host_const_um t_int_1d_const_um;
 typedef tdual_int_1d::t_host_const_randomread t_int_1d_randomread;
+
+typedef Kokkos::DualView<SPARTA_NS::bigint*, DeviceType::array_layout, DeviceType> tdual_bigint_1d;
+typedef tdual_bigint_1d::t_host t_bigint_1d;
+typedef tdual_bigint_1d::t_host_const t_bigint_1d_const;
+typedef tdual_bigint_1d::t_host_um t_bigint_1d_um;
+typedef tdual_bigint_1d::t_host_const_um t_bigint_1d_const_um;
+typedef tdual_bigint_1d::t_host_const_randomread t_bigint_1d_randomread;
 
 typedef Kokkos::DualView<int*[3], Kokkos::LayoutRight, DeviceType> tdual_int_1d_3;
 typedef tdual_int_1d_3::t_host t_int_1d_3;

--- a/src/KOKKOS/react_bird_kokkos.cpp
+++ b/src/KOKKOS/react_bird_kokkos.cpp
@@ -159,14 +159,14 @@ double ReactBirdKokkos::extract_tally(int m)
 
     if (sparta->kokkos->gpu_direct_flag) {
       MPI_Allreduce(d_tally_reactions.data(),k_tally_reactions_all.d_view.data(),nlist,
-                    MPI_INT,MPI_SUM,world);
+                    MPI_SPARTA_BIGINT,MPI_SUM,world);
       k_tally_reactions_all.modify_device();
       k_tally_reactions_all.sync_host();
     } else {
       k_tally_reactions.modify_device();
       k_tally_reactions.sync_host();
       MPI_Allreduce(k_tally_reactions.h_view.data(),k_tally_reactions_all.h_view.data(),nlist,
-                    MPI_INT,MPI_SUM,world);
+                    MPI_SPARTA_BIGINT,MPI_SUM,world);
     }
 
   }

--- a/src/KOKKOS/react_bird_kokkos.h
+++ b/src/KOKKOS/react_bird_kokkos.h
@@ -43,9 +43,9 @@ class ReactBirdKokkos : public ReactBird {
 
   // tallies for reactions
 
-  DAT::tdual_int_1d k_tally_reactions;
-  DAT::t_int_1d d_tally_reactions;
-  DAT::tdual_int_1d k_tally_reactions_all;
+  DAT::tdual_bigint_1d k_tally_reactions;
+  DAT::t_bigint_1d d_tally_reactions;
+  DAT::tdual_bigint_1d k_tally_reactions_all;
 
   struct OneReactionKokkos {
     int active;                    // 1 if reaction is active

--- a/src/react_bird.cpp
+++ b/src/react_bird.cpp
@@ -54,8 +54,8 @@ ReactBird::ReactBird(SPARTA *sparta, int narg, char **arg) :
   readfile(arg[1]);
   check_duplicate();
 
-  tally_reactions = new int[nlist];
-  tally_reactions_all = new int[nlist];
+  tally_reactions = new bigint[nlist];
+  tally_reactions_all = new bigint[nlist];
   tally_flag = 0;
 
   reactions = NULL;
@@ -886,7 +886,7 @@ double ReactBird::extract_tally(int m)
   if (!tally_flag) {
     tally_flag = 1;
     MPI_Allreduce(tally_reactions,tally_reactions_all,nlist,
-                  MPI_INT,MPI_SUM,world);
+                  MPI_SPARTA_BIGINT,MPI_SUM,world);
   }
 
   return 1.0*tally_reactions_all[m];

--- a/src/react_bird.h
+++ b/src/react_bird.h
@@ -39,7 +39,7 @@ class ReactBird : public React {
 
   // tallies for reactions
 
-  int *tally_reactions,*tally_reactions_all;
+  bigint *tally_reactions,*tally_reactions_all;
   int tally_flag;
 
   struct OneReaction {


### PR DESCRIPTION
## Purpose

Change reaction tally to bigint to prevent overflow, fixes #233.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes.