### PR TITLE
move: remove superfluous int

### DIFF
--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -390,7 +390,6 @@ template < int DIM, int SURF > void UpdateKokkos::move()
   // move/migrate iterations
 
   dt = update->dt;
-  int notfirst = 0;
 
   ParticleKokkos* particle_kk = ((ParticleKokkos*)particle);
 
@@ -479,8 +478,7 @@ template < int DIM, int SURF > void UpdateKokkos::move()
     nmigrate = 0;
     entryexit = 0;
 
-    if (notfirst == 0) {
-      notfirst = 1;
+    if (niterate == 1) {
       pstart = 0;
       pstop = nlocal;
     }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -339,7 +339,6 @@ template < int DIM, int SURF > void Update::move()
   Surf::Tri *tris = surf->tris;
   Surf::Line *lines = surf->lines;
   double dt = update->dt;
-  int notfirst = 0;
 
   // DEBUG
 
@@ -354,8 +353,7 @@ template < int DIM, int SURF > void Update::move()
     nmigrate = 0;
     entryexit = 0;
 
-    if (notfirst == 0) {
-      notfirst = 1;
+    if (niterate == 1) {
       pstart = 0;
       pstop = nlocal;
     }


### PR DESCRIPTION
## Purpose

Remove a superfluous int in the move() method. We can use `niterate == 1` instead of introducing another `notfirst` "flag". In theory this should also be more efficient (although I am no compiler expert).

## Author(s)

Tim Teichmann, KIT

## Backward Compatibility

compatible

## Implementation Notes

Self explanatory. Did **not** test the KOKKOS version.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines