### PR TITLE
2nd variant of a new persurf surf2grid mapping algorithm

### DIFF
--- a/src/grid.h
+++ b/src/grid.h
@@ -373,8 +373,8 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_new_algorithm(int);
   void surf2grid_new2_algorithm(int);
-  void recurse2d(double *, double *, cellint, int, Surf::Line *, double *, double *,
-		 int &, int &, int **&, MyHash *, MyHash *);
+  void recurse2d(double *, double *, cellint, int, int, Surf::Line *,
+		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
   void surf2grid_split(int, int);
   
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);

--- a/src/grid.h
+++ b/src/grid.h
@@ -374,7 +374,7 @@ class Grid : protected Pointers {
   void surf2grid_new_algorithm(int);
   void surf2grid_new2_algorithm(int);
   void recurse2d(double *, double *, cellint, int, Surf::Line *, double *, double *,
-		 int &, int &, int **&);
+		 int &, int &, int **&, MyHash *, MyHash *);
   void surf2grid_split(int, int);
   
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);

--- a/src/grid.h
+++ b/src/grid.h
@@ -373,11 +373,10 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_surf_algorithm(int);
   void surf2grid_split(int, int);
-  void recurse2d(double *, double *, cellint, int, int, Surf::Line *,
-		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
-  void recurse3d(double *, double *, cellint, int, int, Surf::Tri *,
-		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
-  
+  void recurse2d(int, int, double *, double *, int Surf::Line *, double *, double *,
+		 int &, int &, int **&, MyHash *, MyHash *);
+  void recurse3d(int, int, double *, double *, int Surf::Tri *, double *, double *,
+		 int &, int &, int **&, MyHash *, MyHash *);
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,
 	     GridTree *);

--- a/src/grid.h
+++ b/src/grid.h
@@ -371,13 +371,12 @@ class Grid : protected Pointers {
   // private methods
 
   void surf2grid_cell_algorithm(int);
-  void surf2grid_new_algorithm(int);
-  void surf2grid_new2_algorithm(int);
+  void surf2grid_surf_algorithm(int);
+  void surf2grid_split(int, int);
   void recurse2d(double *, double *, cellint, int, int, Surf::Line *,
 		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
   void recurse3d(double *, double *, cellint, int, int, Surf::Tri *,
 		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
-  void surf2grid_split(int, int);
   
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,

--- a/src/grid.h
+++ b/src/grid.h
@@ -373,9 +373,9 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_surf_algorithm(int);
   void surf2grid_split(int, int);
-  void recurse2d(int, int, double *, double *, Surf::Line *, double *, double *,
+  void recurse2d(int, int, double *, double *, int, Surf::Line *, double *, double *,
 		 int &, int &, int **&, MyHash *, MyHash *);
-  void recurse3d(int, int, double *, double *, Surf::Tri *, double *, double *,
+  void recurse3d(int, int, double *, double *, int, Surf::Tri *, double *, double *,
 		 int &, int &, int **&, MyHash *, MyHash *);
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,

--- a/src/grid.h
+++ b/src/grid.h
@@ -373,8 +373,9 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_new_algorithm(int);
   void surf2grid_new2_algorithm(int);
-  void surf2grid_surf_algorithm(int, int);
   void surf2grid_split(int, int);
+  void recurse(double *, double *, celling, int, Surf::Line *, double *, double *,
+	       int &, int &, int **&);
 
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,

--- a/src/grid.h
+++ b/src/grid.h
@@ -373,10 +373,10 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_new_algorithm(int);
   void surf2grid_new2_algorithm(int);
+  void recurse2d(double *, double *, cellint, int, Surf::Line *, double *, double *,
+		 int &, int &, int **&);
   void surf2grid_split(int, int);
-  void recurse(double *, double *, cellint, int, Surf::Line *, double *, double *,
-	       int &, int &, int **&);
-
+  
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,
 	     GridTree *);

--- a/src/grid.h
+++ b/src/grid.h
@@ -375,6 +375,8 @@ class Grid : protected Pointers {
   void surf2grid_new2_algorithm(int);
   void recurse2d(double *, double *, cellint, int, int, Surf::Line *,
 		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
+  void recurse3d(double *, double *, cellint, int, int, Surf::Tri *,
+		 double *, double *, int &, int &, int **&, MyHash *, MyHash *);
   void surf2grid_split(int, int);
   
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);

--- a/src/grid.h
+++ b/src/grid.h
@@ -373,9 +373,9 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_surf_algorithm(int);
   void surf2grid_split(int, int);
-  void recurse2d(int, int, double *, double *, int Surf::Line *, double *, double *,
+  void recurse2d(int, int, double *, double *, Surf::Line *, double *, double *,
 		 int &, int &, int **&, MyHash *, MyHash *);
-  void recurse3d(int, int, double *, double *, int Surf::Tri *, double *, double *,
+  void recurse3d(int, int, double *, double *, Surf::Tri *, double *, double *,
 		 int &, int &, int **&, MyHash *, MyHash *);
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,

--- a/src/grid.h
+++ b/src/grid.h
@@ -268,6 +268,7 @@ class Grid : protected Pointers {
 
   // grid_id.cpp
 
+  cellint parent_of_child(cellint, int);
   int id_find_child(cellint, int, double *, double *, double *);
   cellint id_uniform_level(int, int, int, int);
   void id_find_child_uniform_level(int, int, double *, double *, double *,
@@ -371,6 +372,7 @@ class Grid : protected Pointers {
 
   void surf2grid_cell_algorithm(int);
   void surf2grid_new_algorithm(int);
+  void surf2grid_new2_algorithm(int);
   void surf2grid_surf_algorithm(int, int);
   void surf2grid_split(int, int);
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -374,7 +374,7 @@ class Grid : protected Pointers {
   void surf2grid_new_algorithm(int);
   void surf2grid_new2_algorithm(int);
   void surf2grid_split(int, int);
-  void recurse(double *, double *, celling, int, Surf::Line *, double *, double *,
+  void recurse(double *, double *, cellint, int, Surf::Line *, double *, double *,
 	       int &, int &, int **&);
 
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);

--- a/src/grid.h
+++ b/src/grid.h
@@ -373,9 +373,11 @@ class Grid : protected Pointers {
   void surf2grid_cell_algorithm(int);
   void surf2grid_surf_algorithm(int);
   void surf2grid_split(int, int);
-  void recurse2d(int, int, double *, double *, int, Surf::Line *, double *, double *,
+  void recurse2d(cellint, int, double *, double *,
+		 int, Surf::Line *, double *, double *,
 		 int &, int &, int **&, MyHash *, MyHash *);
-  void recurse3d(int, int, double *, double *, int, Surf::Tri *, double *, double *,
+  void recurse3d(cellint, int, double *, double *,
+		 int, Surf::Tri *, double *, double *,
 		 int &, int &, int **&, MyHash *, MyHash *);
   void partition_grid(int, int, int, int, int, int, int, int, GridTree *);
   void mybox(int, int, int, int &, int &, int &, int &, int &, int &,

--- a/src/grid_id.cpp
+++ b/src/grid_id.cpp
@@ -32,7 +32,7 @@ enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
    return parentID
 ------------------------------------------------------------------------- */
 
-cellint Grid::parent_of_child(cellint childid, int level)
+cellint Grid::parent_of_child(cellint childID, int level)
 {
   // mask = all 1s for parent bits of ID
 

--- a/src/grid_id.cpp
+++ b/src/grid_id.cpp
@@ -38,7 +38,8 @@ cellint Grid::parent_of_child(cellint childid, int level)
 
   int parentbits = plevels[level-1].nbits;
   cellint mask = (1L << parentbits) - 1;
-  cellint parentID = id & mask;
+  cellint parentID = childID & mask;
+  
   return parentID;
 }
 

--- a/src/grid_id.cpp
+++ b/src/grid_id.cpp
@@ -28,6 +28,21 @@ enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
 //   to multiply 2 or 3 nx,ny,nz indices
 
 /* ----------------------------------------------------------------------
+   calculate parentID of a childID at level
+   return parentID
+------------------------------------------------------------------------- */
+
+cellint Grid::parent_of_child(cellint childid, int level)
+{
+  // mask = all 1s for parent bits of ID
+
+  int parentbits = plevels[level-1].nbits;
+  cellint mask = (1L << parentbits) - 1;
+  cellint parentID = id & mask;
+  return parentID;
+}
+
+/* ----------------------------------------------------------------------
    find child cell within parentID which contains point X
    level = level of parent cell
    oplo/ophi = original parent cell corner pts

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1435,8 +1435,6 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
   double clo[3],chi[3];
   double newlo[3],newhi[3];
   
-  double *boxlo = domain->boxlo;
-  double *boxhi = domain->boxhi;
   double *p1 = line->p1;
   double *p2 = line->p2;
 
@@ -1483,6 +1481,9 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
   // set newslo/newshi to intersection of slo/shi with new parent cell
 
   newlo[2] = newhi[2] = 0.0;
+
+  if (me == 0 && surfindex == 0)
+    printf("IJLOHI parentID %d lo %d %d hi %d %d\n",parentID,ilo,jlo,ihi,jhi);
   
   for (iy = jlo; iy <= jhi; iy++) {
     for (ix = ilo; ix <= ihi; ix++) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -959,7 +959,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 	printf("BOX lo %g %g %g hi %g %g %g\n",
 	       boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
 	printf("UNI lo %d %d %d hi %d %d %d\n",
-	       suinlo[0],sunilo[1],sunilo[2],sunihi[0],sunihi[1],sunihi[2]);
+	       sunilo[0],sunilo[1],sunilo[2],sunihi[0],sunihi[1],sunihi[2]);
       }
        
       // glo/hi = overlap of surf grid bbox with my RCB grid box

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -930,6 +930,13 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     mybox(me,0,nprocs-1,myunilo[0],myunihi[0],myunilo[1],
 	  myunihi[1],myunilo[2],myunihi[2],gtree);
 
+    printf("BOX lo %g %g %g hi %g %g %g\n",
+	   boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
+    printf("UNI lo %d %d %d hi %d %d %d\n",
+	   unilo[0],unilo[1],unilo[2],unihi[0],unihi[1],unihi[2]);
+    printf("MYUNI lo %d %d %d hi %d %d %d\n",
+	   myunilo[0],myunilo[1],myunilo[2],myunihi[0],myunihi[1],myunihi[2]);
+    
     childID = id_uniform_level(level,myunilo[0],myunilo[2],myunilo[2]);
     id_lohi(childID,level,boxlo,boxhi,rcblo,bbhi);
     childID = id_uniform_level(level,myunihi[0],myunihi[2],myunihi[2]);

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1625,7 +1625,7 @@ void Grid::recurse3d(double *bblo, double *bbhi, cellint parentID, int level,
 	if (!cflag && !pflag) continue;
       
 	grid->id_child_lohi(level,plo,phi,ichild,clo,chi);
-	overlap = cut2d->surf2grid_one(p1,p2,clo,chi);
+	overlap = cut3d->surf2grid_one(p1,p2,p3,clo,chi);
 	if (!overlap) continue;
 
 	if (cflag) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1424,10 +1424,9 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
                      int &npair, int &maxpair, int **&pair,
 		     MyHash *chash, MyHash *phash)
 {
-  int ix,iy,overlap;
+  int ix,iy,cflag,pflag,overlap;
   cellint ichild,childID;
   double celledge;
-  double plo[3],phi[3];
   double clo[3],chi[3];
   double newlo[3],newhi[3];
   
@@ -1435,8 +1434,6 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
   double *boxhi = domain->boxhi;
   double *p1 = line->p1;
   double *p2 = line->p2;
-
-  id_lohi(parentID,boxlo,boxhi,plo,phi);
 
   int nx = plevels[level].nx;
   int ny = plevels[level].ny;

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1464,6 +1464,9 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
   // else it is a parent cell, so recurse
   // set newslo/newshi to intersection of slo/shi with new parent cell
 
+  if (me == 0 && surfindex == 0)
+    printf("IJLOHI parentID %ld lo %d %d hi %d %d\n",parentID,ilo,jlo,ihi,jhi);
+      
   newlo[2] = newhi[2] = 0.0;
 
   for (iy = jlo; iy <= jhi; iy++) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -833,7 +833,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
   int nprocs = comm->nprocs;
   int dim = domain->dimension;
   int distributed = surf->distributed;
-
+ 
+  MPI_Barrier(world);
+  if (me == 0) printf("AAA 1\n");
+ 
   boxlo = domain->boxlo;
   boxhi = domain->boxhi;
 
@@ -898,6 +901,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
   for (int level = minlevel; level <= maxlevel; level++) {
 
+    MPI_Barrier(world);
+    if (me == 0) printf("LEV %d\n",level);
+
     if (outflag) {
       MPI_Barrier(world);
       t1 = MPI_Wtime();
@@ -921,14 +927,14 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     myunilo[0] = unilo[0]; myunihi[0] = unihi[0];
     myunilo[1] = unilo[1]; myunihi[1] = unihi[1];
     myunilo[2] = unilo[2]; myunihi[2] = unihi[2];
-    mybox(me,0,nprocs-1,myunilo[0],myunihi[1],myunilo[1],
+    mybox(me,0,nprocs-1,myunilo[0],myunihi[0],myunilo[1],
 	  myunihi[1],myunilo[2],myunihi[2],gtree);
 
     childID = id_uniform_level(level,myunilo[0],myunilo[2],myunilo[2]);
     id_lohi(childID,level,boxlo,boxhi,rcblo,bbhi);
     childID = id_uniform_level(level,myunihi[0],myunihi[2],myunihi[2]);
     id_lohi(childID,level,boxlo,boxhi,bblo,rcbhi);
-    
+
     // first portion of irregular comm
     // loop over my surfs:
     //   compute surf bbox as a brick of uniform grid cells at this level
@@ -988,6 +994,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     char *rbuf1 = (char *) memory->smalloc(nrecv1*nbytes_surf,"surf2grid:rbuf");
     irregular->exchange_uniform(sbuf1,nbytes_surf,rbuf1);
     delete irregular;
+
+    MPI_Barrier(world);
+    if (me == 0) printf("IRR1 %d %d\n",nsend,nrecv);
 
     if (outflag) {
       MPI_Barrier(world);

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1080,6 +1080,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     int npair = 0;
     int overlap;
 
+    printf("PRERECURSE me %d: level %d nrecv12 %d %d\n",me,level,nrecv1,nrecv2);
+    printf("UNI me %d: lo %d %d hi %d %d\n",me,unilo[0],unilo[1],unihi[0],unihi[1]);
+    printf("MYUNI me %d: lo %d %d hi %d %d\n",me,myunilo[0],myunilo[1],myunihi[0],myunihi[1]);
+    
     for (i = 0; i < nrecv1; i++) {
 
       // skip surf if it does not intersect my RCB box
@@ -1482,6 +1486,11 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
       
       grid->id_child_lohi(level,plo,phi,ichild,clo,chi);
       overlap = cut2d->surf2grid_one(p1,p2,clo,chi);
+
+      if (me == 0 && surfindex == 0)
+	printf("  loop: ixy %d %d cpflag %d %d childID %ld overlap %d\n",
+	       ix,iy,cflag,pflag,childID,overlap);
+      
       if (!overlap) continue;
 
       if (cflag) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -834,9 +834,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
   int dim = domain->dimension;
   int distributed = surf->distributed;
  
-  MPI_Barrier(world);
-  if (me == 0) printf("AAA 1\n");
- 
   boxlo = domain->boxlo;
   boxhi = domain->boxhi;
 
@@ -901,9 +898,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
   for (int level = minlevel; level <= maxlevel; level++) {
 
-    MPI_Barrier(world);
-    if (me == 0) printf("LEV %d\n",level);
-
     if (outflag) {
       MPI_Barrier(world);
       t1 = MPI_Wtime();
@@ -935,16 +929,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     childID = id_uniform_level(level,myunihi[0],myunihi[1],myunihi[2]);
     id_lohi(childID,level,boxlo,boxhi,bblo,rcbhi);
 
-    printf("BOX lo %g %g %g hi %g %g %g\n",
-	   boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
-    printf("UNI lo %d %d %d hi %d %d %d\n",
-	   unilo[0],unilo[1],unilo[2],unihi[0],unihi[1],unihi[2]);
-    printf("MYUNI lo %d %d %d hi %d %d %d\n",
-	   myunilo[0],myunilo[1],myunilo[2],myunihi[0],myunihi[1],myunihi[2]);
-    printf("RCB lo %g %g %g hi %g %g %g\n",
-	   rcblo[0],rcblo[1],rcblo[2],rcbhi[0],rcbhi[1],rcbhi[2]);
-    
-
     // first portion of irregular comm
     // loop over my surfs:
     //   compute surf bbox as a brick of uniform grid cells at this level
@@ -963,28 +947,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       id_find_child_uniform_level(level,1,boxlo,boxhi,shi,
 				  sunihi[0],sunihi[1],sunihi[2]);
 
-      if (isurf == 0) {
-	printf("ISURF slo %g %g %g shi %g %g %g\n",
-	       slo[0],slo[1],slo[2],shi[0],shi[1],shi[2]);
-	printf("BOX lo %g %g %g hi %g %g %g\n",
-	       boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
-	printf("SUNI lo %d %d %d hi %d %d %d\n",
-	       sunilo[0],sunilo[1],sunilo[2],sunihi[0],sunihi[1],sunihi[2]);
-	printf("MYUNI lo %d %d %d hi %d %d %d\n",
-	       myunilo[0],myunilo[1],myunilo[2],myunihi[0],myunihi[1],myunihi[2]);
-      }
-       
-      // glo/hi = overlap of surf grid bbox with my RCB grid box
-
-      /*
-      glo[0] = MAX(sunilo[0],myunilo[0]);
-      glo[1] = MAX(sunilo[1],myunilo[1]);
-      glo[2] = MAX(sunilo[2],myunilo[2]);
-      ghi[0] = MIN(sunihi[0],myunihi[0]);
-      ghi[1] = MIN(sunihi[1],myunihi[1]);
-      ghi[2] = MIN(sunihi[2],myunihi[2]);
-      */
-      
       // drop trimmed surf box on RCB tree
       // return list of procs whose RCB subbox it overlaps
 

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1588,9 +1588,9 @@ void Grid::recurse3d(double *bblo, double *bbhi, cellint parentID, int level,
   if (bbhi[1] >= celledge) jhi++;
 
   celledge = plo[2] + klo*(phi[2]-plo[2])/nz;
-  if (slo[2] <= celledge) klo--;
+  if (bblo[2] <= celledge) klo--;
   celledge = plo[2] + (khi+1)*(phi[2]-plo[2])/nz;
-  if (shi[2] >= celledge) khi++;
+  if (bbhi[2] >= celledge) khi++;
 
   // insure each index is between 0 and Nxy-1 inclusive
 

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1103,6 +1103,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     int npair = 0;
     int overlap;
 
+    // DEBUG
+    int count = 0;
+    
     for (i = 0; i < nrecv1; i++) {
 
       // skip surf if it does not intersect my RCB box
@@ -1125,13 +1128,14 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       bbhi[2] = MIN(shi[2],rcbhi[2]);
 
       // find all my RCB child cells this surf intersects
-      
+
+      count++;
       recurse2d(bblo,bbhi,0,0,i,&rcblines[i],boxlo,boxhi,
 		npair,maxpair,pairs,chash,phash);
     }
 
     MPI_Barrier(world);
-    if (me == 0) printf("RECURSE %d\n",npair);
+    printf("RECURSE me %d: %d %d %d count %d\n",me,npair,nrecv1,nrecv2,count);
     
     if (outflag) {
       MPI_Barrier(world);
@@ -1149,7 +1153,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     for (i = 0; i < npair; i++) {
       if (nsend == maxsend3) {
 	maxsend3 += DELTA_SEND;
-	memory->grow(proclist3,maxsend3,"surf2grid:proclist3");
+	memory->grow(proclist3,maxsend3,"surf2grigd:proclist3");
 	sbuf3 = (Send3 *) memory->srealloc(sbuf3,maxsend3*sizeof(Send3),
 					  "surf2grid:sbuf3");
       }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1140,8 +1140,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       }
     }
 
-    printf("RECURSE me %d nrecv %d %d npair %d\n",me,nrecv1,nrecv2,npair);
-    
     if (outflag) {
       MPI_Barrier(world);
       t4 = MPI_Wtime();

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1107,7 +1107,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       // skip surf if it does not intersect my RCB box
       
-      overlap = cut2d->surf2grid_one(rcblines[i].p1,rcblines[i].p2,rcblo,rcblo);
+      overlap = cut2d->surf2grid_one(rcblines[i].p1,rcblines[i].p2,rcblo,rcbhi);
       if (!overlap) continue;
 
       // slo/hi = bbox around one surf
@@ -1130,6 +1130,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 		npair,maxpair,pairs,chash,phash);
     }
 
+    MPI_Barrier(world);
+    if (me == 0) printf("RECURSE %d\n",npair);
+    
     if (outflag) {
       MPI_Barrier(world);
       t4 = MPI_Wtime();
@@ -1166,6 +1169,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 					     "surf2grid:rbuf3");
     irregular->exchange_uniform((char *) sbuf3,sizeof(Send3),(char *) rbuf3);
     delete irregular;
+
+    MPI_Barrier(world);
+    if (me == 0) printf("IRR3 %d %d\n",nsend,nrecv3);
 
     // process received cell/surf pairs
     // set nsurf and csurfs for each cell (only ones at this level)

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1081,10 +1081,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
     int npair = 0;
     int overlap;
-
-    printf("PRERECURSE me %d: level %d nrecv12 %d %d\n",me,level,nrecv1,nrecv2);
-    printf("UNI me %d: lo %d %d hi %d %d\n",me,unilo[0],unilo[1],unihi[0],unihi[1]);
-    printf("MYUNI me %d: lo %d %d hi %d %d\n",me,myunilo[0],myunilo[1],myunihi[0],myunihi[1]);
     
     for (i = 0; i < nrecv1; i++) {
 
@@ -1470,9 +1466,6 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
   // else it is a parent cell, so recurse
   // set newslo/newshi to intersection of slo/shi with new parent cell
 
-  if (me == 0 && surfindex == 0)
-    printf("IJLOHI parentID %ld lo %d %d hi %d %d\n",parentID,ilo,jlo,ihi,jhi);
-      
   newlo[2] = newhi[2] = 0.0;
 
   for (iy = jlo; iy <= jhi; iy++) {
@@ -1484,19 +1477,10 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
       else cflag = 1;
       if (phash->find(childID) == phash->end()) pflag = 0;
       else pflag = 1;
-
-      if (me == 0 && surfindex == 0)
-	printf("  loop: ixy %d %d cpflag %d %d childID %ld\n",
-	       ix,iy,cflag,pflag,childID);
-
       if (!cflag && !pflag) continue;
       
       grid->id_child_lohi(level,plo,phi,ichild,clo,chi);
       overlap = cut2d->surf2grid_one(p1,p2,clo,chi);
-
-      if (me == 0 && surfindex == 0)
-	printf("  overlap: %d\n",overlap);
-      
       if (!overlap) continue;
 
       if (cflag) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -978,9 +978,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     irregular->exchange_uniform(sbuf1,nbytes_surf,rbuf1);
     delete irregular;
 
-    MPI_Barrier(world);
-    printf("IRR1 me %d: %d %d\n",me,nsend,nrecv1);
-
     if (outflag) {
       MPI_Barrier(world);
       t2 = MPI_Wtime();
@@ -1036,9 +1033,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     irregular->exchange_uniform((char *) sbuf2,sizeof(Send2),(char *) rbuf2);
     delete irregular;
 
-    MPI_Barrier(world);
-    printf("IRR2 me %d: %d %d\n",me,nsend,nrecv2);
-
     if (outflag) {
       MPI_Barrier(world);
       t3 = MPI_Wtime();
@@ -1086,9 +1080,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     int npair = 0;
     int overlap;
 
-    // DEBUG
-    int count = 0;
-    
     for (i = 0; i < nrecv1; i++) {
 
       // skip surf if it does not intersect my RCB box
@@ -1112,14 +1103,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       // find all my RCB child cells this surf intersects
 
-      count++;
       recurse2d(bblo,bbhi,0,0,i,&rcblines[i],boxlo,boxhi,
 		npair,maxpair,pairs,chash,phash);
     }
 
-    MPI_Barrier(world);
-    printf("RECURSE me %d: %d %d %d count %d\n",me,npair,nrecv1,nrecv2,count);
-    
     if (outflag) {
       MPI_Barrier(world);
       t4 = MPI_Wtime();
@@ -1156,9 +1143,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 					     "surf2grid:rbuf3");
     irregular->exchange_uniform((char *) sbuf3,sizeof(Send3),(char *) rbuf3);
     delete irregular;
-
-    MPI_Barrier(world);
-    if (me == 0) printf("IRR3 %d %d\n",nsend,nrecv3);
 
     // process received cell/surf pairs
     // set nsurf and csurfs for each cell (only ones at this level)
@@ -1482,9 +1466,6 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
 
   newlo[2] = newhi[2] = 0.0;
 
-  if (me == 0 && surfindex == 0)
-    printf("IJLOHI parentID %d lo %d %d hi %d %d\n",parentID,ilo,jlo,ihi,jhi);
-  
   for (iy = jlo; iy <= jhi; iy++) {
     for (ix = ilo; ix <= ihi; ix++) {
       ichild = (cellint) iy*nx + ix + 1;

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -943,8 +943,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     // nrecv1 = # of surfs I have copy of in RCB decomp
     // NOTE: this comm might be faster in Rvous mode?
 
-    int sxlo,sxhi,sylo,syhi,szlo,szhi;
-
     int nsend = 0;
 
     for (isurf = istart; isurf < istop; isurf += idelta) {
@@ -996,7 +994,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     delete irregular;
 
     MPI_Barrier(world);
-    if (me == 0) printf("IRR1 %d %d\n",nsend,nrecv1);
+    printf("IRR1 %d %d\n",nsend,nrecv1);
 
     if (outflag) {
       MPI_Barrier(world);
@@ -1054,7 +1052,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     delete irregular;
 
     MPI_Barrier(world);
-    if (me == 0) printf("IRR2 %d %d\n",nsend,nrecv2);
+    printf("IRR2 %d %d\n",nsend,nrecv2);
 
     if (outflag) {
       MPI_Barrier(world);

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1053,12 +1053,11 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       (*chash)[childID] = i;
       id_lohi(childID,level,boxlo,boxhi,rcblohi[i].lo,rcblohi[i].hi);
 
+      int flag;
+      
       for (int ilevel = level; ilevel > 0; ilevel--) {
 	parentID = parent_of_child(childID,ilevel);
-	printf("CHPAR childID %ld parentID %ld\n",childID,parentID);
-	if (phash->find(parentID) == phash->end()) {
-	  break;
-	}
+	if (phash->find(parentID) != phash->end()) break;
 	(*phash)[parentID] = 0;
 	childID = parentID;
       }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1482,14 +1482,18 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
       else cflag = 1;
       if (phash->find(childID) == phash->end()) pflag = 0;
       else pflag = 1;
+
+      if (me == 0 && surfindex == 0)
+	printf("  loop: ixy %d %d cpflag %d %d childID %ld\n",
+	       ix,iy,cflag,pflag,childID);
+
       if (!cflag && !pflag) continue;
       
       grid->id_child_lohi(level,plo,phi,ichild,clo,chi);
       overlap = cut2d->surf2grid_one(p1,p2,clo,chi);
 
       if (me == 0 && surfindex == 0)
-	printf("  loop: ixy %d %d cpflag %d %d childID %ld overlap %d\n",
-	       ix,iy,cflag,pflag,childID,overlap);
+	printf("  overlap: %d\n",overlap);
       
       if (!overlap) continue;
 

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1548,7 +1548,7 @@ void Grid::recurse3d(double *bblo, double *bbhi, cellint parentID, int level,
                      int &npair, int &maxpair, int **&pairs,
 		     MyHash *chash, MyHash *phash)
 {
-  int ix,iy,cflag,pflag,overlap;
+  int ix,iy,iz,cflag,pflag,overlap;
   cellint ichild,childID;
   double celledge;
   double clo[3],chi[3];

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1114,7 +1114,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       // find all my RCB child cells this surf intersects
       
-      recurse2d(bblo,bbhi,0,0,&rcblines[i],boxlo,boxhi,
+      recurse2d(bblo,bbhi,0,0,i,&rcblines[i],boxlo,boxhi,
 		npair,maxpair,pairs,chash,phash);
     }
 
@@ -1419,7 +1419,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 ------------------------------------------------------------------------- */
 
 void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
-		     Surf::Line *line, 
+		     int surfindex, Surf::Line *line, 
 		     double *plo, double *phi,
                      int &npair, int &maxpair, int **&pair,
 		     MyHash *chash, MyHash *phash)
@@ -1452,14 +1452,14 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
   // same equation as in Grid::id_child_lohi()
 
   celledge = plo[0] + ilo*(phi[0]-plo[0])/nx;
-  if (slo[0] <= celledge) ilo--;
+  if (bblo[0] <= celledge) ilo--;
   celledge = plo[0] + (ihi+1)*(phi[0]-plo[0])/nx;
-  if (shi[0] >= celledge) ihi++;
+  if (bbhi[0] >= celledge) ihi++;
 
   celledge = plo[1] + jlo*(phi[1]-plo[1])/ny;
-  if (slo[1] <= celledge) jlo--;
+  if (bblo[1] <= celledge) jlo--;
   celledge = plo[1] + (jhi+1)*(phi[1]-plo[1])/ny;
-  if (shi[1] >= celledge) jhi++;
+  if (bbhi[1] >= celledge) jhi++;
 
   // insure each index is between 0 and Nxy-1 inclusive
 
@@ -1499,8 +1499,8 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
 	  maxpair += DELTA_SEND;
 	  memory->grow(pairs,maxpair,2,"surf2grid:pairs");
 	}
-	pairs[npair][0] = i;
-	pairs[npair][1] = j;
+	pairs[npair][0] = surfindex;
+	pairs[npair][1] = (*chash)[childID];
 	npair++;
 	continue;
       }
@@ -1510,7 +1510,7 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
 	newlo[1] = MAX(bblo[1],clo[1]);
 	newhi[0] = MIN(bbhi[0],chi[0]);
 	newhi[1] = MIN(bbhi[1],chi[1]);
-	recurse2d(newlo,newhi,childID,level+1,line,clo,chi,
+	recurse2d(newlo,newhi,childID,level+1,surfindex,line,clo,chi,
 		  npair,maxpair,pairs,chash,phash)
       }
     }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1030,7 +1030,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     // also compute the lo/hi extents of the child cells
 
     MyHash *rcbhash = new MyHash();
-    //MyHash *phash = new MyHash();
+    MyHash *phash = new MyHash();
     RCBlohi *rcblohi =
       (RCBlohi *) memory->smalloc(nrecv2*sizeof(RCBlohi),"surf2grid:rcblohi");
 
@@ -1038,14 +1038,13 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       childID = rbuf2[i].childID;
       (*rcbhash)[childID] = i;
       id_lohi(childID,level,boxlo,boxhi,rcblohi[i].lo,rcblohi[i].hi);
-      /*
+
       for (ilevel = level; ilevel > 0; ilevel--) {
 	parentID = parent_of_child(childID,ilevel);
 	if (phash->find(parentID) == phash->end()) break;
 	(phash)[parentID] = 0;
 	childID = parentID;
       }
-      */
     }
 
     // in RCB decomp, compute intersections between:
@@ -1079,6 +1078,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       sxhi = MIN(sxhi,myxhi);
       syhi = MIN(syhi,myyhi);
       szhi = MIN(szhi,myzhi);
+
+
+
+
       
       for (iz = szlo; iz <= szhi; iz++) {
 	for (iy = sylo; iy <= syhi; iy++) {
@@ -1189,6 +1192,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     memory->sfree(rbuf3);
     memory->sfree(rcblohi);
     delete rcbhash;
+    delete phash;
   }
 
   if (outflag) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1067,7 +1067,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       for (int ilevel = level; ilevel > 0; ilevel--) {
 	parentID = parent_of_child(childID,ilevel);
 	if (phash->find(parentID) == phash->end()) break;
-	(phash)[parentID] = 0;
+	(*phash)[parentID] = 0;
 	childID = parentID;
       }
     }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -958,8 +958,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 	       slo[0],slo[1],slo[2],shi[0],shi[1],shi[2]);
 	printf("BOX lo %g %g %g hi %g %g %g\n",
 	       boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
-	printf("UNI lo %d %d %d hi %d %d %d\n",
+	printf("SUNI lo %d %d %d hi %d %d %d\n",
 	       sunilo[0],sunilo[1],sunilo[2],sunihi[0],sunihi[1],sunihi[2]);
+	printf("MYUNI lo %d %d %d hi %d %d %d\n",
+	       myunilo[0],myunilo[1],myunilo[2],myunihi[0],myunihi[1],myunihi[2]);
       }
        
       // glo/hi = overlap of surf grid bbox with my RCB grid box

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -841,10 +841,6 @@ void Grid::surf2grid_new2_algorithm(int outflag)
   allsurflo = surf->bblo;
   allsurfhi = surf->bbhi;
 
-  if (me == 0) printf("ALLSURF BBOX lo %g %g %g hi %g %g %g\n",
-		      allsurflo[0],allsurflo[2],allsurflo[2],
-		      allsurfhi[0],allsurfhi[2],allsurfhi[2]);
-
   if (dim == 3) cut3d = new Cut3d(sparta);
   else cut2d = new Cut2d(sparta,domain->axisymmetric);
 

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1136,6 +1136,8 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       }
     }
 
+    printf("RECURSE me %d nrecv %d %d npair %d\n",me,nrecv1,nrecv2,npair);
+    
     if (outflag) {
       MPI_Barrier(world);
       t4 = MPI_Wtime();

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -930,9 +930,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     mybox(me,0,nprocs-1,myunilo[0],myunihi[0],myunilo[1],
 	  myunihi[1],myunilo[2],myunihi[2],gtree);
 
-    childID = id_uniform_level(level,myunilo[0],myunilo[2],myunilo[2]);
+    childID = id_uniform_level(level,myunilo[0],myunilo[1],myunilo[2]);
     id_lohi(childID,level,boxlo,boxhi,rcblo,bbhi);
-    childID = id_uniform_level(level,myunihi[0],myunihi[2],myunihi[2]);
+    childID = id_uniform_level(level,myunihi[0],myunihi[1],myunihi[2]);
     id_lohi(childID,level,boxlo,boxhi,bblo,rcbhi);
 
     printf("BOX lo %g %g %g hi %g %g %g\n",

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -953,6 +953,15 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       id_find_child_uniform_level(level,1,boxlo,boxhi,shi,
 				  sunihi[0],sunihi[1],sunihi[2]);
 
+      if (isurf == 0) {
+	printf("ISURF slo %g %g %g shi %g %g %g\n",
+	       slo[0],slo[1],slo[2],shi[0],shi[1],shi[2]);
+	printf("BOX lo %g %g %g hi %g %g %g\n",
+	       boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
+	printf("UNI lo %d %d %d hi %d %d %d\n",
+	       suinlo[0],sunilo[1],sunilo[2],sunihi[0],sunihi[1],sunihi[2]);
+      }
+       
       // glo/hi = overlap of surf grid bbox with my RCB grid box
 
       glo[0] = MAX(sunilo[0],myunilo[0]);

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -908,7 +908,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     id_find_child_uniform_level(level,0,boxlo,boxhi,allsurflo,
 				unilo[0],unilo[1],unilo[2]);
     id_find_child_uniform_level(level,1,boxlo,boxhi,allsurfhi,
-				unilhi[0],unihi[1],unihi[2]);
+				unihi[0],unihi[1],unihi[2]);
 
     // compute a recursive (RCB) decomp of the uniform grid box
     // gtree = tree of RCB cuts, cuts are along grid planes
@@ -919,8 +919,8 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     myunilo[0] = unilo[0]; myunihi[0] = unihi[0];
     myunilo[1] = unilo[1]; myunihi[1] = unihi[1];
     myunilo[2] = unilo[2]; myunihi[2] = unihi[2];
-    mybox(me,0,nprocs-1,myunilo[0],myunihi[1],myunilo[1],myunihi[1],
-	  myunilo[2],myunihi[2],,gtree);
+    mybox(me,0,nprocs-1,myunilo[0],myunihi[1],myunilo[1],
+	  myunihi[1],myunilo[2],myunihi[2],gtree);
 
     // first portion of irregular comm
     // loop over my surfs:
@@ -1057,7 +1057,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
       (*rcbhash)[childID] = i;
       id_lohi(childID,level,boxlo,boxhi,rcblohi[i].lo,rcblohi[i].hi);
 
-      for (ilevel = level; ilevel > 0; ilevel--) {
+      for (int ilevel = level; ilevel > 0; ilevel--) {
 	parentID = parent_of_child(childID,ilevel);
 	if (phash->find(parentID) == phash->end()) break;
 	(phash)[parentID] = 0;

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1421,7 +1421,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
 		     int surfindex, Surf::Line *line, 
 		     double *plo, double *phi,
-                     int &npair, int &maxpair, int **&pair,
+                     int &npair, int &maxpair, int **&pairs,
 		     MyHash *chash, MyHash *phash)
 {
   int ix,iy,cflag,pflag,overlap;

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1114,7 +1114,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       // find all my RCB child cells this surf intersects
       
-      recurse2d(bblo,bbhi,0,0,rcblines[i],boxlo,boxhi,npair,maxpair,pairs);
+      recurse2d(bblo,bbhi,0,0,&rcblines[i],boxlo,boxhi,npair,maxpair,pairs);
     }
 
     /*

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -930,17 +930,20 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     mybox(me,0,nprocs-1,myunilo[0],myunihi[0],myunilo[1],
 	  myunihi[1],myunilo[2],myunihi[2],gtree);
 
+    childID = id_uniform_level(level,myunilo[0],myunilo[2],myunilo[2]);
+    id_lohi(childID,level,boxlo,boxhi,rcblo,bbhi);
+    childID = id_uniform_level(level,myunihi[0],myunihi[2],myunihi[2]);
+    id_lohi(childID,level,boxlo,boxhi,bblo,rcbhi);
+
     printf("BOX lo %g %g %g hi %g %g %g\n",
 	   boxlo[0],boxlo[1],boxlo[2],boxhi[0],boxhi[1],boxhi[2]);
     printf("UNI lo %d %d %d hi %d %d %d\n",
 	   unilo[0],unilo[1],unilo[2],unihi[0],unihi[1],unihi[2]);
     printf("MYUNI lo %d %d %d hi %d %d %d\n",
 	   myunilo[0],myunilo[1],myunilo[2],myunihi[0],myunihi[1],myunihi[2]);
+    printf("RCB lo %g %g %g hi %g %g %g\n",
+	   rcblo[0],rcblo[1],rcblo[2],rcbhi[0],rcbhi[1],rcbhi[2]);
     
-    childID = id_uniform_level(level,myunilo[0],myunilo[2],myunilo[2]);
-    id_lohi(childID,level,boxlo,boxhi,rcblo,bbhi);
-    childID = id_uniform_level(level,myunihi[0],myunihi[2],myunihi[2]);
-    id_lohi(childID,level,boxlo,boxhi,bblo,rcbhi);
 
     // first portion of irregular comm
     // loop over my surfs:

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -966,20 +966,20 @@ void Grid::surf2grid_new2_algorithm(int outflag)
        
       // glo/hi = overlap of surf grid bbox with my RCB grid box
 
+      /*
       glo[0] = MAX(sunilo[0],myunilo[0]);
       glo[1] = MAX(sunilo[1],myunilo[1]);
       glo[2] = MAX(sunilo[2],myunilo[2]);
       ghi[0] = MIN(sunihi[0],myunihi[0]);
       ghi[1] = MIN(sunihi[1],myunihi[1]);
       ghi[2] = MIN(sunihi[2],myunihi[2]);
-
+      */
+      
       // drop trimmed surf box on RCB tree
       // return list of procs whose RCB subbox it overlaps
 
       int np = 0;
-      box_drop(glo,ghi,0,nprocs-1,gtree,np,plist);
-      printf("NP: %d: %d %d: %d %d: %d %d: %d %d\n",
-	     me,isurf,np,glo[0],ghi[0],glo[1],ghi[1],glo[2],ghi[2]);
+      box_drop(sunilo,sunihi,0,nprocs-1,gtree,np,plist);
       if (!np) continue;
 
       for (i = 0; i < np; i++) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -967,6 +967,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       int np = 0;
       box_drop(glo,ghi,0,nprocs-1,gtree,np,plist);
+      printf("NP: %d: %d %d\n",me,isurf,np);
       if (!np) continue;
 
       for (i = 0; i < np; i++) {
@@ -994,7 +995,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     delete irregular;
 
     MPI_Barrier(world);
-    printf("IRR1 %d %d\n",nsend,nrecv1);
+    printf("IRR1 me %d: %d %d\n",me,nsend,nrecv1);
 
     if (outflag) {
       MPI_Barrier(world);
@@ -1052,7 +1053,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     delete irregular;
 
     MPI_Barrier(world);
-    printf("IRR2 %d %d\n",nsend,nrecv2);
+    printf("IRR2 me %d: %d %d\n",me,nsend,nrecv2);
 
     if (outflag) {
       MPI_Barrier(world);

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -967,7 +967,8 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       int np = 0;
       box_drop(glo,ghi,0,nprocs-1,gtree,np,plist);
-      printf("NP: %d: %d %d\n",me,isurf,np);
+      printf("NP: %d: %d %d: %d %d: %d %d: %d %d\n",
+	     me,isurf,np,glo[0],ghi[0],glo[1],ghi[1],glo[2],ghi[2]);
       if (!np) continue;
 
       for (i = 0; i < np; i++) {

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1081,8 +1081,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
     int npair = 0;
     int overlap;
-    
-    for (i = 0; i < nrecv1; i++) {
+
+    if (dim == 2) {
+      for (i = 0; i < nrecv1; i++) {
 
       // skip surf if it does not intersect my RCB box
       
@@ -1091,8 +1092,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       // slo/hi = bbox around one surf
       
-      if (dim == 2) surf->bbox_one(&rcblines[i],slo,shi);
-      else surf->bbox_one(&rcbtris[i],slo,shi);
+      surf->bbox_one(&rcblines[i],slo,shi);
 
       // bblo/hi = overlap of surf bbox with my RCB box
 

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -51,13 +51,14 @@ enum{SOUTSIDE,SINSIDE,ONSURF2OUT,ONSURF2IN};  // several files (changed 2 words)
 // operations for surfaces in grid cells
 
 /* ----------------------------------------------------------------------
-   map surf elements to grid cells for explicit surfs, distributed or not
+   map surf elements to grid cells for explicit surfs (distributed or not)
    via one of two algorithms
    cell_alg = original, loop over my cells, check all surfs within bbox
    surf_alg = Jan19, loop over N/P surfs, find small set of cells each overlaps,
               perform rendezvous comm to convert cells per surf to surfs per cell
    new_alg = Nov20, no more parent cells, rendezvous alg at each level of grid
    new2_alg = Mar21, modified new alg, use recursive tree to speed overlap finding
+     this one is now surf_alg
    for distributed surfs, have to use surf alg
    PERAUTO option chooses based on total nsurfs vs nprocs
    see info on subflag, outflag options with surf2grid_split()
@@ -67,25 +68,141 @@ enum{SOUTSIDE,SINSIDE,ONSURF2OUT,ONSURF2IN};  // several files (changed 2 words)
 void Grid::surf2grid(int subflag, int outflag)
 {
   if (surf->distributed) {
-    //surf2grid_new_algorithm(outflag);
-    surf2grid_new2_algorithm(outflag);
+    surf2grid_surf_algorithm(outflag);
   } else if (surfgrid_algorithm == PERAUTO) {
     if (comm->nprocs > surf->nsurf) surf2grid_cell_algorithm(outflag);
     else {
-      //surf2grid_new_algorithm(outflag);
-      surf2grid_new2_algorithm(outflag);
+      surf2grid_surf_algorithm(outflag);
     }
   } else if (surfgrid_algorithm == PERCELL) {
     surf2grid_cell_algorithm(outflag);
   } else if (surfgrid_algorithm == PERSURF) {
-    //surf2grid_new_algorithm(outflag);
-    surf2grid_new2_algorithm(outflag);
+    surf2grid_surf_algorithm(outflag);
   }
 
   // now have nsurf,csurfs list of local surfs that overlap each cell
   // compute cut volume and split info for each cell
 
   surf2grid_split(subflag,outflag);
+}
+
+/* ----------------------------------------------------------------------
+   compute split cells for implicit surfs
+   surfs per cell already created
+   called from ReadISurf and FixAblate
+------------------------------------------------------------------------- */
+
+void Grid::surf2grid_implicit(int subflag, int outflag)
+{
+  int dim = domain->dimension;
+  if (dim == 3) cut3d = new Cut3d(sparta);
+  else cut2d = new Cut2d(sparta,domain->axisymmetric);
+
+  tmap = tcomm1 = tcomm2 = tcomm3 = 0.0;
+
+  if (outflag) surf2grid_stats();
+  surf2grid_split(subflag,outflag);
+}
+
+/* ----------------------------------------------------------------------
+   map surf elements into a single grid cell = icell
+   flag = 0 for grid refinement, 1 for grid coarsening
+   in cells: set nsurf, csurfs, nsplit, isplit
+   in cinfo: set type, corner, volume
+   initialize sinfo as needed
+   called from AdaptGrid
+------------------------------------------------------------------------- */
+
+void Grid::surf2grid_one(int flag, int icell, int iparent, int nsurf_caller,
+                         Cut3d *cut3d, Cut2d *cut2d)
+{
+  int nsurf,isub,xsub,nsplitone;
+  int *iptr;
+  surfint *sptr;
+  double xsplit[3];
+  double *vols;
+
+  int dim = domain->dimension;
+
+  // identify surfs in new cell only for grid refinement
+
+  if (flag == 0) {
+    sptr = csurfs->vget();
+    if (dim == 3)
+      nsurf = cut3d->surf2grid_list(cells[icell].id,
+                                    cells[icell].lo,cells[icell].hi,
+                                    cells[iparent].nsurf,cells[iparent].csurfs,
+                                    sptr,maxsurfpercell);
+    else
+      nsurf = cut2d->surf2grid_list(cells[icell].id,
+                                    cells[icell].lo,cells[icell].hi,
+                                    cells[iparent].nsurf,cells[iparent].csurfs,
+                                    sptr,maxsurfpercell);
+
+    if (nsurf == 0) return;
+    if (nsurf > maxsurfpercell) {
+      printf("Surfs in one refined cell = %d\n",nsurf);
+      error->one(FLERR,"Too many surfs in one refined cell - set global surfmax");
+    }
+
+    cinfo[icell].type = OVERLAP;
+    cells[icell].nsurf = nsurf;
+    cells[icell].csurfs = sptr;
+    csurfs->vgot(nsurf);
+
+  } else nsurf = nsurf_caller;
+
+  // split check done for both refinement and coarsening
+
+  int *surfmap = csplits->vget();
+  ChildCell *c = &cells[icell];
+
+  if (dim == 3)
+    nsplitone = cut3d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
+                             vols,surfmap,cinfo[icell].corner,
+                             xsub,xsplit);
+  else
+    nsplitone = cut2d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
+                             vols,surfmap,cinfo[icell].corner,
+                             xsub,xsplit);
+
+  if (nsplitone == 1) {
+    if (cinfo[icell].corner[0] != UNKNOWN)
+      cinfo[icell].volume = vols[0];
+
+  } else {
+    c->nsplit = nsplitone;
+    nunsplitlocal--;
+
+    c->isplit = grid->nsplitlocal;
+    add_split_cell(1);
+    SplitInfo *s = &sinfo[nsplitlocal-1];
+    s->icell = icell;
+    s->csplits = surfmap;
+    s->xsub = xsub;
+    s->xsplit[0] = xsplit[0];
+    s->xsplit[1] = xsplit[1];
+    if (dim == 3) s->xsplit[2] = xsplit[2];
+    else s->xsplit[2] = 0.0;
+
+    iptr = s->csubs = csubs->vget();
+
+    // add nsplitone sub cells
+    // collide and fixes also need to add cells
+
+    for (int i = 0; i < nsplitone; i++) {
+      isub = nlocal;
+      add_sub_cell(icell,1);
+      if (collide) collide->add_grid_one();
+      if (modify->n_pergrid) modify->add_grid_one();
+      cells[isub].nsplit = -i;
+      cinfo[isub].volume = vols[i];
+      iptr[i] = isub;
+    }
+
+    csplits->vgot(nsurf);
+    csubs->vgot(nsplitone);
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -194,605 +311,13 @@ void Grid::surf2grid_cell_algorithm(int outflag)
 
 /* ----------------------------------------------------------------------
    find surfs that overlap owned grid cells
-   algorithm:
-   in cells: set nsurf, csurfs
-   in cinfo: set type=OVERLAP for cells with surfs
-------------------------------------------------------------------------- */
-
-void Grid::surf2grid_new_algorithm(int outflag)
-{
-  int i,j,n,ix,iy,iz,icell,isurf;
-  int xlo,xhi,ylo,yhi,zlo,zhi;
-  int ilo[3],ihi[3];
-  cellint childID;
-  double t1,t2,t3,t4,t5;
-  double bblo[3],bbhi[3],ctr[3];
-  Irregular *irregular;
-
-  struct Send2 {
-    cellint childID;
-    int proc,icell;
-  };
-
-  struct Send3 {
-    surfint surfID;
-    int icell;
-  };
-
-  struct RCBlohi {
-    double lo[3],hi[3];
-  };
-
-  int me = comm->me;
-  int nprocs = comm->nprocs;
-  int dim = domain->dimension;
-  int distributed = surf->distributed;
-
-  double *boxlo = domain->boxlo;
-  double *boxhi = domain->boxhi;
-
-  surf->bbox_all();
-  double *slo = surf->bblo;
-  double *shi = surf->bbhi;
-
-  if (dim == 3) cut3d = new Cut3d(sparta);
-  else cut2d = new Cut2d(sparta,domain->axisymmetric);
-
-  int *plist;
-  memory->create(plist,nprocs,"surf2grid:plist");
-
-  GridTree *gtree =
-    (GridTree *) memory->smalloc(nprocs*sizeof(GridTree),"surf2grid:gtree");
-
-  // data structs for 3 irregular comms
-
-  int *proclist1 = NULL;
-  int *proclist2 = NULL;
-  int *proclist3 = NULL;
-  char *sbuf1 = NULL;
-  Send2 *sbuf2 = NULL;
-  Send3 *sbuf3 = NULL;
-  int maxsend1 = 0;
-  int maxsend2 = 0;
-  int maxsend3 = 0;
-  int **pairs = NULL;
-  int maxpair = 0;
-
-  // which set of Lines or Tris to process
-
-  Surf::Line *lines;
-  Surf::Tri *tris;
-  int nsurf,istart,istop,idelta,nbytes_surf;
-
-  if (distributed) {
-    lines = surf->mylines;
-    tris = surf->mytris;
-    nsurf = surf->nown;
-    istart = 0;
-    istop = nsurf;
-    idelta = 1;
-  } else {
-    lines = surf->lines;
-    tris = surf->tris;
-    int ntotal = surf->nsurf;
-    nsurf = ntotal / nprocs;
-    if (me < ntotal % nprocs) nsurf++;
-    istart = comm->me;
-    istop = ntotal;
-    idelta = nprocs;
-  }
-
-  if (dim == 2) nbytes_surf = sizeof(Surf::Line);
-  else nbytes_surf = sizeof(Surf::Tri);
-
-  // loop over levels of grid
-  // operate only on child cells at one level at each iteration
-
-  tmap = tcomm1 = tcomm2 = tcomm3 = 0.0;
-
-  int minlevel = set_minlevel();
-
-  for (int level = minlevel; level <= maxlevel; level++) {
-
-    if (outflag) {
-      MPI_Barrier(world);
-      t1 = MPI_Wtime();
-    }
-
-    // compute extent of uniform grid at level which overlaps surf bbox
-    // xyz lo/hi = inclusive range of overlapping grid box
-
-    id_find_child_uniform_level(level,0,boxlo,boxhi,slo,xlo,ylo,zlo);
-    id_find_child_uniform_level(level,1,boxlo,boxhi,shi,xhi,yhi,zhi);
-
-    // compute a recursive (RCB) decomp of the uniform grid box
-    // gtree = tree of RCB cuts
-    // my xyz lo/hi = inclusive range of my portion of grid box
-
-    partition_grid(0,nprocs-1,xlo,xhi,ylo,yhi,zlo,zhi,gtree);
-    int myxlo = xlo; int myxhi = xhi;
-    int myylo = ylo; int myyhi = yhi;
-    int myzlo = zlo; int myzhi = zhi;
-    mybox(me,0,nprocs-1,myxlo,myxhi,myylo,myyhi,myzlo,myzhi,gtree);
-
-    // first portion of irregular comm
-    // loop over my surfs:
-    //   compute its bbox as a brick of uniform grid cells at this level
-    //   drop its bbox down RCB tree to identify set of RCB procs to send to
-    // send the surf info via irregular comm
-    // NOTE: this comm might be faster as Rvous comm?
-
-    int sxlo,sxhi,sylo,syhi,szlo,szhi;
-
-    int nsend = 0;
-
-    for (isurf = istart; isurf < istop; isurf += idelta) {
-      if (dim == 2) surf->bbox_one(&lines[isurf],bblo,bbhi);
-      else surf->bbox_one(&tris[isurf],bblo,bbhi);
-      id_find_child_uniform_level(level,0,boxlo,boxhi,bblo,sxlo,sylo,szlo);
-      id_find_child_uniform_level(level,1,boxlo,boxhi,bbhi,sxhi,syhi,szhi);
-
-      // trim surf bbox to grid box
-
-      ilo[0] = MAX(sxlo,xlo);
-      ilo[1] = MAX(sylo,ylo);
-      ilo[2] = MAX(szlo,zlo);
-      ihi[0] = MIN(sxhi,xhi);
-      ihi[1] = MIN(syhi,yhi);
-      ihi[2] = MIN(szhi,zhi);
-
-      // drop trimmed surf bbox on RCB tree
-      // return list of procs whose subbox it overlaps
-
-      int np = 0;
-      box_drop(ilo,ihi,0,nprocs-1,gtree,np,plist);
-      if (!np) continue;
-
-      for (i = 0; i < np; i++) {
-	if (nsend == maxsend1) {
-	  maxsend1 += DELTA_SEND;
-	  memory->grow(proclist1,maxsend1,"surf2grid:proclist1");
-	  if (dim == 2)
-	    sbuf1 = (char *) memory->srealloc(sbuf1,maxsend1*sizeof(Surf::Line),
-					      "surf2grid:sbuf1");
-	  else
-	    sbuf1 = (char *) memory->srealloc(sbuf1,maxsend1*sizeof(Surf::Tri),
-					      "surf2grid:sbuf1");
-	}
-	proclist1[nsend] = plist[i];
-	if (dim == 2) memcpy(&sbuf1[nsend*nbytes_surf],&lines[isurf],nbytes_surf);
-	else memcpy(&sbuf1[nsend*nbytes_surf],&tris[isurf],nbytes_surf);
-	nsend++;
-      }
-    }
-
-    irregular = new Irregular(sparta);
-    int nrecv1 = irregular->create_data_uniform(nsend,proclist1,1);
-    char *rbuf1 = (char *) memory->smalloc(nrecv1*nbytes_surf,"surf2grid:rbuf");
-    irregular->exchange_uniform(sbuf1,nbytes_surf,rbuf1);
-    delete irregular;
-
-    if (outflag) {
-      MPI_Barrier(world);
-      t2 = MPI_Wtime();
-      tcomm1 += t2-t1;
-    }
-
-    // second portion of irregular comm
-    // for each child cell I own at this level: identify which RCB proc owns it
-    // send the cell info via irregular comm
-
-    int cx,cy,cz;
-    double ctr[3];
-
-    nsend = 0;
-
-    for (icell = 0; icell < nlocal; icell++) {
-      if (cells[icell].level != level) continue;
-      if (cells[icell].nsplit <= 0) continue;
-
-      ctr[0] = 0.5 * (cells[icell].lo[0] + cells[icell].hi[0]);
-      ctr[1] = 0.5 * (cells[icell].lo[1] + cells[icell].hi[1]);
-      ctr[2] = 0.5 * (cells[icell].lo[2] + cells[icell].hi[2]);
-      id_find_child_uniform_level(level,0,boxlo,boxhi,ctr,cx,cy,cz);
-
-      ilo[0] = cx; ihi[0] = cx;
-      ilo[1] = cy; ihi[1] = cy;
-      ilo[2] = cz; ihi[2] = cz;
-
-      int np = 0;
-      box_drop(ilo,ihi,0,nprocs-1,gtree,np,plist);
-      if (np != 1) error->one(FLERR,"Box drop of grid cell failed");
-
-      if (nsend == maxsend2) {
-	maxsend2 += DELTA_SEND;
-	memory->grow(proclist2,maxsend2,"surf2grid:proclist2");
-	sbuf2 = (Send2 *) memory->srealloc(sbuf2,maxsend2*sizeof(Send2),
-					  "surf2grid:sbuf2");
-      }
-
-      proclist2[nsend] = plist[0];
-      sbuf2[nsend].childID = cells[icell].id;
-      sbuf2[nsend].proc = me;
-      sbuf2[nsend].icell = icell;
-      nsend++;
-    }
-
-    irregular = new Irregular(sparta);
-    int nrecv2 = irregular->create_data_uniform(nsend,proclist2,1);
-    Send2 *rbuf2 = (Send2 *) memory->smalloc(nrecv2*sizeof(Send2),"surf2grid:rbuf2");
-    irregular->exchange_uniform((char *) sbuf2,sizeof(Send2),(char *) rbuf2);
-    delete irregular;
-
-    if (outflag) {
-      MPI_Barrier(world);
-      t3 = MPI_Wtime();
-      tcomm2 += t3-t2;
-    }
-
-    // hash the cell IDs I own in RCB decomp
-    // also compute their lo/hi extent
-
-    MyHash *rcbhash = new MyHash();
-    RCBlohi *rcblohi =
-      (RCBlohi *) memory->smalloc(nrecv2*sizeof(RCBlohi),"surf2grid:rcblohi");
-
-    for (i = 0; i < nrecv2; i++) {
-      childID = rbuf2[i].childID;
-      (*rcbhash)[childID] = i;
-      id_lohi(childID,level,boxlo,boxhi,rcblohi[i].lo,rcblohi[i].hi);
-    }
-
-    // in RCB decomp, compute intersections between:
-    //   my RCB grid cells that exist and my set of surfs
-    // append results to my list of surf/grid intersections
-    // loop over surfs:
-    //   compute surf's bbox in uniform grid
-    //   find intersection with box of grid cells I own
-    //   for each grid cell that exists in intersection,
-    //     check for actual overlap via cut2d/cut3d
-    //   build pairs list = one surf, one cell
-    //     as indices into received RCB data
-
-    Surf::Line *rcblines;
-    Surf::Tri *rcbtris;
-    if (dim == 2) rcblines = (Surf::Line *) rbuf1;
-    else rcbtris = (Surf::Tri *) rbuf1;
-
-    int npair = 0;
-    int overlap;
-
-    for (i = 0; i < nrecv1; i++) {
-      if (dim == 2) surf->bbox_one(&rcblines[i],bblo,bbhi);
-      else surf->bbox_one(&rcbtris[i],bblo,bbhi);
-      id_find_child_uniform_level(level,0,boxlo,boxhi,bblo,sxlo,sylo,szlo);
-      id_find_child_uniform_level(level,1,boxlo,boxhi,bbhi,sxhi,syhi,szhi);
-
-      for (iz = szlo; iz <= szhi; iz++) {
-	for (iy = sylo; iy <= syhi; iy++) {
-	  for (ix = sxlo; ix <= sxhi; ix++) {
-	    childID = id_uniform_level(level,ix,iy,iz);
-	    if (rcbhash->find(childID) == rcbhash->end()) continue;
-	    j = (*rcbhash)[childID];
-	
-	    if (dim == 2)
-	      overlap = cut2d->surf2grid_one(rcblines[i].p1,rcblines[i].p2,
-					     rcblohi[j].lo,rcblohi[j].hi);
-	    else
-	      overlap = cut3d->surf2grid_one(rcbtris[i].p1,rcbtris[i].p2,
-					     rcbtris[i].p3,
-					     rcblohi[j].lo,rcblohi[j].hi);
-	    if (!overlap) continue;
-	
-	    if (npair == maxpair) {
-	      maxpair += DELTA_SEND;
-	      memory->grow(pairs,maxpair,2,"surf2grid:pairs");
-	    }
-	    pairs[npair][0] = i;
-	    pairs[npair][1] = j;
-	    npair++;
-	  }
-	}
-      }
-    }
-
-    if (outflag) {
-      MPI_Barrier(world);
-      t4 = MPI_Wtime();
-      tmap += t4-t3;
-    }
-
-    // third irregular comm
-    // send each surf/grid intersection back to proc that owns grid cell
-
-    int surfindex,cellindex;
-
-    nsend = 0;
-
-    for (i = 0; i < npair; i++) {
-      if (nsend == maxsend3) {
-	maxsend3 += DELTA_SEND;
-	memory->grow(proclist3,maxsend3,"surf2grid:proclist3");
-	sbuf3 = (Send3 *) memory->srealloc(sbuf3,maxsend3*sizeof(Send3),
-					  "surf2grid:sbuf3");
-      }
-
-      surfindex = pairs[i][0];
-      cellindex = pairs[i][1];
-      proclist3[i] = rbuf2[cellindex].proc;
-      if (dim == 2) sbuf3[i].surfID = rcblines[surfindex].id;
-      else sbuf3[i].surfID = rcbtris[surfindex].id;
-      sbuf3[i].icell = rbuf2[cellindex].icell;
-      nsend++;
-    }
-
-    irregular = new Irregular(sparta);
-    int nrecv3 = irregular->create_data_uniform(nsend,proclist3,1);
-    Send3 *rbuf3 = (Send3 *) memory->smalloc(nrecv3*sizeof(Send3),
-					     "surf2grid:rbuf3");
-    irregular->exchange_uniform((char *) sbuf3,sizeof(Send3),(char *) rbuf3);
-    delete irregular;
-
-    // process received cell/surf pairs
-    // set nsurf and csurfs for each cell (only ones at this level)
-    // 1st pass: count surfs in each cell, then allocate csurfs in each cell
-    // 2nd pass: fill each cell's csurf list
-
-    for (i = 0; i < nrecv3; i++) {
-      icell = rbuf3[i].icell;
-      cells[icell].nsurf++;
-    }
-
-    // skip sub cells since may exist in a restart
-
-    for (icell = 0; icell < nlocal; icell++) {
-      if (cells[icell].level != level) continue;
-      if (cells[icell].nsplit <= 0) continue;
-      nsurf = cells[icell].nsurf;
-      if (nsurf) {
-	if (nsurf > maxsurfpercell)
-	  error->one(FLERR,"Too many surfs in one cell - set global surfmax");
-	cells[icell].csurfs = csurfs->get(nsurf);
-	cells[icell].nsurf = 0;
-      }
-    }
-
-    for (i = 0; i < nrecv3; i++) {
-      icell = rbuf3[i].icell;
-      nsurf = cells[icell].nsurf;
-      cells[icell].csurfs[nsurf] = rbuf3[i].surfID;
-      cells[icell].nsurf++;
-    }
-
-    if (outflag) {
-      MPI_Barrier(world);
-      t5 = MPI_Wtime();
-      tcomm3 += t5-t4;
-    }
-
-    // clean up for this level iteration
-
-    memory->sfree(rbuf1);
-    memory->sfree(rbuf2);
-    memory->sfree(rbuf3);
-    memory->sfree(rcblohi);
-    delete rcbhash;
-  }
-
-  if (outflag) {
-    MPI_Barrier(world);
-    t1 = MPI_Wtime();
-  }
-
-  // clean up after all iterations
-
-  memory->destroy(proclist1);
-  memory->destroy(proclist2);
-  memory->destroy(proclist3);
-  memory->sfree(sbuf1);
-  memory->sfree(sbuf2);
-  memory->sfree(sbuf3);
-  memory->destroy(pairs);
-  memory->destroy(plist);
-  memory->sfree(gtree);
-
-  // non-distributed surfs:
-  // each cell's csurf list currently stores surf IDs
-  // convert to indices into global list stored by each proc
-  // shash used to store IDs of entire global list
-
-  if (!distributed) {
-    lines = surf->lines;
-    tris = surf->tris;
-    int nslocal = surf->nlocal;
-
-    MySurfHash shash;
-    surfint *list;
-
-    if (dim == 2) {
-      for (i = 0; i < nslocal; i++)
-	shash[lines[i].id] = i;
-    } else {
-      for (i = 0; i < nslocal; i++)
-	shash[tris[i].id] = i;
-    }
-
-    for (icell = 0; icell < nlocal; icell++) {
-      if (!cells[icell].nsurf) continue;
-      if (cells[icell].nsplit <= 0) continue;
-
-      list = cells[icell].csurfs;
-      n = cells[icell].nsurf;
-
-      for (i = 0; i < n; i++)
-	list[i] = shash[list[i]];
-    }
-  }
-
-  // distributed surfs:
-  // rendezvous operation to obtain nlocal surfs for each proc
-  // each grid cell requests a surf from proc that owns surf in mylines/mytris
-  //   use shash to only do this once per surf
-  // receive the surf and store in nlocal lines/tris
-
-  if (distributed) {
-
-    // ncount = # of unique surfs I need for my owned grid cells
-    // store IDs of those surfs in shash
-
-    MySurfHash shash;
-    MyIterator it;
-    surfint *list;
-    int ncount = 0;
-
-    for (icell = 0; icell < nlocal; icell++) {
-      if (!cells[icell].nsurf) continue;
-      if (cells[icell].nsplit <= 0) continue;
-
-      list = cells[icell].csurfs;
-      n = cells[icell].nsurf;
-
-      for (i = 0; i < n; i++)
-	if (shash.find(list[i]) == shash.end()) {
-	  shash[list[i]] = 0;
-	  ncount++;
-	}
-    }
-
-    // allocate memory for rvous input
-
-    int *proclist;
-    memory->create(proclist,ncount,"surf2grid:proclist2");
-    InRvous *inbuf =
-      (InRvous *) memory->smalloc((bigint) ncount*sizeof(InRvous),
-				  "surf2grid:inbuf");
-
-    // create rvous inputs
-    // proclist = owner of each surf
-
-    surfint surfID;
-
-    ncount = 0;
-    for (it = shash.begin(); it != shash.end(); ++it) {
-      surfID = it->first;
-      proclist[ncount] = (surfID-1) % nprocs;
-      inbuf[ncount].proc = me;
-      inbuf[ncount].surfID = surfID;
-      ncount++;
-    }
-
-    // perform rendezvous operation
-    // each proc owns subset of surfs
-    // receives all surf requests to return surf to each proc who needs it
-
-    char *outbuf;
-    int outbytes;
-    if (dim == 2) outbytes = sizeof(OutRvousLine);
-    else outbytes = sizeof(OutRvousTri);
-
-    int nreturn = comm->rendezvous(1,ncount,(char *) inbuf,sizeof(InRvous),
-				   0,proclist,rendezvous_surfrequest,
-				   0,outbuf,outbytes,(void *) this);
-
-    memory->destroy(proclist);
-    memory->sfree(inbuf);
-
-    // copy entire rendezvous output buf into realloced Surf lines/tris
-
-    surf->nlocal = surf->nghost = 0;
-    int nmax_old = surf->nmax;
-    surf->nmax = surf->nlocal = nreturn;
-    if (surf->nmax > nmax_old)
-      surf->grow(nmax_old);
-
-    if (dim == 2) memcpy(surf->lines,outbuf,nreturn*sizeof(Surf::Line));
-    else memcpy(surf->tris,outbuf,nreturn*sizeof(Surf::Tri));
-
-    memory->sfree(outbuf);
-
-    // reset Surf hash to point to surf list in lines/tris
-
-    Surf::Line *lines = surf->lines;
-    Surf::Tri *tris = surf->tris;
-
-    if (dim == 2) {
-      for (i = 0; i < nreturn; i++) {
-        surfID = lines[i].id;
-        shash[surfID] = i;
-      }
-    } else {
-      for (i = 0; i < nreturn; i++) {
-        surfID = tris[i].id;
-        shash[surfID] = i;
-      }
-    }
-
-    // reset csurfs list for each of my owned cells
-    // from storing surfID to storing local index of that surfID
-
-    for (icell = 0; icell < nlocal; icell++) {
-      if (!cells[icell].nsurf) continue;
-      if (cells[icell].nsplit <= 0) continue;
-
-      list = cells[icell].csurfs;
-      n = cells[icell].nsurf;
-
-      for (i = 0; i < n; i++)
-	list[i] = shash[list[i]];
-    }
-  }
-
-  // for performance, sort each cell's csurfs list, same order as cell alg
-  // mark cells with surfs as OVERLAP, only if has a non-transparent surf
-
-  lines = surf->lines;
-  tris = surf->tris;
-
-  surfint *list;
-  int nontrans;
-
-  for (icell = 0; icell < nlocal; icell++) {
-    if (!cells[icell].nsurf) continue;
-    if (cells[icell].nsplit <= 0) continue;
-
-    qsort(cells[icell].csurfs,cells[icell].nsurf,
-	  sizeof(surfint),compare_surfIDs);
-
-    list = cells[icell].csurfs;
-    n = cells[icell].nsurf;
-    nontrans = 0;
-
-    if (dim == 2) {
-      for (i = 0; i < n; i++) {
-	if (!lines[list[i]].transparent) nontrans = 1;
-	break;
-      }
-    } else {
-      for (i = 0; i < n; i++) {
-	if (!tris[list[i]].transparent) nontrans = 1;
-	break;
-      }
-    }
-
-    if (nontrans) cinfo[icell].type = OVERLAP;
-  }
-
-  if (outflag) {
-    MPI_Barrier(world);
-    t2 = MPI_Wtime();
-    tcomm4 = t2-t1;
-  }
-}
-
-/* ----------------------------------------------------------------------
-   find surfs that overlap owned grid cells
    NOTE: doc this
    algorithm:
    in cells: set nsurf, csurfs
    in cinfo: set type=OVERLAP for cells with surfs
 ------------------------------------------------------------------------- */
 
-void Grid::surf2grid_new2_algorithm(int outflag)
+void Grid::surf2grid_surf_algorithm(int outflag)
 {
   int i,j,n,ix,iy,iz,icell,isurf;
   cellint childID,parentID;
@@ -1426,6 +951,208 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 }
 
 /* ----------------------------------------------------------------------
+   compute cut volume of each cell and any split cell info
+   nsurf and csurfs list for each grid cell have already been computed
+   if subflag = 1, create new owned split and sub cells as needed
+     called from ReadSurf, RemoveSurf, MoveSurf, FixAblate
+   if subflag = 0, split/sub cells already exist
+     called from ReadRestart
+   outflag = 1 for timing and statistics info
+   in cells: set nsplit, isplit
+   in cinfo: set corner, volume
+   initialize sinfo as needed
+------------------------------------------------------------------------- */
+
+void Grid::surf2grid_split(int subflag, int outflag)
+{
+  int i,isub,nsurf,nsplitone,xsub;
+  int *surfmap,*ptr;
+  double t1,t2;
+  double *lo,*hi,*vols;
+  double xsplit[3];
+  ChildCell *c;
+  SplitInfo *s;
+
+  int dim = domain->dimension;
+
+  if (outflag) {
+    MPI_Barrier(world);
+    t1 = MPI_Wtime();
+  }
+
+  // compute cut volume and possible split of each grid cell by surfs
+  // decrement nunsplitlocal if convert an unsplit cell to split cell
+  // if nsplitone > 1, create new split cell sinfo and sub-cells
+  // skip if nsplit <= 0 b/c split cells could exist if restarting
+
+  int max = 0;
+  int ncurrent = nlocal;
+
+  for (int icell = 0; icell < ncurrent; icell++) {
+    if (cells[icell].nsplit <= 0) continue;
+    if (cinfo[icell].type != OVERLAP) continue;
+
+    surfmap = csplits->vget();
+    c = &cells[icell];
+
+    if (dim == 3)
+      nsplitone = cut3d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
+                               vols,surfmap,cinfo[icell].corner,xsub,xsplit);
+    else
+      nsplitone = cut2d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
+                               vols,surfmap,cinfo[icell].corner,xsub,xsplit);
+
+    if (nsplitone == 1) {
+      cinfo[icell].volume = vols[0];
+
+    } else if (subflag) {
+      if (nsplitone > maxsplitpercell) {
+	max = MAX(max,nsplitone);
+	csplits->vgot(0);
+	
+      } else {
+	cells[icell].nsplit = nsplitone;
+	nunsplitlocal--;
+
+	cells[icell].isplit = nsplitlocal;
+	add_split_cell(1);
+	s = &sinfo[nsplitlocal-1];
+	s->icell = icell;
+	s->csplits = surfmap;
+	s->xsub = xsub;
+	s->xsplit[0] = xsplit[0];
+	s->xsplit[1] = xsplit[1];
+	if (dim == 3) s->xsplit[2] = xsplit[2];
+	else s->xsplit[2] = 0.0;
+
+	ptr = s->csubs = csubs->vget();
+
+        // add nsplitone sub cells
+        // collide and fixes also need to add cells
+
+	for (i = 0; i < nsplitone; i++) {
+	  isub = nlocal;
+	  add_sub_cell(icell,1);
+          if (collide) collide->add_grid_one();
+          if (modify->n_pergrid) modify->add_grid_one();
+	  cells[isub].nsplit = -i;
+	  cinfo[isub].volume = vols[i];
+	  ptr[i] = isub;
+	}
+	
+	csubs->vgot(nsplitone);
+	csplits->vgot(cells[icell].nsurf);
+      }
+
+    } else {
+      if (cells[icell].nsplit != nsplitone) {
+        printf("BAD %d %d: %d %d\n",icell,cells[icell].id,
+               nsplitone,cells[icell].nsplit);
+        error->one(FLERR,
+                   "Inconsistent surface to grid mapping in read_restart");
+      }
+
+      s = &sinfo[cells[icell].isplit];
+      s->csplits = surfmap;
+      s->xsub = xsub;
+      s->xsplit[0] = xsplit[0];
+      s->xsplit[1] = xsplit[1];
+      if (dim == 3) s->xsplit[2] = xsplit[2];
+      else s->xsplit[2] = 0.0;
+
+      ptr = s->csubs;
+      for (i = 0; i < nsplitone; i++) {
+        isub = ptr[i];
+        cells[isub].nsurf = cells[icell].nsurf;
+        cells[isub].csurfs = cells[icell].csurfs;
+        cinfo[isub].volume = vols[i];
+      }
+
+      csplits->vgot(cells[icell].nsurf);
+    }
+  }
+
+  // error if split count exceeds maxsplitpercell for any cell
+
+  int maxall;
+  MPI_Allreduce(&max,&maxall,1,MPI_INT,MPI_MAX,world);
+  if (maxall) {
+    if (me == 0) printf("Max split cells in any cell = %d\n",maxall);
+    error->all(FLERR,"Too many split cells in a single cell - "
+               "set global splitmax");
+  }
+
+  // stats on pushed cells and unmarked corner points in OVERLAP cells
+
+  if (outflag) {
+    int npushmax;
+    int *npushcell;
+    if (dim == 3) {
+      npushmax = cut3d->npushmax;
+      npushcell = cut3d->npushcell;
+    } else {
+      npushmax = cut2d->npushmax;
+      npushcell = cut2d->npushcell;
+    }
+    int *npushall = new int[npushmax+1];
+    MPI_Allreduce(npushcell,npushall,npushmax+1,MPI_INT,MPI_SUM,world);
+    if (comm->me == 0) {
+      if (screen) {
+        fprintf(screen,"  ");
+        for (int i = 1; i <= npushmax; i++)
+          fprintf(screen,"%d ",npushall[i]);
+        fprintf(screen,"= number of pushed cells\n");
+      }
+      if (logfile) {
+        fprintf(logfile,"  ");
+        for (int i = 1; i <= npushmax; i++)
+          fprintf(logfile,"%d ",npushall[i]);
+        fprintf(logfile,"= number of pushed cells\n");
+      }
+    }
+    delete [] npushall;
+
+    int noverlap = 0;
+    int ncorner = 0;
+    for (int icell = 0; icell < nlocal; icell++) {
+      if (cells[icell].nsplit <= 0) continue;
+      if (cinfo[icell].type == OVERLAP) {
+        noverlap++;
+        if (cinfo[icell].corner[0] == UNKNOWN) ncorner++;
+      }
+    }
+
+    bigint bncorner = ncorner;
+    bigint bnoverlap = noverlap;
+    bigint ncornerall,noverlapall;
+    MPI_Allreduce(&bncorner,&ncornerall,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
+    MPI_Allreduce(&bnoverlap,&noverlapall,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
+
+    if (comm->me == 0) {
+      if (screen) fprintf(screen,"  " BIGINT_FORMAT " " BIGINT_FORMAT
+                          " = cells overlapping surfs, "
+                          "overlap cells with unmarked corner pts\n",
+                          noverlapall,ncornerall);
+      if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " " BIGINT_FORMAT
+                           " = cells overlapping surfs, "
+                           "overlap cells with unmarked corner pts\n",
+                           noverlapall,ncornerall);
+    }
+  }
+
+  // clean up
+
+  if (dim == 3) delete cut3d;
+  else delete cut2d;
+
+  if (outflag) {
+    MPI_Barrier(world);
+    t2 = MPI_Wtime();
+    tsplit = t2-t1;
+  }
+}
+
+/* ----------------------------------------------------------------------
    enumerate intersections of isurf with any child grid cell in iparent cell
    called by surf2grid_new2_algorithm()
    bblo/hi = bounding box for surf within parent cell and this proc's RCB box
@@ -1819,327 +1546,6 @@ int Grid::rendezvous_surfrequest(int n, char *inbuf, int &flag,
 
   flag = 2;
   return n;
-}
-
-/* ----------------------------------------------------------------------
-   compute split cells for implicit surfs
-   surfs per cell already created
-   called from ReadISurf and FixAblate
-------------------------------------------------------------------------- */
-
-void Grid::surf2grid_implicit(int subflag, int outflag)
-{
-  int dim = domain->dimension;
-  if (dim == 3) cut3d = new Cut3d(sparta);
-  else cut2d = new Cut2d(sparta,domain->axisymmetric);
-
-  tmap = tcomm1 = tcomm2 = tcomm3 = 0.0;
-
-  if (outflag) surf2grid_stats();
-  surf2grid_split(subflag,outflag);
-}
-
-/* ----------------------------------------------------------------------
-   compute cut volume of each cell and any split cell info
-   nsurf and csurfs list for each grid cell have already been computed
-   if subflag = 1, create new owned split and sub cells as needed
-     called from ReadSurf, RemoveSurf, MoveSurf, FixAblate
-   if subflag = 0, split/sub cells already exist
-     called from ReadRestart
-   outflag = 1 for timing and statistics info
-   in cells: set nsplit, isplit
-   in cinfo: set corner, volume
-   initialize sinfo as needed
-------------------------------------------------------------------------- */
-
-void Grid::surf2grid_split(int subflag, int outflag)
-{
-  int i,isub,nsurf,nsplitone,xsub;
-  int *surfmap,*ptr;
-  double t1,t2;
-  double *lo,*hi,*vols;
-  double xsplit[3];
-  ChildCell *c;
-  SplitInfo *s;
-
-  int dim = domain->dimension;
-
-  if (outflag) {
-    MPI_Barrier(world);
-    t1 = MPI_Wtime();
-  }
-
-  // compute cut volume and possible split of each grid cell by surfs
-  // decrement nunsplitlocal if convert an unsplit cell to split cell
-  // if nsplitone > 1, create new split cell sinfo and sub-cells
-  // skip if nsplit <= 0 b/c split cells could exist if restarting
-
-  int max = 0;
-  int ncurrent = nlocal;
-
-  for (int icell = 0; icell < ncurrent; icell++) {
-    if (cells[icell].nsplit <= 0) continue;
-    if (cinfo[icell].type != OVERLAP) continue;
-
-    surfmap = csplits->vget();
-    c = &cells[icell];
-
-    if (dim == 3)
-      nsplitone = cut3d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
-                               vols,surfmap,cinfo[icell].corner,xsub,xsplit);
-    else
-      nsplitone = cut2d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
-                               vols,surfmap,cinfo[icell].corner,xsub,xsplit);
-
-    if (nsplitone == 1) {
-      cinfo[icell].volume = vols[0];
-
-    } else if (subflag) {
-      if (nsplitone > maxsplitpercell) {
-	max = MAX(max,nsplitone);
-	csplits->vgot(0);
-	
-      } else {
-	cells[icell].nsplit = nsplitone;
-	nunsplitlocal--;
-
-	cells[icell].isplit = nsplitlocal;
-	add_split_cell(1);
-	s = &sinfo[nsplitlocal-1];
-	s->icell = icell;
-	s->csplits = surfmap;
-	s->xsub = xsub;
-	s->xsplit[0] = xsplit[0];
-	s->xsplit[1] = xsplit[1];
-	if (dim == 3) s->xsplit[2] = xsplit[2];
-	else s->xsplit[2] = 0.0;
-
-	ptr = s->csubs = csubs->vget();
-
-        // add nsplitone sub cells
-        // collide and fixes also need to add cells
-
-	for (i = 0; i < nsplitone; i++) {
-	  isub = nlocal;
-	  add_sub_cell(icell,1);
-          if (collide) collide->add_grid_one();
-          if (modify->n_pergrid) modify->add_grid_one();
-	  cells[isub].nsplit = -i;
-	  cinfo[isub].volume = vols[i];
-	  ptr[i] = isub;
-	}
-	
-	csubs->vgot(nsplitone);
-	csplits->vgot(cells[icell].nsurf);
-      }
-
-    } else {
-      if (cells[icell].nsplit != nsplitone) {
-        printf("BAD %d %d: %d %d\n",icell,cells[icell].id,
-               nsplitone,cells[icell].nsplit);
-        error->one(FLERR,
-                   "Inconsistent surface to grid mapping in read_restart");
-      }
-
-      s = &sinfo[cells[icell].isplit];
-      s->csplits = surfmap;
-      s->xsub = xsub;
-      s->xsplit[0] = xsplit[0];
-      s->xsplit[1] = xsplit[1];
-      if (dim == 3) s->xsplit[2] = xsplit[2];
-      else s->xsplit[2] = 0.0;
-
-      ptr = s->csubs;
-      for (i = 0; i < nsplitone; i++) {
-        isub = ptr[i];
-        cells[isub].nsurf = cells[icell].nsurf;
-        cells[isub].csurfs = cells[icell].csurfs;
-        cinfo[isub].volume = vols[i];
-      }
-
-      csplits->vgot(cells[icell].nsurf);
-    }
-  }
-
-  // error if split count exceeds maxsplitpercell for any cell
-
-  int maxall;
-  MPI_Allreduce(&max,&maxall,1,MPI_INT,MPI_MAX,world);
-  if (maxall) {
-    if (me == 0) printf("Max split cells in any cell = %d\n",maxall);
-    error->all(FLERR,"Too many split cells in a single cell - "
-               "set global splitmax");
-  }
-
-  // stats on pushed cells and unmarked corner points in OVERLAP cells
-
-  if (outflag) {
-    int npushmax;
-    int *npushcell;
-    if (dim == 3) {
-      npushmax = cut3d->npushmax;
-      npushcell = cut3d->npushcell;
-    } else {
-      npushmax = cut2d->npushmax;
-      npushcell = cut2d->npushcell;
-    }
-    int *npushall = new int[npushmax+1];
-    MPI_Allreduce(npushcell,npushall,npushmax+1,MPI_INT,MPI_SUM,world);
-    if (comm->me == 0) {
-      if (screen) {
-        fprintf(screen,"  ");
-        for (int i = 1; i <= npushmax; i++)
-          fprintf(screen,"%d ",npushall[i]);
-        fprintf(screen,"= number of pushed cells\n");
-      }
-      if (logfile) {
-        fprintf(logfile,"  ");
-        for (int i = 1; i <= npushmax; i++)
-          fprintf(logfile,"%d ",npushall[i]);
-        fprintf(logfile,"= number of pushed cells\n");
-      }
-    }
-    delete [] npushall;
-
-    int noverlap = 0;
-    int ncorner = 0;
-    for (int icell = 0; icell < nlocal; icell++) {
-      if (cells[icell].nsplit <= 0) continue;
-      if (cinfo[icell].type == OVERLAP) {
-        noverlap++;
-        if (cinfo[icell].corner[0] == UNKNOWN) ncorner++;
-      }
-    }
-
-    bigint bncorner = ncorner;
-    bigint bnoverlap = noverlap;
-    bigint ncornerall,noverlapall;
-    MPI_Allreduce(&bncorner,&ncornerall,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
-    MPI_Allreduce(&bnoverlap,&noverlapall,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
-
-    if (comm->me == 0) {
-      if (screen) fprintf(screen,"  " BIGINT_FORMAT " " BIGINT_FORMAT
-                          " = cells overlapping surfs, "
-                          "overlap cells with unmarked corner pts\n",
-                          noverlapall,ncornerall);
-      if (logfile) fprintf(logfile,"  " BIGINT_FORMAT " " BIGINT_FORMAT
-                           " = cells overlapping surfs, "
-                           "overlap cells with unmarked corner pts\n",
-                           noverlapall,ncornerall);
-    }
-  }
-
-  // clean up
-
-  if (dim == 3) delete cut3d;
-  else delete cut2d;
-
-  if (outflag) {
-    MPI_Barrier(world);
-    t2 = MPI_Wtime();
-    tsplit = t2-t1;
-  }
-}
-
-/* ----------------------------------------------------------------------
-   map surf elements into a single grid cell = icell
-   flag = 0 for grid refinement, 1 for grid coarsening
-   in cells: set nsurf, csurfs, nsplit, isplit
-   in cinfo: set type, corner, volume
-   initialize sinfo as needed
-   called from AdaptGrid
-------------------------------------------------------------------------- */
-
-void Grid::surf2grid_one(int flag, int icell, int iparent, int nsurf_caller,
-                         Cut3d *cut3d, Cut2d *cut2d)
-{
-  int nsurf,isub,xsub,nsplitone;
-  int *iptr;
-  surfint *sptr;
-  double xsplit[3];
-  double *vols;
-
-  int dim = domain->dimension;
-
-  // identify surfs in new cell only for grid refinement
-
-  if (flag == 0) {
-    sptr = csurfs->vget();
-    if (dim == 3)
-      nsurf = cut3d->surf2grid_list(cells[icell].id,
-                                    cells[icell].lo,cells[icell].hi,
-                                    cells[iparent].nsurf,cells[iparent].csurfs,
-                                    sptr,maxsurfpercell);
-    else
-      nsurf = cut2d->surf2grid_list(cells[icell].id,
-                                    cells[icell].lo,cells[icell].hi,
-                                    cells[iparent].nsurf,cells[iparent].csurfs,
-                                    sptr,maxsurfpercell);
-
-    if (nsurf == 0) return;
-    if (nsurf > maxsurfpercell) {
-      printf("Surfs in one refined cell = %d\n",nsurf);
-      error->one(FLERR,"Too many surfs in one refined cell - set global surfmax");
-    }
-
-    cinfo[icell].type = OVERLAP;
-    cells[icell].nsurf = nsurf;
-    cells[icell].csurfs = sptr;
-    csurfs->vgot(nsurf);
-
-  } else nsurf = nsurf_caller;
-
-  // split check done for both refinement and coarsening
-
-  int *surfmap = csplits->vget();
-  ChildCell *c = &cells[icell];
-
-  if (dim == 3)
-    nsplitone = cut3d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
-                             vols,surfmap,cinfo[icell].corner,
-                             xsub,xsplit);
-  else
-    nsplitone = cut2d->split(c->id,c->lo,c->hi,c->nsurf,c->csurfs,
-                             vols,surfmap,cinfo[icell].corner,
-                             xsub,xsplit);
-
-  if (nsplitone == 1) {
-    if (cinfo[icell].corner[0] != UNKNOWN)
-      cinfo[icell].volume = vols[0];
-
-  } else {
-    c->nsplit = nsplitone;
-    nunsplitlocal--;
-
-    c->isplit = grid->nsplitlocal;
-    add_split_cell(1);
-    SplitInfo *s = &sinfo[nsplitlocal-1];
-    s->icell = icell;
-    s->csplits = surfmap;
-    s->xsub = xsub;
-    s->xsplit[0] = xsplit[0];
-    s->xsplit[1] = xsplit[1];
-    if (dim == 3) s->xsplit[2] = xsplit[2];
-    else s->xsplit[2] = 0.0;
-
-    iptr = s->csubs = csubs->vget();
-
-    // add nsplitone sub cells
-    // collide and fixes also need to add cells
-
-    for (int i = 0; i < nsplitone; i++) {
-      isub = nlocal;
-      add_sub_cell(icell,1);
-      if (collide) collide->add_grid_one();
-      if (modify->n_pergrid) modify->add_grid_one();
-      cells[isub].nsplit = -i;
-      cinfo[isub].volume = vols[i];
-      iptr[i] = isub;
-    }
-
-    csplits->vgot(nsurf);
-    csubs->vgot(nsplitone);
-  }
 }
 
 /* ----------------------------------------------------------------------

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -841,6 +841,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
   allsurflo = surf->bblo;
   allsurfhi = surf->bbhi;
 
+  if (me == 0) printf("ALLSURF BBOX lo %g %g %g hi %g %g %g\n",
+		      allsurflo[0],allsurflo[2],allsurflo[2],
+		      allsurfhi[0],allsurfhi[2],allsurfhi[2]);
+
   if (dim == 3) cut3d = new Cut3d(sparta);
   else cut2d = new Cut2d(sparta,domain->axisymmetric);
 

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -795,7 +795,7 @@ void Grid::surf2grid_new_algorithm(int outflag)
 void Grid::surf2grid_new2_algorithm(int outflag)
 {
   int i,j,n,ix,iy,iz,icell,isurf;
-  cellint childID;
+  cellint childID,parentID;
   double t1,t2,t3,t4,t5;
   double ctr[3];
   Irregular *irregular;
@@ -810,6 +810,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
                                     //   at level which encompasses a single surf
   int glo[3],ghi[3];                // corner indices of a grid box
   double bblo[3],bbhi[3];           // corners of a bounding box
+  double rcblo[3],rcbhi[3];         // corners of my RCB box
   GridTree *gtree;                  // tree of RCB cuts for partitioning uniform grid
   
   // data structs for communication
@@ -913,7 +914,8 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     // compute a recursive (RCB) decomp of the uniform grid box
     // gtree = tree of RCB cuts, cuts are along grid planes
     // myunilo/hi = inclusive range of my portion of grid box
-
+    // rcblo/hi = corner points of my RCB box
+    
     partition_grid(0,nprocs-1,unilo[0],unihi[0],unilo[1],unihi[1],
 		   unilo[2],unihi[2],gtree);
     myunilo[0] = unilo[0]; myunihi[0] = unihi[0];
@@ -922,6 +924,11 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     mybox(me,0,nprocs-1,myunilo[0],myunihi[1],myunilo[1],
 	  myunihi[1],myunilo[2],myunihi[2],gtree);
 
+    childID = id_uniform_level(level,myunilo[0],myunilo[2],myunilo[2]);
+    id_lohi(childID,level,boxlo,boxhi,rcblo,bbhi);
+    childID = id_uniform_level(level,myunihi[0],myunihi[2],myunihi[2]);
+    id_lohi(childID,level,boxlo,boxhi,bblo,rcbhi);
+    
     // first portion of irregular comm
     // loop over my surfs:
     //   compute surf bbox as a brick of uniform grid cells at this level

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1055,7 +1055,10 @@ void Grid::surf2grid_new2_algorithm(int outflag)
 
       for (int ilevel = level; ilevel > 0; ilevel--) {
 	parentID = parent_of_child(childID,ilevel);
-	if (phash->find(parentID) == phash->end()) break;
+	printf("CHPAR childID %ld parentID %ld\n",childID,parentID);
+	if (phash->find(parentID) == phash->end()) {
+	  break;
+	}
 	(*phash)[parentID] = 0;
 	childID = parentID;
       }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1511,7 +1511,7 @@ void Grid::recurse2d(double *bblo, double *bbhi, cellint parentID, int level,
 	newhi[0] = MIN(bbhi[0],chi[0]);
 	newhi[1] = MIN(bbhi[1],chi[1]);
 	recurse2d(newlo,newhi,childID,level+1,surfindex,line,clo,chi,
-		  npair,maxpair,pairs,chash,phash)
+		  npair,maxpair,pairs,chash,phash);
       }
     }
   }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -996,7 +996,7 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     delete irregular;
 
     MPI_Barrier(world);
-    if (me == 0) printf("IRR1 %d %d\n",nsend,nrecv);
+    if (me == 0) printf("IRR1 %d %d\n",nsend,nrecv1);
 
     if (outflag) {
       MPI_Barrier(world);
@@ -1052,6 +1052,9 @@ void Grid::surf2grid_new2_algorithm(int outflag)
     Send2 *rbuf2 = (Send2 *) memory->smalloc(nrecv2*sizeof(Send2),"surf2grid:rbuf2");
     irregular->exchange_uniform((char *) sbuf2,sizeof(Send2),(char *) rbuf2);
     delete irregular;
+
+    MPI_Barrier(world);
+    if (me == 0) printf("IRR2 %d %d\n",nsend,nrecv2);
 
     if (outflag) {
       MPI_Barrier(world);

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -687,21 +687,21 @@ void Surf::bbox_all()
   int dim = domain->dimension;
 
   int istart,istop,idelta;
-  Line *looplines;
-  Tri *looptris;
+  Line *linelist;
+  Tri *trilist;
   
   if (!distributed) {
     istart = me;
     istop = nlocal;
     idelta = nprocs;
-    looplines = lines;
-    looptris = tris;
+    linelist = lines;
+    trilist = tris;
   } else {
     istart = 0;
     istop = nown;
     idelta = 1;
-    looplines = mylines;
-    looptris = mytris;
+    linelist = mylines;
+    trilist = mytris;
   }
 
   for (j = 0; j < 3; j++) {
@@ -711,12 +711,12 @@ void Surf::bbox_all()
 
   if (dim == 2) {
     for (i = istart; i < istop; i += idelta) {
-      x = looplines[i].p1;
+      x = linelist[i].p1;
       for (j = 0; j < 2; j++) {
 	bblo_one[j] = MIN(bblo_one[j],x[j]);
 	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
-      x = looplines[i].p2;
+      x = linelist[i].p2;
       for (j = 0; j < 2; j++) {
 	bblo_one[j] = MIN(bblo_one[j],x[j]);
 	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
@@ -727,17 +727,17 @@ void Surf::bbox_all()
     
   } else if (dim == 3) {
     for (i = istart; i < istop; i += idelta) {
-      x = looptris[i].p1;
+      x = trilist[i].p1;
       for (j = 0; j < 3; j++) {
 	bblo_one[j] = MIN(bblo_one[j],x[j]);
 	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
-      x = looptris[i].p2;
+      x = trilist[i].p2;
       for (j = 0; j < 3; j++) {
 	bblo_one[j] = MIN(bblo_one[j],x[j]);
 	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
-      x = looptris[i].p3;
+      x = trilist[i].p3;
       for (j = 0; j < 3; j++) {
 	bblo_one[j] = MIN(bblo_one[j],x[j]);
 	bbhi_one[j] = MAX(bbhi_one[j],x[j]);

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -682,47 +682,65 @@ void Surf::bbox_all()
 {
   int i,j;
   double bblo_one[3],bbhi_one[3];
+  double *x;
+
+  int dim = domain->dimension;
+
+  int istart,istop,idelta;
+  Line *looplines;
+  Tri *looptris;
+  
+  if (!distributed) {
+    istart = me;
+    istop = nlocal;
+    idelta = nprocs;
+    looplines = lines;
+    looptris = tris;
+  } else {
+    istart = 0;
+    istop = nown;
+    idelta = 1;
+    looplines = mylines;
+    looptris = mytris;
+  }
 
   for (j = 0; j < 3; j++) {
     bblo_one[j] = BIG;
     bbhi_one[j] = -BIG;
   }
 
-  int dim = domain->dimension;
-  double *x;
-
   if (dim == 2) {
-    for (i = 0; i < nlocal; i++) {
-      x = lines[i].p1;
+    for (i = istart; i < istop; i += idelta) {
+      x = looplines[i].p1;
       for (j = 0; j < 2; j++) {
-        bblo_one[j] = MIN(bblo_one[j],x[j]);
-        bbhi_one[j] = MAX(bbhi_one[j],x[j]);
+	bblo_one[j] = MIN(bblo_one[j],x[j]);
+	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
-      x = lines[i].p2;
+      x = looplines[i].p2;
       for (j = 0; j < 2; j++) {
-        bblo_one[j] = MIN(bblo_one[j],x[j]);
-        bbhi_one[j] = MAX(bbhi_one[j],x[j]);
+	bblo_one[j] = MIN(bblo_one[j],x[j]);
+	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
     }
     bblo_one[2] = domain->boxlo[2];
     bbhi_one[2] = domain->boxhi[2];
-
+    
   } else if (dim == 3) {
-    for (i = 0; i < nlocal; i++) {
-      x = tris[i].p1;
+    for (i = istart; i < istop; i += idelta) {
+      x = looptris[i].p1;
       for (j = 0; j < 3; j++) {
-        bblo_one[j] = MIN(bblo_one[j],x[j]);
-        bbhi_one[j] = MAX(bbhi_one[j],x[j]);
+	bblo_one[j] = MIN(bblo_one[j],x[j]);
+	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
-      x = tris[i].p2;
+      x = looptris[i].p2;
       for (j = 0; j < 3; j++) {
-        bblo_one[j] = MIN(bblo_one[j],x[j]);
-        bbhi_one[j] = MAX(bbhi_one[j],x[j]);
+	bblo_one[j] = MIN(bblo_one[j],x[j]);
+	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
-      x = tris[i].p3;
+      x = looptris[i].p3;
       for (j = 0; j < 3; j++) {
-        bblo_one[j] = MIN(bblo_one[j],x[j]);
-        bbhi_one[j] = MAX(bbhi_one[j],x[j]);
+	bblo_one[j] = MIN(bblo_one[j],x[j]);
+	bbhi_one[j] = MAX(bbhi_one[j],x[j]);
       }
     }
   }


### PR DESCRIPTION
## Purpose

Another try at a more scalable surf2grid algorithm for the persurf case (as opposed to percell), see global surfgrid option.  This one should have performance and scalability close to the old persurf algorithm which used the parent cells data struct (since discarded).

## Author(s)

Steve

## Backward Compatibility

Should make no difference in results, just in CPU cost of doing the surf2grid mapping.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


