### PR TITLE
Small typos fix in Sparta Python documentation

### DIFF
--- a/doc/Section_python.html
+++ b/doc/Section_python.html
@@ -103,7 +103,7 @@ will load by default.  Note that if you are building multiple machine
 versions of the shared library, the soft link is always set to the
 most recently built version.
 </P>
-<P>If this fails, see <A HREF = "Section_start.html#start_6">Section 2.3</A> for more
+<P>If this fails, see <A HREF = "Section_start.html#start_3">Section 2.3</A> for more
 details, especially if your SPARTA build uses auxiliary libraries like
 MPI which may not be built as shared libraries on your system.
 </P>

--- a/doc/Section_python.html
+++ b/doc/Section_python.html
@@ -22,7 +22,7 @@ interface.
 <LI>11.6 <A HREF = "#py_6">Example Python scripts that use SPARTA</A> 
 </UL>
 <P>The SPARTA distribution includes the file python/sparta.py which wraps
-the library interface to SPARTA.  This file makes it is possible to
+the library interface to SPARTA.  This file makes it possible to
 run SPARTA, invoke SPARTA commands or give it an input script, extract
 SPARTA results, and modify internal SPARTA variables, either from a
 Python script or interactively from a Python prompt.  You can do the

--- a/doc/Section_python.html
+++ b/doc/Section_python.html
@@ -88,7 +88,7 @@ this is a library file that ends in ".so", not ".a".
 </P>
 <P>For make, from the src directory, type
 </P>
-<PRE>make makeshlib
+<PRE>make mode=shlib foo
 make -f Makefile.shlib foo 
 </PRE>
 <P>For CMake, from the build directory, tyoe

--- a/doc/Section_python.txt
+++ b/doc/Section_python.txt
@@ -99,7 +99,7 @@ will load by default.  Note that if you are building multiple machine
 versions of the shared library, the soft link is always set to the
 most recently built version.
 
-If this fails, see "Section 2.3"_Section_start.html#start_6 for more
+If this fails, see "Section 2.3"_Section_start.html#start_3 for more
 details, especially if your SPARTA build uses auxiliary libraries like
 MPI which may not be built as shared libraries on your system.
 

--- a/doc/Section_python.txt
+++ b/doc/Section_python.txt
@@ -19,7 +19,7 @@ interface.
 11.6 "Example Python scripts that use SPARTA"_#py_6 :ul
 
 The SPARTA distribution includes the file python/sparta.py which wraps
-the library interface to SPARTA.  This file makes it is possible to
+the library interface to SPARTA.  This file makes it possible to
 run SPARTA, invoke SPARTA commands or give it an input script, extract
 SPARTA results, and modify internal SPARTA variables, either from a
 Python script or interactively from a Python prompt.  You can do the

--- a/doc/Section_python.txt
+++ b/doc/Section_python.txt
@@ -84,7 +84,7 @@ this is a library file that ends in ".so", not ".a".
 
 For make, from the src directory, type
 
-make makeshlib
+make mode=shlib foo
 make -f Makefile.shlib foo :pre
 
 For CMake, from the build directory, tyoe

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -251,8 +251,8 @@ MPI_PATH), and the name of the library file (via MPI_LIB).  See
 Makefile.serial for an example of how this can be done.
 </P>
 <P>If you are installing MPI yourself, we recommend MPICH 1.2 or 2.0 or
-OpenMPI.  MPICH can be downloaded from the <A HREF = "http://www-unix.mcs.anl.gov/mpi">Argonne MPI
-site</A>.  OpenMPI can be downloaded the
+OpenMPI.  MPICH can be downloaded from the <A HREF = "https://www.mpich.org">Argonne MPI
+site</A>.  OpenMPI can be downloaded from the
 <A HREF = "http://www.open-mpi.org">OpenMPI site</A>.  If you are running on a big
 parallel platform, your system admins or the vendor should have
 already installed a version of MPI, which will be faster than MPICH or

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -247,7 +247,7 @@ Makefile.serial for an example of how this can be done.
 
 If you are installing MPI yourself, we recommend MPICH 1.2 or 2.0 or
 OpenMPI.  MPICH can be downloaded from the "Argonne MPI
-site"_http://www-unix.mcs.anl.gov/mpi.  OpenMPI can be downloaded the
+site"_https://www.mpich.org.  OpenMPI can be downloaded from the
 "OpenMPI site"_http://www.open-mpi.org.  If you are running on a big
 parallel platform, your system admins or the vendor should have
 already installed a version of MPI, which will be faster than MPICH or


### PR DESCRIPTION
## Purpose

_While looking at the Sparta Python interface documentation, I found these small typos_

## Author(s)

_Chonglin Zhang, Rensselaer Polytechnic Institute_

## Backward Compatibility

_No, since only documentation typos fix_

## Implementation Notes

_Modified typos and broken links in the documentation._
