### PR TITLE
Test alternative options to surfpush for insuring cut/split cell calculations always work

### DIFF
--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -75,7 +75,7 @@ Surf::Surf(SPARTA *sparta) : Pointers(sparta)
   nlocal = nghost = nmax = 0;
   lines = NULL;
   tris = NULL;
-  pushflag = 1;
+  pushflag = 0;  // turn off by default for testing
 
   nown = maxown = 0;
   mylines = NULL;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1484,19 +1484,19 @@ void Update::global(int narg, char **arg)
     } else if (strcmp(arg[iarg],"surfpush") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal global command");
       if (strcmp(arg[iarg+1],"no") == 0) {
-        surf->pushflag = 0;
+        //surf->pushflag = 0;
         iarg += 2;
       } else if (strcmp(arg[iarg+1],"yes") == 0) {
-        surf->pushflag = 1;
+        //surf->pushflag = 1;
         iarg += 2;
       } else {
         if (iarg+4 > narg) error->all(FLERR,"Illegal global command");
-        surf->pushflag = 2;
-        surf->pushlo = input->numeric(FLERR,arg[iarg+1]);
-        surf->pushhi = input->numeric(FLERR,arg[iarg+2]);
-        surf->pushvalue = input->numeric(FLERR,arg[iarg+3]);
-        if (surf->pushlo > surf->pushhi)
-          error->all(FLERR,"Illegal global command");
+        //surf->pushflag = 2;
+        //surf->pushlo = input->numeric(FLERR,arg[iarg+1]);
+        //surf->pushhi = input->numeric(FLERR,arg[iarg+2]);
+        //surf->pushvalue = input->numeric(FLERR,arg[iarg+3]);
+        //if (surf->pushlo > surf->pushhi)
+        //  error->all(FLERR,"Illegal global command");
         iarg += 4;
       }
 


### PR DESCRIPTION
## Purpose

Experiemental branch to test alternanatives to the global surfpush settings for insuring cut/split cell calculations work robustly when round-off issues arise

## Author(s)

Steve

## Backward Compatibility

Just testing changes at this point

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


