### PR TITLE
Fix bug in grid_surf when collide isn't initialized

### DIFF
--- a/src/collide.h
+++ b/src/collide.h
@@ -59,6 +59,8 @@ class Collide : protected Pointers {
   virtual void add_grid_one();
   virtual void adapt_grid();
 
+  int ngroups;        // # of groups
+
  protected:
   int npmax;          // max # of particles in plist
   int *plist;         // list of particle indices for the entire cell
@@ -66,7 +68,6 @@ class Collide : protected Pointers {
   int nglocal;        // current size of per-cell arrays
   int nglocalmax;     // max allocated size of per-cell arrays (vremax, remain)
 
-  int ngroups;        // # of groups
   int *ngroup;        // # of particles in each group
   int *maxgroup;      // max # of particles allocated per group
   int **glist;        // indices into plist of particles in each group

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1611,7 +1611,7 @@ void Grid::clear_surf()
       if (icell != nlocal-1) {
         memcpy(&cells[icell],&cells[nlocal-1],sizeof(ChildCell));
         memcpy(&cinfo[icell],&cinfo[nlocal-1],sizeof(ChildInfo));
-        if (collide) collide->copy_grid_one(nlocal-1,icell);
+        if (collide && collide->ngroups) collide->copy_grid_one(nlocal-1,icell);
         if (modify->n_pergrid) modify->copy_grid_one(nlocal-1,icell);
       }
       nlocal--;


### PR DESCRIPTION
## Purpose

Fix bug in grid_surf when collide isn't initialized, leading to segfault.

## Author(s)

Stan Moore (SNL), reported by Rommil Emperado (University of the Philippines) on the mail list

## Backward Compatibility

Yes