### PR TITLE
Fix typo in create_grid docs

### DIFF
--- a/doc/create_grid.html
+++ b/doc/create_grid.html
@@ -44,11 +44,11 @@
 <PRE>create_grid 10 10 10
 create_grid 10 10 10 block * * *
 create_grid 10 10 10 block 4 2 5
-create_grid 10 10 10 levels 4 level 2*4 * * * 2 2 3
-create_grid 20 10 1 levels 2 level 2 10*15 3*7 1 2 2 1
+create_grid 10 10 10 levels 4 subset 2*4 * * * 2 2 3
+create_grid 20 10 1 levels 2 subset 2 10*15 3*7 1 2 2 1
 create_grid 20 10 1 levels 3 region 2 b2 2 2 1 region 3 b3 2 3 1 inside any
-create_grid 20 10 1 levels 2 level 2 10*15 3*7 1 2 2 1 region 3 b3 2 3 1
-create_grid 8 8 10 levels 3 level 2 5* * * 4 4 4 level 3 1 2*3 3* 2 2 1 
+create_grid 20 10 1 levels 2 subset 2 10*15 3*7 1 2 2 1 region 3 b3 2 3 1
+create_grid 8 8 10 levels 3 subset 2 5* * * 4 4 4 subset 3 1 2*3 3* 2 2 1 
 </PRE>
 <P><B>Description:</B>
 </P>
@@ -193,7 +193,7 @@ not have been partitioned into level 2 cells.
 </P>
 <P>For example this command creates a two-level grid:
 </P>
-<PRE>create_grid 10 10 10 levels 2 level 2 * * * 2 2 3 
+<PRE>create_grid 10 10 10 levels 2 subset 2 * * * 2 2 3 
 </PRE>
 <P>The 1st level is 10x10x10.  Each of the 1000 level 1 cells is further
 partitioned into 2x2x3 cells.  This means the total number of
@@ -201,7 +201,7 @@ resulting grid cells is 1000 * 12 = 12000.
 </P>
 <P>This command creates a 3-level grid:
 </P>
-<PRE>create_grid 8 8 10 levels 3 level 2 5* * * 4 4 4 level 3 1 2*3 3* 2 2 1 
+<PRE>create_grid 8 8 10 levels 3 subset 2 5* * * 4 4 4 subset 3 1 2*3 3* 2 2 1 
 </PRE>
 <P>The first level is 8x8x10.  The second level is 4x4x4 within each
 level 1 cell, but only half or 320 of the 640 level 1 cells are

--- a/doc/create_grid.txt
+++ b/doc/create_grid.txt
@@ -37,11 +37,11 @@ keyword = {block} or {clump} or {random} or {stride} or {levels} or {subset} or 
 create_grid 10 10 10
 create_grid 10 10 10 block * * *
 create_grid 10 10 10 block 4 2 5
-create_grid 10 10 10 levels 4 level 2*4 * * * 2 2 3
-create_grid 20 10 1 levels 2 level 2 10*15 3*7 1 2 2 1
+create_grid 10 10 10 levels 4 subset 2*4 * * * 2 2 3
+create_grid 20 10 1 levels 2 subset 2 10*15 3*7 1 2 2 1
 create_grid 20 10 1 levels 3 region 2 b2 2 2 1 region 3 b3 2 3 1 inside any
-create_grid 20 10 1 levels 2 level 2 10*15 3*7 1 2 2 1 region 3 b3 2 3 1
-create_grid 8 8 10 levels 3 level 2 5* * * 4 4 4 level 3 1 2*3 3* 2 2 1 :pre
+create_grid 20 10 1 levels 2 subset 2 10*15 3*7 1 2 2 1 region 3 b3 2 3 1
+create_grid 8 8 10 levels 3 subset 2 5* * * 4 4 4 subset 3 1 2*3 3* 2 2 1 :pre
 
 [Description:]
 
@@ -186,7 +186,7 @@ not have been partitioned into level 2 cells.
 
 For example this command creates a two-level grid:
 
-create_grid 10 10 10 levels 2 level 2 * * * 2 2 3 :pre
+create_grid 10 10 10 levels 2 subset 2 * * * 2 2 3 :pre
 
 The 1st level is 10x10x10.  Each of the 1000 level 1 cells is further
 partitioned into 2x2x3 cells.  This means the total number of
@@ -194,7 +194,7 @@ resulting grid cells is 1000 * 12 = 12000.
 
 This command creates a 3-level grid:
 
-create_grid 8 8 10 levels 3 level 2 5* * * 4 4 4 level 3 1 2*3 3* 2 2 1 :pre
+create_grid 8 8 10 levels 3 subset 2 5* * * 4 4 4 subset 3 1 2*3 3* 2 2 1 :pre
 
 The first level is 8x8x10.  The second level is 4x4x4 within each
 level 1 cell, but only half or 320 of the 640 level 1 cells are


### PR DESCRIPTION
## Purpose

Fix typo in create_grid docs, where `subset` should be used instead of `level` in the example lines in the `create_grid` doc page.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes