### PR TITLE
Fix bugs in surf_collide methods

### DIFF
--- a/src/KOKKOS/create_particles_kokkos.cpp
+++ b/src/KOKKOS/create_particles_kokkos.cpp
@@ -110,10 +110,10 @@ void CreateParticlesKokkos::create_local(bigint np)
 
   memory->destroy(vols);
 
-  // nfix_add_particle = # of fixes with add_particle() method
+  // nfix_update_custom = # of fixes with update_custom() method
 
   modify->list_init_fixes();
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   // loop over cells I own
   // only add particles to OUTSIDE cells
@@ -323,8 +323,8 @@ void CreateParticlesKokkos::create_local(bigint np)
       auto cand = h_cells2cands(i) + m;
       if (!h_keep(cand)) continue;
       auto inew = h_cands2new(cand) + nlocal_before;
-      if (nfix_add_particle)
-        modify->add_particle(inew,temp_thermal,temp_rot,temp_vib,vstream);
+      if (nfix_update_custom)
+        modify->update_custom(inew,temp_thermal,temp_rot,temp_vib,vstream);
     }
   }
 

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -311,7 +311,7 @@ void FixEmitFaceKokkos::perform_task()
   particleKK->nlocal = nlocal_before + nnew;
   particleKK->modify(SPARTA_NS::Device, PARTICLE_MASK);
 
-  if (modify->n_add_particle) {
+  if (modify->n_update_custom) {
     auto h_keep = Kokkos::create_mirror_view(d_keep);
     auto h_task = Kokkos::create_mirror_view(d_task);
     Kokkos::deep_copy(h_keep, d_keep);
@@ -336,7 +336,7 @@ void FixEmitFaceKokkos::perform_task()
       auto inew = h_cands2new(cand);
       auto ilocal = nlocal_before + inew;
 
-      modify->add_particle(ilocal,temp_thermal,
+      modify->update_custom(ilocal,temp_thermal,
           temp_rot,temp_vib,vstream);
     }
   }

--- a/src/KOKKOS/fix_vibmode_kokkos.cpp
+++ b/src/KOKKOS/fix_vibmode_kokkos.cpp
@@ -56,16 +56,17 @@ FixVibmodeKokkos::~FixVibmodeKokkos()
 
 /* ----------------------------------------------------------------------
    called when a particle with index is created
+    or when temperature dependent properties need to be updated
    populate all vibrational modes and set evib = sum of mode energies
 ------------------------------------------------------------------------- */
 
-void FixVibmodeKokkos::add_particle(int index, double temp_thermal,
-                                    double temp_rot, double temp_vib,
-                                    double *vstream)
+void FixVibmodeKokkos::update_custom(int index, double temp_thermal,
+                                     double temp_rot, double temp_vib,
+                                     double *vstream)
 {
   ParticleKokkos* particle_kk = (ParticleKokkos*) particle;
   particle_kk->sync(Host,PARTICLE_MASK|SPECIES_MASK|CUSTOM_MASK);
-  FixVibmode::add_particle(index, temp_thermal, temp_rot, temp_vib, vstream);
+  FixVibmode::update_custom(index, temp_thermal, temp_rot, temp_vib, vstream);
   particle_kk->modify(Host,PARTICLE_MASK|CUSTOM_MASK);
 }
 

--- a/src/KOKKOS/fix_vibmode_kokkos.h
+++ b/src/KOKKOS/fix_vibmode_kokkos.h
@@ -34,10 +34,10 @@ class FixVibmodeKokkos : public FixVibmode {
   FixVibmodeKokkos(class SPARTA *, int, char **);
   ~FixVibmodeKokkos();
   //void init();
-  void add_particle(int, double, double, double, double *);
+  void update_custom(int, double, double, double, double *);
 
   KOKKOS_INLINE_FUNCTION
-  void add_particle_kokkos(int, double, double, double, double *);
+  void update_custom_kokkos(int, double, double, double, double *);
 
  private:
   int boltz;
@@ -63,13 +63,14 @@ class FixVibmodeKokkos : public FixVibmode {
 
 /* ----------------------------------------------------------------------
    called when a particle with index is created
+    or when temperature dependent properties need to be updated
    populate all vibrational modes and set evib = sum of mode energies
 ------------------------------------------------------------------------- */
 
 KOKKOS_INLINE_FUNCTION
-void FixVibmodeKokkos::add_particle_kokkos(int index, double temp_thermal,
-                                           double temp_rot, double temp_vib,
-                                           double *)
+void FixVibmodeKokkos::update_custom_kokkos(int index, double temp_thermal,
+                                            double temp_rot, double temp_vib,
+                                            double *)
 {
   auto &d_vibmode = k_eiarray.d_view[d_ewhich[vibmodeindex]].k_view.d_view;
 

--- a/src/KOKKOS/modify_kokkos.cpp
+++ b/src/KOKKOS/modify_kokkos.cpp
@@ -216,19 +216,19 @@ void ModifyKokkos::grid_changed()
 }
 
 /* ----------------------------------------------------------------------
-   invoke add_particle() method, only for relevant fixes
+   invoke update_custom() method, only for relevant fixes
 ------------------------------------------------------------------------- */
 
-void ModifyKokkos::add_particle(int index, double temp_thermal,
-                          double temp_rot, double temp_vib, double *vstream)
+void ModifyKokkos::update_custom(int index, double temp_thermal,
+                                 double temp_rot, double temp_vib, double *vstream)
 {
-  for (int i = 0; i < n_add_particle; i++) {
-    int j = list_add_particle[i];
+  for (int i = 0; i < n_update_custom; i++) {
+    int j = list_update_custom[i];
     particle_kk->sync(fix[j]->execution_space,fix[j]->datamask_read);
     int prev_auto_sync = sparta->kokkos->auto_sync;
     if (!fix[j]->kokkos_flag) sparta->kokkos->auto_sync = 1;
 
-    fix[list_add_particle[i]]->add_particle(index,temp_thermal,temp_rot,
+    fix[list_update_custom[i]]->update_custom(index,temp_thermal,temp_rot,
                                             temp_vib,vstream);
 
     sparta->kokkos->auto_sync = prev_auto_sync;

--- a/src/KOKKOS/modify_kokkos.h
+++ b/src/KOKKOS/modify_kokkos.h
@@ -33,7 +33,7 @@ class ModifyKokkos : public Modify {
   void reset_grid_count(int);
   void grid_changed();
 
-  void add_particle(int, double, double, double, double *);
+  void update_custom(int, double, double, double, double *);
   void gas_react(int);
   void surf_react(Particle::OnePart *, int &, int &);
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -168,6 +168,10 @@ SurfCollideDiffuseKokkos::~SurfCollideDiffuseKokkos()
 
 void SurfCollideDiffuseKokkos::pre_collide()
 {
+  if (modify->n_add_particle)
+    error->all(FLERR,"Cannot yet use surf_collide diffuse/kk"
+               "with fix vibmode or fix ambipolar");
+
   if (random == NULL) {
     // initialize RNG
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -168,7 +168,7 @@ SurfCollideDiffuseKokkos::~SurfCollideDiffuseKokkos()
 
 void SurfCollideDiffuseKokkos::pre_collide()
 {
-  if (modify->n_add_particle)
+  if (modify->n_update_custom)
     error->all(FLERR,"Cannot yet use surf_collide diffuse/kk"
                "with fix vibmode or fix ambipolar");
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -98,9 +98,26 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
     //}
 
     // diffuse reflection for each particle
+    // resets v, roteng, vibeng
+    // particle I needs to trigger any fixes to update per-particle
+    //  properties which depend on the temperature of the particle
+    //  (e.g. fix vibmode and fix ambipolar)
+    // if new particle J created, also need to trigger any fixes
 
-    if (ip) diffuse(ip,norm);
-    //if (jp) diffuse(jp,norm);
+    if (ip) {
+      diffuse(ip,norm);
+      //if (modify->n_add_particle) {
+      //  int i = ip - particle->particles;
+      //  modify->add_particle(i,twall,twall,twall,vstream);
+      //}
+    }
+    //if (jp) {
+    //  diffuse(jp,norm);
+    //  if (modify->n_add_particle) {
+    //    int j = jp - particle->particles;
+    //    modify->add_particle(j,twall,twall,twall,vstream);
+    //  }
+    //}
 
     // call any fixes with a surf_react() method
     // they may reset j to -1, e.g. fix ambipolar

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -106,16 +106,16 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
 
     if (ip) {
       diffuse(ip,norm);
-      //if (modify->n_add_particle) {
+      //if (modify->n_update_custom) {
       //  int i = ip - particle->particles;
-      //  modify->add_particle(i,twall,twall,twall,vstream);
+      //  modify->update_custom(i,twall,twall,twall,vstream);
       //}
     }
     //if (jp) {
     //  diffuse(jp,norm);
-    //  if (modify->n_add_particle) {
+    //  if (modify->n_update_custom) {
     //    int j = jp - particle->particles;
-    //    modify->add_particle(j,twall,twall,twall,vstream);
+    //    modify->update_custom(j,twall,twall,twall,vstream);
     //  }
     //}
 
@@ -300,7 +300,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
     if (vibstyle == NONE || d_species[isp].vibdof < 2) return 0.0;
 
     // for DISCRETE, only need set evib for vibdof = 2
-    // mode levels and evib will be set by FixVibmode::add_particle()
+    // mode levels and evib will be set by FixVibmode::update_custom()
 
     eng = 0.0;
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -227,6 +227,8 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
         v[2] = vperp*norm[2] + vtan1*tangent1[2] + vtan2*tangent2[2];
       }
 
+      // initialize rot/vib energy
+
       p->erot = erot(ispecies,twall,rand_gen,boltz);
       p->evib = evib(ispecies,twall,rand_gen,boltz);
     }

--- a/src/MAKE/Makefile.kokkos_omp
+++ b/src/MAKE/Makefile.kokkos_omp
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3 -DSPARTA_KOKKOS_EXACT
+CCFLAGS =	-g -O3
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O3 -DSPARTA_KOKKOS_EXACT
+LINKFLAGS =	-g -O3
 LIB = 
 SIZE =		size
 
@@ -100,4 +100,4 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 # Individual dependencies
 
 DEPENDS = $(OBJ:.o=.d)
-include $(DEPENDS)
+sinclude $(DEPENDS)

--- a/src/MAKE/Makefile.kokkos_omp
+++ b/src/MAKE/Makefile.kokkos_omp
@@ -7,12 +7,12 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		mpicxx
-CCFLAGS =	-g -O3
+CCFLAGS =	-g -O3 -DSPARTA_KOKKOS_EXACT
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
 LINK =		mpicxx
-LINKFLAGS =	-g -O3
+LINKFLAGS =	-g -O3 -DSPARTA_KOKKOS_EXACT
 LIB = 
 SIZE =		size
 
@@ -100,4 +100,4 @@ shlib:	$(OBJ) $(EXTRA_LINK_DEPENDS)
 # Individual dependencies
 
 DEPENDS = $(OBJ:.o=.d)
-sinclude $(DEPENDS)
+include $(DEPENDS)

--- a/src/create_particles.cpp
+++ b/src/create_particles.cpp
@@ -416,11 +416,11 @@ void CreateParticles::create_single()
   if (flagall != 1)
     error->all(FLERR,"Could not create a single particle");
 
-  // nfix_add_particle = # of fixes with add_particle() method
+  // nfix_update_custom = # of fixes with update_custom() method
 
   particle->error_custom();
   modify->list_init_fixes();
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   // add the particle
 
@@ -431,8 +431,8 @@ void CreateParticles::create_single()
     double erot = particle->erot(mspecies,temp_rot,random);
     double evib = particle->evib(mspecies,temp_vib,random);
     particle->add_particle(id,mspecies,iwhich,x,v,erot,evib);
-    if (nfix_add_particle)
-      modify->add_particle(particle->nlocal-1,temp_thermal,
+    if (nfix_update_custom)
+      modify->update_custom(particle->nlocal-1,temp_thermal,
                            temp_rot,temp_vib,vstream);
   }
 
@@ -509,11 +509,11 @@ void CreateParticles::create_local(bigint np)
 
   memory->destroy(vols);
 
-  // nfix_add_particle = # of fixes with add_particle() method
+  // nfix_update_custom = # of fixes with update_custom() method
 
   particle->error_custom();
   modify->list_init_fixes();
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   // loop over cells I own
   // only add particles to OUTSIDE cells
@@ -616,8 +616,8 @@ void CreateParticles::create_local(bigint np)
 
       particle->add_particle(id,ispecies,i,x,v,erot,evib);
 
-      if (nfix_add_particle)
-        modify->add_particle(particle->nlocal-1,temp_thermal,
+      if (nfix_update_custom)
+        modify->update_custom(particle->nlocal-1,temp_thermal,
                              temp_rot,temp_vib,vstream);
     }
 
@@ -700,10 +700,10 @@ void CreateParticles::create_local_twopass(bigint np)
 
   memory->destroy(vols);
 
-  // nfix_add_particle = # of fixes with add_particle() method
+  // nfix_update_custom = # of fixes with update_custom() method
 
   modify->list_init_fixes();
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   // loop over cells I own
   // only add particles to OUTSIDE cells
@@ -822,8 +822,8 @@ void CreateParticles::create_local_twopass(bigint np)
       id = MAXSMALLINT*random->uniform();
 
       particle->add_particle(id,ispecies,i,x,v,erot,evib);
-      if (nfix_add_particle)
-        modify->add_particle(particle->nlocal-1,temp_thermal,
+      if (nfix_update_custom)
+        modify->update_custom(particle->nlocal-1,temp_thermal,
                              temp_rot,temp_vib,vstream);
     }
   }

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -46,7 +46,7 @@ Fix::Fix(SPARTA *sparta, int, char **arg) : Pointers(sparta)
 
   time_depend = 0;
   gridmigrate = 0;
-  flag_add_particle = flag_gas_react = flag_surf_react = 0;
+  flag_update_custom = flag_gas_react = flag_surf_react = 0;
 
   scalar_flag = vector_flag = array_flag = 0;
   per_particle_flag = per_grid_flag = per_surf_flag = 0;

--- a/src/fix.h
+++ b/src/fix.h
@@ -27,7 +27,7 @@ class Fix : protected Pointers {
   int nevery;                    // how often to call an end_of_step fix
   int time_depend;               // 1 if requires continuous timestepping
   int gridmigrate;               // 0/1 if per grid cell info must migrate
-  int flag_add_particle;         // 0/1 if has add_particle() method
+  int flag_update_custom;         // 0/1 if has update_custom() method
   int flag_gas_react;            // 0/1 if has gas_react() method
   int flag_surf_react;           // 0/1 if has surf_react() method
 
@@ -76,7 +76,7 @@ class Fix : protected Pointers {
 
   virtual void start_of_step() {}
   virtual void end_of_step() {}
-  virtual void add_particle(int, double, double, double, double *) {}
+  virtual void update_custom(int, double, double, double, double *) {}
   virtual void gas_react(int) {}
   virtual void surf_react(Particle::OnePart *, int &, int &) {}
 

--- a/src/fix_ambipolar.cpp
+++ b/src/fix_ambipolar.cpp
@@ -37,7 +37,7 @@ FixAmbipolar::FixAmbipolar(SPARTA *sparta, int narg, char **arg) :
 {
   if (narg < 4) error->all(FLERR,"Illegal fix ambipolar command");
 
-  flag_add_particle = 1;
+  flag_update_custom = 1;
   flag_surf_react = 1;
 
   especies = particle->find_species(arg[2]);
@@ -101,11 +101,12 @@ void FixAmbipolar::init()
 
 /* ----------------------------------------------------------------------
    called when a particle with index is created
+    or when temperature dependent properties need to be updated
    creation used temp_thermal and vstream to set particle velocity
    if an ion, set ionambi and velambi for particle
 ------------------------------------------------------------------------- */
 
-void FixAmbipolar::add_particle(int index, double temp_thermal,
+void FixAmbipolar::update_custom(int index, double temp_thermal,
                                 double, double,
                                 double *vstream)
 {
@@ -175,7 +176,7 @@ void FixAmbipolar::surf_react(Particle::OnePart *iorig, int &i, int &j)
     Particle::OnePart *particles = particle->particles;
     if (ions[particles[i].ispecies] == 0) return;
     if (particles[j].ispecies != especies) return;
-    add_particle(i,update->temp_thermal,update->temp_thermal,
+    update_custom(i,update->temp_thermal,update->temp_thermal,
                  update->temp_thermal,update->vstream);
     j = -1;
   }

--- a/src/fix_ambipolar.h
+++ b/src/fix_ambipolar.h
@@ -35,7 +35,7 @@ class FixAmbipolar : public Fix {
   ~FixAmbipolar();
   int setmask();
   void init();
-  void add_particle(int, double, double, double, double *);
+  void update_custom(int, double, double, double, double *);
   void surf_react(Particle::OnePart *, int &, int &);
 
  private:

--- a/src/fix_emit_face.cpp
+++ b/src/fix_emit_face.cpp
@@ -493,7 +493,7 @@ void FixEmitFace::perform_task_onepass()
   //   shift Maxwellian distribution by stream velocity component
   //   see Bird 1994, p 259, eq 12.5
 
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   for (int i = 0; i < ntask; i++) {
     pcell = tasks[i].pcell;
@@ -556,8 +556,8 @@ void FixEmitFace::perform_task_onepass()
           p->flag = PINSERT;
           p->dtremain = dt * random->uniform();
 
-          if (nfix_add_particle)
-            modify->add_particle(particle->nlocal-1,temp_thermal,
+          if (nfix_update_custom)
+            modify->update_custom(particle->nlocal-1,temp_thermal,
                                  temp_rot,temp_vib,vstream);
 	}
 
@@ -615,8 +615,8 @@ void FixEmitFace::perform_task_onepass()
         p->flag = PINSERT;
         p->dtremain = dt * random->uniform();
 
-        if (nfix_add_particle)
-          modify->add_particle(particle->nlocal-1,temp_thermal,
+        if (nfix_update_custom)
+          modify->update_custom(particle->nlocal-1,temp_thermal,
                                temp_rot,temp_vib,vstream);
       }
 
@@ -664,7 +664,7 @@ void FixEmitFace::perform_task_twopass()
   //   shift Maxwellian distribution by stream velocity component
   //   see Bird 1994, p 259, eq 12.5
 
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   int ninsert_dim1 = perspecies ? nspecies : 1;
   int** ninsert_values;
@@ -749,8 +749,8 @@ void FixEmitFace::perform_task_twopass()
           p->flag = PINSERT;
           p->dtremain = dt * random->uniform();
 
-          if (nfix_add_particle)
-            modify->add_particle(particle->nlocal-1,temp_thermal,
+          if (nfix_update_custom)
+            modify->update_custom(particle->nlocal-1,temp_thermal,
                 temp_rot,temp_vib,vstream);
         }
 
@@ -802,8 +802,8 @@ void FixEmitFace::perform_task_twopass()
         p->flag = PINSERT;
         p->dtremain = dt * random->uniform();
 
-        if (nfix_add_particle)
-          modify->add_particle(particle->nlocal-1,temp_thermal,
+        if (nfix_update_custom)
+          modify->update_custom(particle->nlocal-1,temp_thermal,
               temp_rot,temp_vib,vstream);
       }
 

--- a/src/fix_emit_face_file.cpp
+++ b/src/fix_emit_face_file.cpp
@@ -377,7 +377,7 @@ void FixEmitFaceFile::perform_task()
   //   shift Maxwellian distribution by stream velocity component
   //   see Bird 1994, p 259, eq 12.5
 
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
 
   for (int i = 0; i < ntask; i++) {
     pcell = tasks[i].pcell;
@@ -434,8 +434,8 @@ void FixEmitFaceFile::perform_task()
           p->flag = PINSERT;
           p->dtremain = dt * random->uniform();
 
-          if (nfix_add_particle)
-            modify->add_particle(particle->nlocal-1,temp_thermal,
+          if (nfix_update_custom)
+            modify->update_custom(particle->nlocal-1,temp_thermal,
                                  temp_rot,temp_vib,vstream);
 	}
 
@@ -488,8 +488,8 @@ void FixEmitFaceFile::perform_task()
         p->flag = PINSERT;
         p->dtremain = dt * random->uniform();
 
-        if (nfix_add_particle)
-          modify->add_particle(particle->nlocal-1,temp_thermal,
+        if (nfix_update_custom)
+          modify->update_custom(particle->nlocal-1,temp_thermal,
                                temp_rot,temp_vib,vstream);
       }
 

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -460,7 +460,7 @@ void FixEmitSurf::perform_task()
   Surf::Line *lines = surf->lines;
   Surf::Tri *tris = surf->tris;
 
-  int nfix_add_particle = modify->n_add_particle;
+  int nfix_update_custom = modify->n_update_custom;
   indot = magvstream;
 
   for (i = 0; i < ntask; i++) {
@@ -558,8 +558,8 @@ void FixEmitSurf::perform_task()
           p->flag = PSURF + 1 + isurf;
           p->dtremain = dt * random->uniform();
 
-          if (nfix_add_particle)
-            modify->add_particle(particle->nlocal-1,temp_thermal,
+          if (nfix_update_custom)
+            modify->update_custom(particle->nlocal-1,temp_thermal,
                                  temp_rot,temp_vib,vstream);
         }
 
@@ -651,8 +651,8 @@ void FixEmitSurf::perform_task()
         p->flag = PSURF + 1 + isurf;
         p->dtremain = dt * random->uniform();
 
-        if (nfix_add_particle)
-          modify->add_particle(particle->nlocal-1,temp_thermal,
+        if (nfix_update_custom)
+          modify->update_custom(particle->nlocal-1,temp_thermal,
                                temp_rot,temp_vib,vstream);
       }
 

--- a/src/fix_vibmode.cpp
+++ b/src/fix_vibmode.cpp
@@ -36,7 +36,7 @@ FixVibmode::FixVibmode(SPARTA *sparta, int narg, char **arg) :
 {
   if (narg != 2) error->all(FLERR,"Illegal fix vibmode command");
 
-  flag_add_particle = 1;
+  flag_update_custom = 1;
 
   // random = RNG for vibrational mode initialization
 
@@ -90,12 +90,13 @@ void FixVibmode::init()
 
 /* ----------------------------------------------------------------------
    called when a particle with index is created
+    or when temperature dependent properties need to be updated
    populate all vibrational modes and set evib = sum of mode energies
 ------------------------------------------------------------------------- */
 
-void FixVibmode::add_particle(int index, double temp_thermal,
-                              double temp_rot, double temp_vib,
-                              double *vstream)
+void FixVibmode::update_custom(int index, double temp_thermal,
+                               double temp_rot, double temp_vib,
+                               double *vstream)
 {
   int **vibmode = particle->eiarray[particle->ewhich[vibmodeindex]];
 

--- a/src/fix_vibmode.h
+++ b/src/fix_vibmode.h
@@ -32,7 +32,7 @@ class FixVibmode : public Fix {
   virtual ~FixVibmode();
   int setmask();
   void init();
-  virtual void add_particle(int, double, double, double, double *);
+  virtual void update_custom(int, double, double, double, double *);
 
  protected:
   int maxmode;           // max # of vibrational modes for any species

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -46,7 +46,7 @@ Modify::Modify(SPARTA *sparta) : Pointers(sparta)
 
   end_of_step_every = NULL;
   list_pergrid = NULL;
-  list_add_particle = NULL;
+  list_update_custom = NULL;
   list_gas_react = NULL;
   list_surf_react = NULL;
   list_timeflag = NULL;
@@ -81,7 +81,7 @@ Modify::~Modify()
 
   delete [] end_of_step_every;
   delete [] list_pergrid;
-  delete [] list_add_particle;
+  delete [] list_update_custom;
   delete [] list_gas_react;
   delete [] list_surf_react;
   delete [] list_timeflag;
@@ -230,15 +230,15 @@ void Modify::grid_changed()
 }
 
 /* ----------------------------------------------------------------------
-   invoke add_particle() method, only for relevant fixes
+   invoke update_custom() method, only for relevant fixes
 ------------------------------------------------------------------------- */
 
-void Modify::add_particle(int index, double temp_thermal,
+void Modify::update_custom(int index, double temp_thermal,
                           double temp_rot, double temp_vib, double *vstream)
 {
-  for (int i = 0; i < n_add_particle; i++)
-    fix[list_add_particle[i]]->add_particle(index,temp_thermal,temp_rot,
-                                            temp_vib,vstream);
+  for (int i = 0; i < n_update_custom; i++)
+    fix[list_update_custom[i]]->update_custom(index,temp_thermal,temp_rot,
+                                              temp_vib,vstream);
 }
 
 /* ----------------------------------------------------------------------
@@ -554,27 +554,27 @@ void Modify::list_init_end_of_step(int mask, int &n, int *&list)
 void Modify::list_init_fixes()
 {
   delete [] list_pergrid;
-  delete [] list_add_particle;
+  delete [] list_update_custom;
   delete [] list_gas_react;
   delete [] list_surf_react;
 
-  n_pergrid = n_add_particle = n_gas_react = n_surf_react = 0;
+  n_pergrid = n_update_custom = n_gas_react = n_surf_react = 0;
   for (int i = 0; i < nfix; i++) {
     if (fix[i]->gridmigrate) n_pergrid++;
-    if (fix[i]->flag_add_particle) n_add_particle++;
+    if (fix[i]->flag_update_custom) n_update_custom++;
     if (fix[i]->flag_gas_react) n_gas_react++;
     if (fix[i]->flag_surf_react) n_surf_react++;
   }
 
   list_pergrid = new int[n_pergrid];
-  list_add_particle = new int[n_add_particle];
+  list_update_custom = new int[n_update_custom];
   list_gas_react = new int[n_gas_react];
   list_surf_react = new int[n_surf_react];
 
-  n_pergrid = n_add_particle = n_gas_react = n_surf_react = 0;
+  n_pergrid = n_update_custom = n_gas_react = n_surf_react = 0;
   for (int i = 0; i < nfix; i++) {
     if (fix[i]->gridmigrate) list_pergrid[n_pergrid++] = i;
-    if (fix[i]->flag_add_particle) list_add_particle[n_add_particle++] = i;
+    if (fix[i]->flag_update_custom) list_update_custom[n_update_custom++] = i;
     if (fix[i]->flag_gas_react) list_gas_react[n_gas_react++] = i;
     if (fix[i]->flag_surf_react) list_surf_react[n_surf_react++] = i;
   }

--- a/src/modify.h
+++ b/src/modify.h
@@ -24,7 +24,7 @@ class Modify : protected Pointers {
  public:
   int nfix,maxfix;
   int n_start_of_step,n_end_of_step;
-  int n_pergrid,n_add_particle,n_gas_react,n_surf_react;
+  int n_pergrid,n_update_custom,n_gas_react,n_surf_react;
 
   class Fix **fix;           // list of fixes
   int *fmask;                // bit mask for when each fix is applied
@@ -61,7 +61,7 @@ class Modify : protected Pointers {
   void list_init_fixes();
   void list_init_computes();
 
-  virtual void add_particle(int, double, double, double, double *);
+  virtual void update_custom(int, double, double, double, double *);
   virtual void gas_react(int);
   virtual void surf_react(Particle::OnePart *, int &, int &);
 
@@ -76,7 +76,7 @@ class Modify : protected Pointers {
   int *end_of_step_every;
 
   int *list_pergrid;         // list of fixes that store per grid cell info
-  int *list_add_particle;    // list of fixes with add_particle() method
+  int *list_update_custom;    // list of fixes with update_custom() method
   int *list_gas_react;       // list of fixes with gas_react() method
   int *list_surf_react;      // list of fixes with surf_react() method
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1051,7 +1051,7 @@ double Particle::evib(int isp, double temp_thermal, RanPark *erandom)
   if (vibstyle == NONE || species[isp].vibdof < 2) return 0.0;
 
   // for DISCRETE, only need set evib for vibdof = 2
-  // mode levels and evib will be set by FixVibmode::add_particle()
+  // mode levels and evib will be set by FixVibmode::update_custom()
 
   eng = 0.0;
 

--- a/src/surf_collide_cll.cpp
+++ b/src/surf_collide_cll.cpp
@@ -181,9 +181,18 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
   }
 
   // CLL reflection for each particle
+  // particle I needs to trigger any fixes to update per-particle
+  //  properties which depend on the temperature of the particle
+  //  (e.g. fix vibmode and fix ambipolar)
   // if new particle J created, also need to trigger any fixes
 
-  if (ip) cll(ip,norm);
+  if (ip) {
+    cll(ip,norm);
+    if (modify->n_add_particle) {
+      int i = ip - particle->particles;
+      modify->add_particle(i,twall,twall,twall,vstream);
+    }
+  }
   if (jp) {
     cll(jp,norm);
     if (modify->n_add_particle) {

--- a/src/surf_collide_cll.cpp
+++ b/src/surf_collide_cll.cpp
@@ -188,16 +188,16 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 
   if (ip) {
     cll(ip,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int i = ip - particle->particles;
-      modify->add_particle(i,twall,twall,twall,vstream);
+      modify->update_custom(i,twall,twall,twall,vstream);
     }
   }
   if (jp) {
     cll(jp,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int j = jp - particle->particles;
-      modify->add_particle(j,twall,twall,twall,vstream);
+      modify->update_custom(j,twall,twall,twall,vstream);
     }
   }
 

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -162,9 +162,18 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 
   // diffuse reflection for each particle
   // resets v, roteng, vibeng
+  // particle I needs to trigger any fixes to update per-particle
+  //  properties which depend on the temperature of the particle
+  //  (e.g. fix vibmode and fix ambipolar)
   // if new particle J created, also need to trigger any fixes
 
-  if (ip) diffuse(ip,norm);
+  if (ip) {
+    diffuse(ip,norm);
+    if (modify->n_add_particle) {
+      int i = ip - particle->particles;
+      modify->add_particle(i,twall,twall,twall,vstream);
+    }
+  }
   if (jp) {
     diffuse(jp,norm);
     if (modify->n_add_particle) {

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -169,16 +169,16 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 
   if (ip) {
     diffuse(ip,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int i = ip - particle->particles;
-      modify->add_particle(i,twall,twall,twall,vstream);
+      modify->update_custom(i,twall,twall,twall,vstream);
     }
   }
   if (jp) {
     diffuse(jp,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int j = jp - particle->particles;
-      modify->add_particle(j,twall,twall,twall,vstream);
+      modify->update_custom(j,twall,twall,twall,vstream);
     }
   }
 

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -206,8 +206,6 @@ void SurfCollideDiffuse::diffuse(Particle::OnePart *p, double *norm)
 
   if (random->uniform() > acc) {
     MathExtra::reflect3(p->v,norm);
-    p->erot = particle->erot(p->ispecies,twall,random);
-    p->evib = particle->evib(p->ispecies,twall,random);
 
   // diffuse reflection
   // vrm = most probable speed of species, eqns (4.1) and (4.7)

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -192,9 +192,18 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
   }
 
   // impulsive reflection for each particle
+  // particle I needs to trigger any fixes to update per-particle
+  //  properties which depend on the temperature of the particle
+  //  (e.g. fix vibmode and fix ambipolar)
   // if new particle J created, also need to trigger any fixes
 
-  if (ip) impulsive(ip,norm);
+  if (ip) {
+    impulsive(ip,norm);
+    if (modify->n_add_particle) {
+      int i = ip - particle->particles;
+      modify->add_particle(i,twall,twall,twall,vstream);
+    }
+  }
   if (jp) {
     impulsive(jp,norm);
     if (modify->n_add_particle) {

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -199,16 +199,16 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 
   if (ip) {
     impulsive(ip,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int i = ip - particle->particles;
-      modify->add_particle(i,twall,twall,twall,vstream);
+      modify->update_custom(i,twall,twall,twall,vstream);
     }
   }
   if (jp) {
     impulsive(jp,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int j = jp - particle->particles;
-      modify->add_particle(j,twall,twall,twall,vstream);
+      modify->update_custom(j,twall,twall,twall,vstream);
     }
   }
 

--- a/src/surf_collide_td.cpp
+++ b/src/surf_collide_td.cpp
@@ -159,16 +159,16 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
 
   if (ip) {
     td(ip,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int i = ip - particle->particles;
-      modify->add_particle(i,twall,twall,twall,vstream);
+      modify->update_custom(i,twall,twall,twall,vstream);
     }
   }
   if (jp) {
     td(jp,norm);
-    if (modify->n_add_particle) {
+    if (modify->n_update_custom) {
       int j = jp - particle->particles;
-      modify->add_particle(j,twall,twall,twall,vstream);
+      modify->update_custom(j,twall,twall,twall,vstream);
     }
   }
 

--- a/src/surf_collide_td.cpp
+++ b/src/surf_collide_td.cpp
@@ -152,9 +152,18 @@ collide(Particle::OnePart *&ip, double *norm, double &, int isr, int &reaction)
   }
 
   // td reflection for each particle
+  // particle I needs to trigger any fixes to update per-particle
+  //  properties which depend on the temperature of the particle
+  //  (e.g. fix vibmode and fix ambipolar)
   // if new particle J created, also need to trigger any fixes
 
-  if (ip) td(ip,norm);
+  if (ip) {
+    td(ip,norm);
+    if (modify->n_add_particle) {
+      int i = ip - particle->particles;
+      modify->add_particle(i,twall,twall,twall,vstream);
+    }
+  }
   if (jp) {
     td(jp,norm);
     if (modify->n_add_particle) {


### PR DESCRIPTION
## Purpose

Fix bugs in surf_collide methods. Closes #167.
- The rotational and vibrational temperatures were not set correctly in `surf_collide_diffuse` when  the accommodation coefficient is < 1.0.
- Trigger fixes for particle I to update per-particle properties which depend on the temperature of the particle

## Author(s)

Arnaud Borner (NASA), Stan Moore (SNL)

## Backward Compatibility

Yes