### PR TITLE
doc: fix surf_react commands missing ID

### DIFF
--- a/doc/surf_react.html
+++ b/doc/surf_react.html
@@ -31,8 +31,8 @@
 </UL>
 <P><B>Examples:</B>
 </P>
-<PRE>surf_react global 0.2 0.15
-surf_react prob air.surf 
+<PRE>surf_react 1 global 0.2 0.15
+surf_react 1 prob air.surf 
 </PRE>
 <P><B>Description:</B>
 </P>

--- a/doc/surf_react.txt
+++ b/doc/surf_react.txt
@@ -24,8 +24,8 @@ args = arguments for that style :l
 
 [Examples:]
 
-surf_react global 0.2 0.15
-surf_react prob air.surf :pre
+surf_react 1 global 0.2 0.15
+surf_react 1 prob air.surf :pre
 
 [Description:]
 


### PR DESCRIPTION
## Purpose

The `surf_react` doc is missing the required ID parameter, thus these commands cannot be copy-pasted. This commit adds a generic `1`.

## Author(s)

Tim Teichmann, ITEP, KIT

## Backward Compatibility

Yes

## Implementation Notes

trivial


