### PR TITLE
Change pRNG in SPARTA from Park to Knuth algorithm

### DIFF
--- a/examples/ablation/log.29Jun21.mpi_1.ablation.2d
+++ b/examples/ablation/log.29Jun21.mpi_1.ablation.2d
@@ -1,0 +1,148 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around porous media
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 150 0 150 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (150 150 0.5)
+create_grid 	    150 150 1
+Created 22500 child grid cells
+  CPU time = 0.0137877 secs
+  create/ghost percent = 33.6106 66.3894
+
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00816011 secs
+  reassign/sort/migrate/ghost percent = 25.7933 2.0949 7.26933 64.8425
+
+global		    nrho 1.0 fnum 0.01
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+region              inner block 25.5 124.5 25.5 124.5 INF INF
+group               inner grid region inner one
+10000 grid cells in group inner
+
+compute             COMP isurf/grid all all n
+fix                 FIX ave/grid all 10 10 100 c_COMP[*]
+fix                 ablate ablate inner 100 0.2 f_FIX
+
+global              surfs implicit
+read_isurf          inner 100 100 1 binary.101x101 180.5 ablate
+  10201 corner points
+  28744 11256 pushed corner pt values
+  25.7078 124.292 xlo xhi
+  25.7078 124.292 ylo yhi
+  0 0 zlo zhi
+  0.413172 min line length
+  7213 = cells with surfs
+  8006 = total surfs in all grid cells
+  2 = max surfs in one grid cell
+  0.413172 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  7213 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  15211 76 7213 = cells outside/inside/overlapping surfs
+  7213 = surf cells with 1,2,etc splits
+  21209.8 21209.8 = cell-wise and global flow volume
+  CPU time = 0.0301695 secs
+  read/create-surfs percent = 13.2148 86.7852
+
+surf_collide	    1 diffuse 300.0 1.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+fix                 check grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.05 #                    size 1024 1024 zoom 1.75 grid proc sline yes 0.005 #                    # surf proc 0.004
+#dump_modify	    2 pad 5
+
+fix                 bal balance 100 1.001 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck                     f_bal f_bal[2] f_ablate
+
+# run 10-20x longer for a better movie
+
+run                 500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 4.38879 4.38879 4.38879
+  surf      (ave,min,max) = 0.794052 0.794052 0.794052
+  total     (ave,min,max) = 7.15695 7.15695 7.15695
+Step CPU Np Natt Ncoll Nscoll Nscheck f_bal f_bal[2] f_ablate 
+       0            0        0        0        0        0        0            1            1       717570 
+     100   0.15675426    31623        0        0        0        0            1            1       717570 
+     200   0.54150724    63223        0        0        1       30            1            1       717568 
+     300    1.2537777    94820        0        0       14      944            1            1     717423.8 
+     400    2.3182425   126445        0        0       74     4000            1            1    716483.38 
+     500    3.7411542   158002        0        0      124     8386            1            1    714499.34 
+Loop time of 3.74148 on 1 procs for 500 steps with 158002 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.554      | 1.554      | 1.554      |   0.0 | 41.53
+Coll    | 0.38468    | 0.38468    | 0.38468    |   0.0 | 10.28
+Sort    | 0.67792    | 0.67792    | 0.67792    |   0.0 | 18.12
+Comm    | 0.0014236  | 0.0014236  | 0.0014236  |   0.0 |  0.04
+Modify  | 1.1184     | 1.1184     | 1.1184     |   0.0 | 29.89
+Output  | 0.0016582  | 0.0016582  | 0.0016582  |   0.0 |  0.04
+Other   |            | 0.003406   |            |       |  0.09
+
+Particle moves    = 39590487 (39.6M)
+Cells touched     = 42788073 (42.8M)
+Particle comms    = 0 (0K)
+Boundary collides = 8149 (8.15K)
+Boundary exits    = 15 (0.015K)
+SurfColl checks   = 876698 (0.877M)
+SurfColl occurs   = 13882 (13.9K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.05815e+07
+Particle-moves/step: 79181
+Cell-touches/particle/step: 1.08077
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.000205832
+Particle fraction exiting boundary: 3.78879e-07
+Surface-checks/particle/step: 0.0221442
+Surface-collisions/particle/step: 0.00035064
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 158002 ave 158002 max 158002 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      22500 ave 22500 max 22500 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    8006 ave 8006 max 8006 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/ablation/log.29Jun21.mpi_1.ablation.3d
+++ b/examples/ablation/log.29Jun21.mpi_1.ablation.3d
@@ -1,0 +1,150 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 3d flow through porous media ablating cylindrical fibers
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    r r o
+
+create_box  	    0 100 0 100 0 100
+Created orthogonal box = (0 0 0) to (100 100 100)
+create_grid 	    100 100 100 block * * *
+Created 1000000 child grid cells
+  CPU time = 0.746079 secs
+  create/ghost percent = 26.4886 73.5114
+
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.469823 secs
+  reassign/sort/migrate/ghost percent = 22.6058 2.11095 10.259 65.0243
+
+global		    nrho 1 fnum 1
+
+species		    air.species N O
+mixture		    air N O vstream 0 0 -100.0
+
+compute             COMP isurf/grid all all n
+fix                 FIX ave/grid all 1 10 10 c_COMP[*] ave one
+fix                 ablate ablate all 10 5.0 f_FIX
+
+global              surfs implicit
+
+read_isurf          all 100 100 100 fibers-101x101x101.binary 127.5 ablate
+  1030301 corner points
+  5646176 2353824 pushed corner pt values
+  0.5 99.5 xlo xhi
+  0.5 99.5 ylo yhi
+  0.5 99.5 zlo zhi
+  0.707107 min triangle edge length
+  0.216506 min triangle area
+  190990 = cells with surfs
+  381924 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.707107 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  190990 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  603700 205310 190990 = cells outside/inside/overlapping surfs
+  190794 196 = surf cells with 1,2,etc splits
+  708904 708904 = cell-wise and global flow volume
+  CPU time = 6.94051 secs
+  read/create-surfs percent = 8.19091 91.8091
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+create_particles    air n 0 twopass
+Created 708903 particles
+  CPU time = 0.368709 secs
+fix		    in emit/face air zhi twopass
+
+timestep 	    1e-3
+
+#dump                2 image all 10 binary.*.ppm type type #                    pdiam 0.0000015 particle yes #                    sline no 0.002 surf proc 0.03 size 1024 1024 #                    axes yes 1 0.01 zoom 1.2
+#dump_modify	    2 pad 4 pcolor * blue backcolor white
+
+stats		    10
+stats_style	    step cpu np nattempt ncoll nscoll nscheck f_ablate
+
+# run 3-5x longer for a better movie
+
+run 		    100
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 74.25 74.25 74.25
+  grid      (ave,min,max) = 178.713 178.713 178.713
+  surf      (ave,min,max) = 46.6216 46.6216 46.6216
+  total     (ave,min,max) = 448.421 448.421 448.421
+Step CPU Np Natt Ncoll Nscoll Nscheck f_ablate 
+       0            0   708903        0        0        0        0     75028140 
+      10     8.287935   702736        0        0    24482   410384     73976340 
+      20    17.099373   695167        0        0    24720   431448     72656835 
+      30    26.143854   688675        0        0    24204   441777     71320040 
+      40    35.711857   682247        0        0    23957   462791     69998497 
+      50    45.873036   676579        0        0    24309   494767     68687730 
+      60    56.409257   671222        0        0    24556   534591     67397681 
+      70    67.191726   666214        0        0    24830   564339     66131549 
+      80     78.17624   661783        0        0    25317   584989     64866418 
+      90    89.377273   657915        0        0    25376   599878     63597562 
+     100    100.67079   654483        0        0    25308   609372     62316744 
+Loop time of 100.693 on 1 procs for 100 steps with 654483 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 19.82      | 19.82      | 19.82      |   0.0 | 19.68
+Coll    | 2.4764     | 2.4764     | 2.4764     |   0.0 |  2.46
+Sort    | 3.2428     | 3.2428     | 3.2428     |   0.0 |  3.22
+Comm    | 0.013699   | 0.013699   | 0.013699   |   0.0 |  0.01
+Modify  | 74.814     | 74.814     | 74.814     |   0.0 | 74.30
+Output  | 0.23046    | 0.23046    | 0.23046    |   0.0 |  0.23
+Other   |            | 0.09637    |            |       |  0.10
+
+Particle moves    = 68095146 (68.1M)
+Cells touched     = 130765649 (131M)
+Particle comms    = 0 (0K)
+Boundary collides = 551307 (0.551M)
+Boundary exits    = 262576 (0.263M)
+SurfColl checks   = 50051274 (50.1M)
+SurfColl occurs   = 2406566 (2.41M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 676262
+Particle-moves/step: 680951
+Cell-touches/particle/step: 1.92034
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00809613
+Particle fraction exiting boundary: 0.00385602
+Surface-checks/particle/step: 0.73502
+Surface-collisions/particle/step: 0.0353412
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 654483 ave 654483 max 654483 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1.0181e+06 ave 1.0181e+06 max 1.0181e+06 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    582584 ave 582584 max 582584 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/ablation/log.29Jun21.mpi_4.ablation.2d
+++ b/examples/ablation/log.29Jun21.mpi_4.ablation.2d
@@ -1,0 +1,149 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around porous media
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 150 0 150 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (150 150 0.5)
+create_grid 	    150 150 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 22500 child grid cells
+  CPU time = 0.00178909 secs
+  create/ghost percent = 85.621 14.379
+
+balance_grid        rcb cell
+Balance grid migrated 16876 cells
+  CPU time = 0.0098176 secs
+  reassign/sort/migrate/ghost percent = 25.2392 2.41148 38.591 33.7583
+
+global		    nrho 1.0 fnum 0.01
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+region              inner block 25.5 124.5 25.5 124.5 INF INF
+group               inner grid region inner one
+10000 grid cells in group inner
+
+compute             COMP isurf/grid all all n
+fix                 FIX ave/grid all 10 10 100 c_COMP[*]
+fix                 ablate ablate inner 100 0.2 f_FIX
+
+global              surfs implicit
+read_isurf          inner 100 100 1 binary.101x101 180.5 ablate
+  10201 corner points
+  28744 11256 pushed corner pt values
+  25.7078 124.292 xlo xhi
+  25.7078 124.292 ylo yhi
+  0 0 zlo zhi
+  0.413172 min line length
+  7213 = cells with surfs
+  8006 = total surfs in all grid cells
+  2 = max surfs in one grid cell
+  0.413172 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  7213 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  15211 76 7213 = cells outside/inside/overlapping surfs
+  7213 = surf cells with 1,2,etc splits
+  21209.8 21209.8 = cell-wise and global flow volume
+  CPU time = 0.0119522 secs
+  read/create-surfs percent = 20.2888 79.7112
+
+surf_collide	    1 diffuse 300.0 1.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+fix                 check grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.05 #                    size 1024 1024 zoom 1.75 grid proc sline yes 0.005 #                    # surf proc 0.004
+#dump_modify	    2 pad 5
+
+fix                 bal balance 100 1.001 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck                     f_bal f_bal[2] f_ablate
+
+# run 10-20x longer for a better movie
+
+run                 500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.198513 0.19519 0.203522
+  total     (ave,min,max) = 2.22601 2.22269 2.23102
+Step CPU Np Natt Ncoll Nscoll Nscheck f_bal f_bal[2] f_ablate 
+       0            0        0        0        0        0        0            1            1       717570 
+     100   0.10569525    31598        0        0        0        0    1.0681689     2.000633       717570 
+     200    0.2834177    63196        0        0        3       36    1.0310146    1.4611684       717564 
+     300   0.62205148    94771        0        0       20      999    1.0192569    1.2823332     717419.4 
+     400    1.0971689   126380        0        0       64     3828    1.0133882    1.2089888    716550.94 
+     500    1.7259643   157948        0        0      136     8553    1.0120293    1.1523286    714622.09 
+Loop time of 1.72623 on 4 procs for 500 steps with 157948 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.33859    | 0.40289    | 0.46707    |   9.5 | 23.34
+Coll    | 0.057266   | 0.11017    | 0.16445    |  14.6 |  6.38
+Sort    | 0.32607    | 0.38723    | 0.45271    |   9.1 | 22.43
+Comm    | 0.022915   | 0.026027   | 0.027601   |   1.1 |  1.51
+Modify  | 0.417      | 0.46187    | 0.5128     |   6.4 | 26.76
+Output  | 0.0010498  | 0.001143   | 0.0014122  |   0.5 |  0.07
+Other   |            | 0.3369     |            |       | 19.52
+
+Particle moves    = 39573231 (39.6M)
+Cells touched     = 42772941 (42.8M)
+Particle comms    = 141451 (0.141M)
+Boundary collides = 8199 (8.2K)
+Boundary exits    = 14 (0.014K)
+SurfColl checks   = 871601 (0.872M)
+SurfColl occurs   = 13911 (13.9K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 5.73115e+06
+Particle-moves/step: 79146.5
+Cell-touches/particle/step: 1.08086
+Particle comm iterations/step: 1.982
+Particle fraction communicated: 0.00357441
+Particle fraction colliding with boundary: 0.000207186
+Particle fraction exiting boundary: 3.53774e-07
+Surface-checks/particle/step: 0.022025
+Surface-collisions/particle/step: 0.000351526
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 39487 ave 39962 max 39080 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Cells:      5625 ave 10655 max 802 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 204.75 ave 346 max 86 min
+Histogram: 1 1 0 0 0 0 1 0 0 1
+EmptyCell: 151.5 ave 217 max 86 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    2001 ave 4153 max 0 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostSurf: 19 ave 47 max 0 min
+Histogram: 2 0 0 0 0 0 1 0 0 1

--- a/examples/ablation/log.29Jun21.mpi_4.ablation.3d
+++ b/examples/ablation/log.29Jun21.mpi_4.ablation.3d
@@ -1,0 +1,150 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 3d flow through porous media ablating cylindrical fibers
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    r r o
+
+create_box  	    0 100 0 100 0 100
+Created orthogonal box = (0 0 0) to (100 100 100)
+create_grid 	    100 100 100 block * * *
+Created 1000000 child grid cells
+  CPU time = 0.259229 secs
+  create/ghost percent = 21.0247 78.9753
+
+balance_grid        rcb cell
+Balance grid migrated 500000 cells
+  CPU time = 0.449589 secs
+  reassign/sort/migrate/ghost percent = 22.6878 2.49969 45.0119 29.8006
+
+global		    nrho 1 fnum 1
+
+species		    air.species N O
+mixture		    air N O vstream 0 0 -100.0
+
+compute             COMP isurf/grid all all n
+fix                 FIX ave/grid all 1 10 10 c_COMP[*] ave one
+fix                 ablate ablate all 10 5.0 f_FIX
+
+global              surfs implicit
+
+read_isurf          all 100 100 100 fibers-101x101x101.binary 127.5 ablate
+  1030301 corner points
+  5646176 2353824 pushed corner pt values
+  0.5 99.5 xlo xhi
+  0.5 99.5 ylo yhi
+  0.5 99.5 zlo zhi
+  0.707107 min triangle edge length
+  0.216506 min triangle area
+  190990 = cells with surfs
+  381924 = total surfs in all grid cells
+  4 = max surfs in one grid cell
+  0.707107 = min surf-size/cell-size ratio
+  0 0 = number of pushed cells
+  190990 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  603700 205310 190990 = cells outside/inside/overlapping surfs
+  190794 196 = surf cells with 1,2,etc splits
+  708904 708904 = cell-wise and global flow volume
+  CPU time = 2.53978 secs
+  read/create-surfs percent = 16.0124 83.9876
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+create_particles    air n 0 twopass
+Created 708903 particles
+  CPU time = 0.114511 secs
+fix		    in emit/face air zhi twopass
+
+timestep 	    1e-3
+
+#dump                2 image all 10 binary.*.ppm type type #                    pdiam 0.0000015 particle yes #                    sline no 0.002 surf proc 0.03 size 1024 1024 #                    axes yes 1 0.01 zoom 1.2
+#dump_modify	    2 pad 4 pcolor * blue backcolor white
+
+stats		    10
+stats_style	    step cpu np nattempt ncoll nscoll nscheck f_ablate
+
+# run 3-5x longer for a better movie
+
+run 		    100
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 19.4062 18.5625 20.25
+  grid      (ave,min,max) = 46.2946 46.2946 46.2946
+  surf      (ave,min,max) = 11.6554 11.1716 12.1392
+  total     (ave,min,max) = 115.998 115.638 116.358
+Step CPU Np Natt Ncoll Nscoll Nscheck f_ablate 
+       0            0   708903        0        0        0        0     75028140 
+      10     2.935704   703001        0        0    24612   411188     73974030 
+      20    6.0102317   695388        0        0    24091   427315     72659759 
+      30    9.1614635   689085        0        0    24412   443215     71325208 
+      40    12.542132   682658        0        0    24232   461126     69998030 
+      50    16.076468   676644        0        0    24218   496790     68680552 
+      60    19.730814   671385        0        0    24271   533120     67388884 
+      70    23.460157   666588        0        0    24787   564347     66122166 
+      80    27.256653   662433        0        0    25366   586770     64856059 
+      90    31.106766   658616        0        0    25158   594357     63583211 
+     100    35.008737   654794        0        0    25579   608564     62304060 
+Loop time of 35.026 on 4 procs for 100 steps with 654794 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 5.6827     | 5.7466     | 5.8276     |   2.2 | 16.41
+Coll    | 0.99339    | 0.99974    | 1.0048     |   0.4 |  2.85
+Sort    | 2.3596     | 2.3985     | 2.4277     |   1.9 |  6.85
+Comm    | 0.045732   | 0.045916   | 0.0461     |   0.1 |  0.13
+Modify  | 25.428     | 25.448     | 25.474     |   0.4 | 72.66
+Output  | 0.17171    | 0.1719     | 0.17245    |   0.1 |  0.49
+Other   |            | 0.215      |            |       |  0.61
+
+Particle moves    = 68130419 (68.1M)
+Cells touched     = 130852544 (131M)
+Particle comms    = 450748 (0.451M)
+Boundary collides = 550987 (0.551M)
+Boundary exits    = 262562 (0.263M)
+SurfColl checks   = 50053061 (50.1M)
+SurfColl occurs   = 2409159 (2.41M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 486284
+Particle-moves/step: 681304
+Cell-touches/particle/step: 1.92062
+Particle comm iterations/step: 3.05
+Particle fraction communicated: 0.00661596
+Particle fraction colliding with boundary: 0.00808724
+Particle fraction exiting boundary: 0.00385381
+Surface-checks/particle/step: 0.734665
+Surface-collisions/particle/step: 0.035361
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 163698 ave 167316 max 160704 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Cells:      254572 ave 254851 max 254319 min
+Histogram: 1 0 0 1 0 1 0 0 0 1
+GhostCell: 10100 ave 10100 max 10100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 10100 ave 10100 max 10100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    145526 ave 151960 max 139012 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/adapt/log.29Jun21.mpi_1.adapt.rotate
+++ b/examples/adapt/log.29Jun21.mpi_1.adapt.rotate
@@ -1,0 +1,299 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000957966 secs
+  create/ghost percent = 83.5988 16.4012
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00017643 secs
+  reassign/sort/migrate/ghost percent = 63.3784 1.48649 18.3784 16.7568
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 scale 1.2 0.2 1
+  50 points
+  50 lines
+  1.4 8.6 xlo xhi
+  4.40118 5.59882 ylo yhi
+  0 0 zlo zhi
+  0.0803795 min line length
+  0 0 = number of pushed cells
+  16 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  84 0 16 = cells outside/inside/overlapping surfs
+  16 = surf cells with 1,2,etc splits
+  93.232 93.232 = cell-wise and global flow volume
+  CPU time = 0.00065136 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.0878 9.55344 1.42753 50.8785 8.05271 6.03953 0.0366032
+  surf2grid time = 0.000331402 secs
+  map/comm1/comm2/comm3/comm4/split percent = 39.5683 11.9424 8.84892 4.02878 15.3957 16.4029
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 #                    surf one 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75
+#dump_modify	    2 pad 5 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 #                    surf one 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75 grid proc
+#dump_modify	    3 pad 5 scolor * white glinecolor white
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    400
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.075474977    20801        0        0       61    10738 
+     200   0.26232028    35782        0        0      105    17871 
+     300   0.51249862    43260        0        0      123    21488 
+     400   0.80323458    47713        0        0      101    22949 
+Loop time of 0.803256 on 1 procs for 400 steps with 47713 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.48198    | 0.48198    | 0.48198    |   0.0 | 60.00
+Coll    | 0.053051   | 0.053051   | 0.053051   |   0.0 |  6.60
+Sort    | 0.070344   | 0.070344   | 0.070344   |   0.0 |  8.76
+Comm    | 0.001843   | 0.001843   | 0.001843   |   0.0 |  0.23
+Modify  | 0.19504    | 0.19504    | 0.19504    |   0.0 | 24.28
+Output  | 9.1076e-05 | 9.1076e-05 | 9.1076e-05 |   0.0 |  0.01
+Other   |            | 0.0009036  |            |       |  0.11
+
+Particle moves    = 12579237 (12.6M)
+Cells touched     = 13437584 (13.4M)
+Particle comms    = 0 (0K)
+Boundary collides = 44261 (44.3K)
+Boundary exits    = 36525 (36.5K)
+SurfColl checks   = 6229565 (6.23M)
+SurfColl occurs   = 32698 (32.7K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.56603e+07
+Particle-moves/step: 31448.1
+Cell-touches/particle/step: 1.06824
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00351858
+Particle fraction exiting boundary: 0.00290359
+Surface-checks/particle/step: 0.495226
+Surface-collisions/particle/step: 0.00259936
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 47713 ave 47713 max 47713 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf all 200 10000 rotate 360 0 0 1 5 5 0
+
+run 		    10000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 5.0625 5.0625 5.0625
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 6.58144 6.58144 6.58144
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     400            0    47713        0        0        0        0 
+     500   0.31464458    50299        0        0      121    24820 
+     600   0.64976239    50381        0        0      155     9127 
+     700    1.0410588    52150        0        0      131     4090 
+     800    1.4461093    51326        0        0      150     5069 
+     900    1.8487031    52973        0        0      153     4807 
+    1000    2.2616668    52288        0        0      149     4653 
+    1100    2.6662104    53719        0        0      135     5266 
+    1200    3.0853295    52758        0        0      156     4517 
+    1300    3.4882748    54367        0        0      140     5208 
+    1400    3.9106822    53770        0        0      148     5294 
+    1500    4.3169787    55092        0        0      146     4969 
+    1600    4.7355814    53684        0        0      162     4798 
+    1700    5.1449239    54874        0        0      171     5153 
+    1800    5.5625308    53642        0        0      176     5353 
+    1900    5.9747231    55076        0        0      152     5650 
+    2000    6.3938737    53567        0        0      144     5310 
+    2100    6.7949617    54866        0        0      163     5016 
+    2200    7.2181652    53562        0        0      141     4513 
+    2300    7.6209908    55027        0        0      158     5747 
+    2400    8.0442765    53835        0        0      147     4947 
+    2500    8.4475186    55024        0        0      145     6029 
+    2600    8.8597994    53738        0        0      143     4269 
+    2700    9.2685115    54669        0        0      145     5458 
+    2800    9.6787958    53071        0        0      159     4751 
+    2900    10.079301    53962        0        0      161     5171 
+    3000    10.483022    52716        0        0      155     4144 
+    3100    10.875239    53708        0        0      157     5367 
+    3200    11.283127    52532        0        0      136     4131 
+    3300    11.676006    53764        0        0      156     5775 
+    3400    12.087028    52805        0        0      151     4160 
+    3500    12.481631    53832        0        0      167     5772 
+    3600    12.887118    52686        0        0      172     5005 
+    3700    13.288372    53905        0        0      141     6005 
+    3800    13.696095    53027        0        0      157     5316 
+    3900    14.102962    54404        0        0      145     7188 
+    4000    14.515062    53191        0        0      145     4953 
+    4100    14.915788    54674        0        0      143     6163 
+    4200    15.337003    53775        0        0      138     4947 
+    4300    15.740875    55093        0        0      142     5516 
+    4400    16.166575    53892        0        0      165     5283 
+    4500    16.573049    55206        0        0      143     6964 
+    4600    16.994711    54011        0        0      140     5503 
+    4700    17.409481    55424        0        0      178     7113 
+    4800    17.828552    54141        0        0      148     5664 
+    4900    18.242268    55307        0        0      144     5204 
+    5000    18.663007    53940        0        0      112     4601 
+    5100    19.078403    55099        0        0      142     6269 
+    5200    19.498384    53755        0        0      153     5548 
+    5300    19.911138    55223        0        0      168     7728 
+    5400     20.34187    53517        0        0      146     5794 
+    5500    20.752449    54801        0        0      142     6158 
+    5600    21.184833    53838        0        0      144     5221 
+    5700    21.600014    55064        0        0      156     4178 
+    5800    22.028806    53904        0        0      136     4030 
+    5900    22.455958    55073        0        0      132     4956 
+    6000     22.88746    54021        0        0      138     4683 
+    6100    23.313814    55307        0        0      127     4764 
+    6200    23.744934    54101        0        0      122     4413 
+    6300    24.168293    55503        0        0      175     5040 
+    6400    24.595716    54290        0        0      146     5597 
+    6500    25.006604    55457        0        0      152     5042 
+    6600    25.438253    54227        0        0      159     4606 
+    6700    25.846886    55501        0        0      158     5027 
+    6800    26.277296    54273        0        0      163     5211 
+    6900    26.691104    55725        0        0      161     6105 
+    7000    27.117019    54082        0        0      167     5505 
+    7100     27.52787    55213        0        0      172     4846 
+    7200    27.958356    53608        0        0      151     4662 
+    7300    28.369765    55015        0        0      168     5760 
+    7400    28.785736    53727        0        0      169     5079 
+    7500    29.193702    54736        0        0      183     5905 
+    7600    29.605002    53873        0        0      164     4312 
+    7700    30.008215    54723        0        0      167     5884 
+    7800    30.426396    53139        0        0      150     4598 
+    7900    30.821973    54224        0        0      131     5032 
+    8000    31.235134    53186        0        0      150     4057 
+    8100    31.630162    54241        0        0      162     5100 
+    8200      32.0355    53179        0        0      151     4127 
+    8300    32.438344    54233        0        0      151     5732 
+    8400     32.84576    53351        0        0      152     4664 
+    8500    33.248241    54157        0        0      159     5615 
+    8600     33.65543    52954        0        0      156     4652 
+    8700    34.057232    54247        0        0      163     6209 
+    8800    34.476076    53420        0        0      141     5126 
+    8900    34.878395    54670        0        0      168     7182 
+    9000    35.299621    53640        0        0      145     5046 
+    9100    35.702355    54898        0        0      160     6282 
+    9200    36.117287    53596        0        0      167     5116 
+    9300    36.528084    54892        0        0      174     5827 
+    9400    36.950652    53868        0        0      160     5662 
+    9500    37.365706    55268        0        0      137     7024 
+    9600    37.787367    53899        0        0      139     6061 
+    9700    38.200768    55098        0        0      148     6944 
+    9800    38.626187    54139        0        0      136     5785 
+    9900    39.030876    55101        0        0      141     4739 
+   10000    39.456467    53701        0        0      146     4601 
+   10100    39.862491    55240        0        0      157     6140 
+   10200    40.290279    53757        0        0      132     5191 
+   10300    40.703591    55055        0        0      156     7867 
+   10400    41.127056    53581        0        0      146     5666 
+Loop time of 41.1271 on 1 procs for 10000 steps with 53581 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 22.529     | 22.529     | 22.529     |   0.0 | 54.78
+Coll    | 3.845      | 3.845      | 3.845      |   0.0 |  9.35
+Sort    | 4.0231     | 4.0231     | 4.0231     |   0.0 |  9.78
+Comm    | 0.088264   | 0.088264   | 0.088264   |   0.0 |  0.21
+Modify  | 10.608     | 10.608     | 10.608     |   0.0 | 25.79
+Output  | 0.0027959  | 0.0027959  | 0.0027959  |   0.0 |  0.01
+Other   |            | 0.03152    |            |       |  0.08
+
+Particle moves    = 547494027 (547M)
+Cells touched     = 680062803 (680M)
+Particle comms    = 0 (0K)
+Boundary collides = 1921243 (1.92M)
+Boundary exits    = 1993183 (1.99M)
+SurfColl checks   = 51896418 (51.9M)
+SurfColl occurs   = 1470325 (1.47M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.33123e+07
+Particle-moves/step: 54749.4
+Cell-touches/particle/step: 1.24214
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00350916
+Particle fraction exiting boundary: 0.00364056
+Surface-checks/particle/step: 0.094789
+Surface-collisions/particle/step: 0.00268555
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 53581 ave 53581 max 53581 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1333 ave 1333 max 1333 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/adapt/log.29Jun21.mpi_1.adapt.slide
+++ b/examples/adapt/log.29Jun21.mpi_1.adapt.slide
@@ -1,0 +1,401 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000917196 secs
+  create/ghost percent = 84.0135 15.9865
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000165462 secs
+  reassign/sort/migrate/ghost percent = 59.366 1.72911 19.5965 19.3084
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000656128 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 29.8328 11.1555 1.05378 47.0203 10.9375 5.88663 0.0363372
+  surf2grid time = 0.000308514 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41.5765 12.7512 8.50077 3.86399 16.0742 13.1376
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  8 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  92 0 8 = cells outside/inside/overlapping surfs
+  8 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.000560284 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 20.3404 12.2128 0.808511 49.9149 16.7234 6.59574 0.0425532
+  surf2grid time = 0.000279665 secs
+  map/comm1/comm2/comm3/comm4/split percent = 42.1995 20.0341 8.09889 6.99062 7.67263 12.873
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 #                    surf one 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75
+#dump_modify	    2 pad 5 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 #                    surf one 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005 grid proc
+#dump_modify	    3 pad 5 scolor * white glinecolor white
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    400
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 1.52409 1.52409 1.52409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.068665266    20897        0        0       59     6384 
+     200   0.25030875    36000        0        0      102    14588 
+     300   0.49145508    43531        0        0      123    16506 
+     400   0.76577997    47683        0        0      139    18256 
+Loop time of 0.765795 on 1 procs for 400 steps with 47683 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.44633    | 0.44633    | 0.44633    |   0.0 | 58.28
+Coll    | 0.055018   | 0.055018   | 0.055018   |   0.0 |  7.18
+Sort    | 0.068735   | 0.068735   | 0.068735   |   0.0 |  8.98
+Comm    | 0.0018988  | 0.0018988  | 0.0018988  |   0.0 |  0.25
+Modify  | 0.19281    | 0.19281    | 0.19281    |   0.0 | 25.18
+Output  | 0.00010705 | 0.00010705 | 0.00010705 |   0.0 |  0.01
+Other   |            | 0.0008976  |            |       |  0.12
+
+Particle moves    = 12637210 (12.6M)
+Cells touched     = 13528928 (13.5M)
+Particle comms    = 0 (0K)
+Boundary collides = 45046 (45K)
+Boundary exits    = 36555 (36.6K)
+SurfColl checks   = 4543294 (4.54M)
+SurfColl occurs   = 33320 (33.3K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.65021e+07
+Particle-moves/step: 31593
+Cell-touches/particle/step: 1.07056
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00356455
+Particle fraction exiting boundary: 0.00289265
+Surface-checks/particle/step: 0.359517
+Surface-collisions/particle/step: 0.00263666
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 47683 ave 47683 max 47683 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf 1 200 10000 trans 0 -0.9 0
+fix                 11 move/surf 2 200 10000 trans 0 0.9 0
+
+run 		    10000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 5.0625 5.0625 5.0625
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 6.58659 6.58659 6.58659
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     400            0    47683        0        0        0        0 
+     500   0.30314279    50341        0        0      107    17626 
+     600   0.64924788    50865        0        0      121     9999 
+     700     1.031512    52257        0        0      126     7307 
+     800    1.4383984    52584        0        0      117     7037 
+     900    1.8340023    53431        0        0      121     7666 
+    1000     2.243731    53170        0        0      149     7961 
+    1100    2.6503201    53897        0        0      124     7569 
+    1200    3.0630322    53528        0        0      131     7625 
+    1300    3.4738297    54476        0        0      113     7827 
+    1400    3.8906324    54380        0        0      134     7086 
+    1500    4.2989914    54908        0        0      121     7008 
+    1600    4.7235851    54418        0        0      138     6276 
+    1700    5.1301425    54909        0        0      147     6307 
+    1800    5.5554609    54435        0        0      132     6449 
+    1900    5.9634609    55035        0        0      115     6184 
+    2000    6.3866541    54498        0        0      129     6256 
+    2100      6.80288    55268        0        0      142     6143 
+    2200    7.2236824    54611        0        0      113     5884 
+    2300    7.6442468    55417        0        0      120     6567 
+    2400    8.0692987    54641        0        0      120     6781 
+    2500     8.488848    55590        0        0      123     6588 
+    2600     8.913996    54875        0        0      122     6579 
+    2700    9.3280263    55645        0        0      126     6882 
+    2800    9.7597563    54602        0        0      141     6945 
+    2900    10.170127    55271        0        0      120     6892 
+    3000    10.602555    54501        0        0      136     7173 
+    3100    11.012919    55394        0        0      131     6904 
+    3200    11.438178    54635        0        0      118     7450 
+    3300    11.855416    55201        0        0      137     7045 
+    3400    12.277265    54752        0        0      106     5991 
+    3500    12.695924    55530        0        0      137     6742 
+    3600    13.121386    54765        0        0      124     6842 
+    3700    13.542884    55376        0        0      133     6889 
+    3800    13.968787    54938        0        0      122     6954 
+    3900    14.385382    55835        0        0      127     7419 
+    4000    14.822725    54821        0        0      133     8206 
+    4100    15.239262    55513        0        0      130     7659 
+    4200    15.672239    55032        0        0      120     6628 
+    4300    16.089791    55673        0        0      117     6614 
+    4400    16.525384    54843        0        0      117     6899 
+    4500    16.938634    55569        0        0      123     7280 
+    4600    17.366212    55160        0        0      129     7162 
+    4700    17.790507    55797        0        0      127     6945 
+    4800    18.217672    55062        0        0      139     7527 
+    4900    18.639741    55614        0        0      109     6372 
+    5000    19.065565    55141        0        0      110     6511 
+    5100    19.481165    55660        0        0      105     6580 
+    5200    19.913745    55146        0        0      110     6662 
+    5300    20.331306    55859        0        0      126     6450 
+    5400     20.76687    55469        0        0      118     6327 
+    5500    21.184447    55979        0        0      129     6714 
+    5600    21.617978    55417        0        0      116     6744 
+    5700    22.036065    56014        0        0      120     5778 
+    5800    22.464286    55316        0        0      122     6586 
+    5900    22.887398    55767        0        0      123     5795 
+    6000    23.315405    55681        0        0      129     6085 
+    6100    23.742275    56150        0        0      129     5903 
+    6200    24.171541    55554        0        0      124     5711 
+    6300    24.590905    55946        0        0      133     6303 
+    6400    25.025771    55555        0        0      138     6010 
+    6500    25.444847    56020        0        0      125     5988 
+    6600    25.880075    55330        0        0      122     6251 
+    6700       26.299    55924        0        0      137     6743 
+    6800    26.734646    55326        0        0      135     6489 
+    6900    27.151428    55838        0        0      141     7083 
+    7000    27.579262    55177        0        0      136     6763 
+    7100    28.003718    55860        0        0      135     6581 
+    7200    28.433465    55194        0        0      135     6604 
+    7300    28.859371    56083        0        0      139     7364 
+    7400    29.291269    55333        0        0      128     7185 
+    7500    29.717067    55805        0        0      124     7206 
+    7600    30.148635    55190        0        0      129     6832 
+    7700    30.569978    55938        0        0      142     7351 
+    7800    31.009539    55039        0        0      156     7928 
+    7900     31.42793    55832        0        0      116     7361 
+    8000    31.865985    55007        0        0      130     7428 
+    8100    32.285457    56054        0        0      135     8260 
+    8200    32.726031    55021        0        0      127     7776 
+    8300    33.146111    56142        0        0      135     8481 
+    8400    33.583112    55273        0        0      128     8339 
+    8500    34.012435    55779        0        0      131     8534 
+    8600     34.44273    54984        0        0      115     7757 
+    8700    34.867869    55690        0        0      155     8644 
+    8800    35.300509    55329        0        0      124     8068 
+    8900    35.721222    56238        0        0      109     6599 
+    9000    36.161421    55381        0        0      129     7678 
+    9100    36.581756    55903        0        0      126     7093 
+    9200        37.02    55194        0        0      135     6815 
+    9300    37.441632    55914        0        0      114     7991 
+    9400    37.882768    55409        0        0      129     7491 
+    9500    38.305582    56048        0        0      127     7371 
+    9600    38.741615    55194        0        0      146     6577 
+    9700    39.171812    55848        0        0      122     6233 
+    9800    39.606791    55063        0        0      132     6474 
+    9900    40.034415    55612        0        0      114     5929 
+   10000     40.47025    55141        0        0      137     7543 
+   10100    40.901435    56016        0        0      134     7388 
+   10200     41.34123    55388        0        0      137     7449 
+   10300    41.765936    55999        0        0      140     7398 
+   10400     42.21671    55452        0        0      111     7339 
+Loop time of 42.2168 on 1 procs for 10000 steps with 55452 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 23.121     | 23.121     | 23.121     |   0.0 | 54.77
+Coll    | 3.936      | 3.936      | 3.936      |   0.0 |  9.32
+Sort    | 4.1359     | 4.1359     | 4.1359     |   0.0 |  9.80
+Comm    | 0.096277   | 0.096277   | 0.096277   |   0.0 |  0.23
+Modify  | 10.89      | 10.89      | 10.89      |   0.0 | 25.80
+Output  | 0.0028203  | 0.0028203  | 0.0028203  |   0.0 |  0.01
+Other   |            | 0.03487    |            |       |  0.08
+
+Particle moves    = 556122870 (556M)
+Cells touched     = 685902150 (686M)
+Particle comms    = 0 (0K)
+Boundary collides = 1917414 (1.92M)
+Boundary exits    = 2037143 (2.04M)
+SurfColl checks   = 68358160 (68.4M)
+SurfColl occurs   = 1246364 (1.25M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.3173e+07
+Particle-moves/step: 55612.3
+Cell-touches/particle/step: 1.23336
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00344782
+Particle fraction exiting boundary: 0.00366312
+Surface-checks/particle/step: 0.122919
+Surface-collisions/particle/step: 0.00224117
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 55452 ave 55452 max 55452 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1129 ave 1129 max 1129 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+unfix               10
+unfix               11
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 8.27409 8.27409 8.27409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+   10400            0    55452        0        0        0        0 
+   10500   0.43205976    56066        0        0      130     6992 
+   10600   0.87730289    56979        0        0      122     6820 
+   10700    1.3180876    57178        0        0      136     7458 
+   10800    1.7747643    57195        0        0      135     7425 
+   10900    2.2223759    57155        0        0      129     7175 
+   11000    2.6699018    57280        0        0      116     7132 
+   11100    3.1106119    57221        0        0      129     6955 
+   11200    3.5507021    57078        0        0      126     7253 
+   11300    4.0094993    57297        0        0      126     7071 
+   11400    4.4496112    57162        0        0      128     7278 
+   11500    4.8966062    57286        0        0      123     6914 
+   11600     5.339232    57513        0        0      141     7494 
+   11700    5.7878935    57273        0        0      118     7385 
+   11800    6.2293582    57384        0        0      134     6911 
+   11900    6.6787524    57570        0        0      128     6944 
+   12000    7.1227164    57600        0        0      104     7159 
+   12100    7.5662122    57777        0        0      131     7289 
+   12200    8.0178487    57631        0        0      121     7233 
+   12300    8.4613714    57680        0        0      133     7741 
+   12400    8.9107261    57526        0        0      127     7109 
+Loop time of 8.91075 on 1 procs for 2000 steps with 57526 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 4.8822     | 4.8822     | 4.8822     |   0.0 | 54.79
+Coll    | 0.85461    | 0.85461    | 0.85461    |   0.0 |  9.59
+Sort    | 0.89133    | 0.89133    | 0.89133    |   0.0 | 10.00
+Comm    | 0.020397   | 0.020397   | 0.020397   |   0.0 |  0.23
+Modify  | 2.254      | 2.254      | 2.254      |   0.0 | 25.30
+Output  | 0.00054431 | 0.00054431 | 0.00054431 |   0.0 |  0.01
+Other   |            | 0.007619   |            |       |  0.09
+
+Particle moves    = 114888157 (115M)
+Cells touched     = 142211920 (142M)
+Particle comms    = 0 (0K)
+Boundary collides = 391674 (0.392M)
+Boundary exits    = 419662 (0.42M)
+SurfColl checks   = 14286519 (14.3M)
+SurfColl occurs   = 257271 (0.257M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.28932e+07
+Particle-moves/step: 57444.1
+Cell-touches/particle/step: 1.23783
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00340918
+Particle fraction exiting boundary: 0.00365279
+Surface-checks/particle/step: 0.124352
+Surface-collisions/particle/step: 0.00223932
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 57526 ave 57526 max 57526 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1153 ave 1153 max 1153 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/adapt/log.29Jun21.mpi_1.adapt.static
+++ b/examples/adapt/log.29Jun21.mpi_1.adapt.static
@@ -1,0 +1,413 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around set of circles
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000956059 secs
+  create/ghost percent = 84.6883 15.3117
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000157118 secs
+  reassign/sort/migrate/ghost percent = 59.0288 1.6692 20.4856 18.8164
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+# 7 circles, 4 above, 3 below
+
+read_surf           data.circle origin 5 5 0 trans 1.0 0.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  5.01 6.99 xlo xhi
+  4.51195 6.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  6 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  94 0 6 = cells outside/inside/overlapping surfs
+  6 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000661135 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 29.066 12.4775 1.00974 48.5395 8.90732 6.38298 0.036062
+  surf2grid time = 0.000320911 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41.0104 11.2184 8.39525 3.789 14.7845 16.7162
+read_surf           data.circle origin 5 5 0 trans -1.0 1.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  100 lines
+  3.01 4.99 xlo xhi
+  5.51195 7.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  88 0 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.000538826 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 18.9823 11.9469 0.752212 54.5575 13.7611 6.54867 0.0442478
+  surf2grid time = 0.00029397 secs
+  map/comm1/comm2/comm3/comm4/split percent = 40.3082 18.8159 8.75912 6.48824 7.13706 16.4639
+read_surf           data.circle origin 5 5 0 trans 1.0 2.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  150 lines
+  5.01 6.99 xlo xhi
+  6.51195 8.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  16 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  84 0 16 = cells outside/inside/overlapping surfs
+  16 = surf cells with 1,2,etc splits
+  90.7871 90.7871 = cell-wise and global flow volume
+  CPU time = 0.000561714 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.6095 13.3701 0.679117 46.6893 19.652 6.28183 0.0424448
+  surf2grid time = 0.00026226 secs
+  map/comm1/comm2/comm3/comm4/split percent = 33 20.8182 8.45455 5 10 19.0909
+read_surf           data.circle origin 5 5 0 trans -1.0 3.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  200 lines
+  3.01 4.99 xlo xhi
+  7.51195 9.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  20 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  80 0 20 = cells outside/inside/overlapping surfs
+  20 = surf cells with 1,2,etc splits
+  87.7161 87.7161 = cell-wise and global flow volume
+  CPU time = 0.000685692 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 15.6467 15.9944 0.625869 45.7928 21.9402 5.00695 0.0347705
+  surf2grid time = 0.000313997 secs
+  map/comm1/comm2/comm3/comm4/split percent = 29.9165 22.779 7.44115 6.52999 11.0099 19.8178
+
+read_surf           data.circle origin 5 5 0 trans -1.5 -1.8 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  250 lines
+  2.51 4.49 xlo xhi
+  2.21195 4.18805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  28 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  71 1 28 = cells outside/inside/overlapping surfs
+  28 = surf cells with 1,2,etc splits
+  84.6451 84.6451 = cell-wise and global flow volume
+  CPU time = 0.000747442 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 14.7049 15.7257 0.606061 46.4753 22.488 4.78469 0
+  surf2grid time = 0.000347376 secs
+  map/comm1/comm2/comm3/comm4/split percent = 31.3658 23.5415 5.76527 5.628 11.7364 19.8353
+read_surf           data.circle origin 5 5 0 trans 0.5 -2.8 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  300 lines
+  4.51 6.49 xlo xhi
+  1.21195 3.18805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  34 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  64 2 34 = cells outside/inside/overlapping surfs
+  34 = surf cells with 1,2,etc splits
+  81.5741 81.5741 = cell-wise and global flow volume
+  CPU time = 0.000835896 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 12.8066 16.2008 0.827153 46.9196 23.2459 4.33542 0.0285225
+  surf2grid time = 0.000392199 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.693 24.6201 5.53191 5.59271 12.0973 21.5805
+read_surf           data.circle origin 5 5 0 trans -1.5 -3.8 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  350 lines
+  2.51 4.49 xlo xhi
+  0.211954 2.18805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  38 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  59 3 38 = cells outside/inside/overlapping surfs
+  38 = surf cells with 1,2,etc splits
+  78.5032 78.5032 = cell-wise and global flow volume
+  CPU time = 0.000939846 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 11.8975 17.9858 0.481989 44.1147 25.52 4.00812 0.0253678
+  surf2grid time = 0.00041461 secs
+  map/comm1/comm2/comm3/comm4/split percent = 29.9597 22.7142 3.73778 4.71535 14.7211 22.1392
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 #                    surf one 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 #                    surf one 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005 grid proc
+#dump_modify	    3 pad 4 scolor * white glinecolor white
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0360489 0.0360489 0.0360489
+  total     (ave,min,max) = 1.54984 1.54984 1.54984
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.098601103    19967        0        0      240    47803 
+     200   0.36825824    30720        0        0      338    81773 
+     300   0.72147846    35390        0        0      358    93733 
+     400    1.1070492    37948        0        0      396   102686 
+     500     1.509856    39430        0        0      349   104017 
+Loop time of 1.50988 on 1 procs for 500 steps with 39430 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.1377     | 1.1377     | 1.1377     |   0.0 | 75.35
+Coll    | 0.061911   | 0.061911   | 0.061911   |   0.0 |  4.10
+Sort    | 0.081467   | 0.081467   | 0.081467   |   0.0 |  5.40
+Comm    | 0.0028756  | 0.0028756  | 0.0028756  |   0.0 |  0.19
+Modify  | 0.22472    | 0.22472    | 0.22472    |   0.0 | 14.88
+Output  | 0.00011444 | 0.00011444 | 0.00011444 |   0.0 |  0.01
+Other   |            | 0.001069   |            |       |  0.07
+
+Particle moves    = 14629932 (14.6M)
+Cells touched     = 15578627 (15.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 59013 (59K)
+Boundary exits    = 65892 (65.9K)
+SurfColl checks   = 37685802 (37.7M)
+SurfColl occurs   = 147799 (0.148M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.68949e+06
+Particle-moves/step: 29259.9
+Cell-touches/particle/step: 1.06485
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00403372
+Particle fraction exiting boundary: 0.00450392
+Surface-checks/particle/step: 2.57594
+Surface-collisions/particle/step: 0.0101025
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 39430 ave 39430 max 39430 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    350 ave 350 max 350 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 5.0625 5.0625 5.0625
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0360489 0.0360489 0.0360489
+  total     (ave,min,max) = 6.61234 6.61234 6.61234
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    39430        0        0        0        0 
+     600   0.42198491    40367        0        0      425   108492 
+     700   0.73825073    40933        0        0      377    32134 
+     800    1.0800414    41487        0        0      390    22515 
+     900    1.4281626    41670        0        0      371    21732 
+    1000    1.7732413    41689        0        0      389    21622 
+    1100    2.1162717    41715        0        0      392    22357 
+    1200    2.4669876    42053        0        0      386    21518 
+    1300    2.8164129    42318        0        0      411    22545 
+    1400    3.1680443    42682        0        0      377    21930 
+    1500    3.5266876    42650        0        0      411    22418 
+    1600    3.8784537    42448        0        0      391    21711 
+    1700     4.228286    42224        0        0      396    22417 
+    1800    4.5818365    42378        0        0      385    22427 
+    1900    4.9327877    42598        0        0      406    22575 
+    2000    5.2872078    42374        0        0      396    21280 
+    2100    5.6363273    42608        0        0      392    21296 
+    2200    5.9865277    42861        0        0      442    21873 
+    2300    6.3406644    42634        0        0      390    20996 
+    2400    6.6898859    42640        0        0      423    21302 
+    2500    7.0414455    42763        0        0      411    22564 
+Loop time of 7.04146 on 1 procs for 2000 steps with 42763 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 4.5224     | 4.5224     | 4.5224     |   0.0 | 64.23
+Coll    | 0.4534     | 0.4534     | 0.4534     |   0.0 |  6.44
+Sort    | 0.55138    | 0.55138    | 0.55138    |   0.0 |  7.83
+Comm    | 0.016118   | 0.016118   | 0.016118   |   0.0 |  0.23
+Modify  | 1.4927     | 1.4927     | 1.4927     |   0.0 | 21.20
+Output  | 0.00040436 | 0.00040436 | 0.00040436 |   0.0 |  0.01
+Other   |            | 0.005104   |            |       |  0.07
+
+Particle moves    = 84556517 (84.6M)
+Cells touched     = 103893596 (104M)
+Particle comms    = 0 (0K)
+Boundary collides = 319937 (0.32M)
+Boundary exits    = 418213 (0.418M)
+SurfColl checks   = 53366844 (53.4M)
+SurfColl occurs   = 796043 (0.796M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.20084e+07
+Particle-moves/step: 42278.3
+Cell-touches/particle/step: 1.22869
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00378371
+Particle fraction exiting boundary: 0.00494596
+Surface-checks/particle/step: 0.631138
+Surface-collisions/particle/step: 0.00941433
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 42763 ave 42763 max 42763 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      727 ave 727 max 727 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    350 ave 350 max 350 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+unfix               2
+unfix               5
+
+run                 3000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 5.0625 5.0625 5.0625
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0360489 0.0360489 0.0360489
+  total     (ave,min,max) = 6.61234 6.61234 6.61234
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2500            0    42763        0        0        0        0 
+    2600   0.35615516    42904        0        0      432    23047 
+    2700   0.70659804    42797        0        0      362    21981 
+    2800    1.0591254    42684        0        0      423    23385 
+    2900    1.4153075    42846        0        0      436    22731 
+    3000     1.766953    42971        0        0      390    23037 
+    3100     2.118233    42852        0        0      372    22157 
+    3200    2.4739015    42765        0        0      421    22455 
+    3300    2.8244855    42738        0        0      432    22858 
+    3400    3.1746268    42707        0        0      388    22121 
+    3500    3.5297749    42778        0        0      415    22726 
+    3600    3.8792064    42701        0        0      407    21869 
+    3700    4.2271914    42528        0        0      408    22533 
+    3800    4.5823469    42789        0        0      363    22050 
+    3900    4.9339159    42908        0        0      405    22152 
+    4000    5.2859492    42803        0        0      384    22164 
+    4100    5.6424813    42853        0        0      407    23110 
+    4200    5.9961329    42974        0        0      430    22310 
+    4300     6.354809    42740        0        0      347    21784 
+    4400    6.7067277    42827        0        0      392    21766 
+    4500    7.0581248    42878        0        0      378    21723 
+    4600    7.4149468    43004        0        0      434    23344 
+    4700    7.7676449    42939        0        0      387    21862 
+    4800    8.1182818    42872        0        0      362    22298 
+    4900    8.4742348    42938        0        0      395    22508 
+    5000    8.8258281    42970        0        0      435    22758 
+    5100    9.1781714    43047        0        0      387    22108 
+    5200    9.5374916    43080        0        0      400    22633 
+    5300    9.8934195    43024        0        0      406    21758 
+    5400    10.245772    42855        0        0      378    22633 
+    5500    10.602829    42933        0        0      413    21946 
+Loop time of 10.6028 on 1 procs for 3000 steps with 42933 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 6.7619     | 6.7619     | 6.7619     |   0.0 | 63.77
+Coll    | 0.70934    | 0.70934    | 0.70934    |   0.0 |  6.69
+Sort    | 0.85662    | 0.85662    | 0.85662    |   0.0 |  8.08
+Comm    | 0.024449   | 0.024449   | 0.024449   |   0.0 |  0.23
+Modify  | 2.242      | 2.242      | 2.242      |   0.0 | 21.15
+Output  | 0.00065207 | 0.00065207 | 0.00065207 |   0.0 |  0.01
+Other   |            | 0.007921   |            |       |  0.07
+
+Particle moves    = 129157757 (129M)
+Cells touched     = 160323151 (160M)
+Particle comms    = 0 (0K)
+Boundary collides = 484820 (0.485M)
+Boundary exits    = 632002 (0.632M)
+SurfColl checks   = 67126210 (67.1M)
+SurfColl occurs   = 1199228 (1.2M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.21814e+07
+Particle-moves/step: 43052.6
+Cell-touches/particle/step: 1.2413
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0037537
+Particle fraction exiting boundary: 0.00489326
+Surface-checks/particle/step: 0.519723
+Surface-collisions/particle/step: 0.00928499
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 42933 ave 42933 max 42933 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      727 ave 727 max 727 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    350 ave 350 max 350 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/adapt/log.29Jun21.mpi_4.adapt.rotate
+++ b/examples/adapt/log.29Jun21.mpi_4.adapt.rotate
@@ -1,0 +1,300 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00109982 secs
+  create/ghost percent = 85.6276 14.3724
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000824451 secs
+  reassign/sort/migrate/ghost percent = 69.3175 0.665124 13.5338 16.4835
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 scale 1.2 0.2 1
+  50 points
+  50 lines
+  1.4 8.6 xlo xhi
+  4.40118 5.59882 ylo yhi
+  0 0 zlo zhi
+  0.0803795 min line length
+  0 0 = number of pushed cells
+  16 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  84 0 16 = cells outside/inside/overlapping surfs
+  16 = surf cells with 1,2,etc splits
+  93.232 93.232 = cell-wise and global flow volume
+  CPU time = 0.00100255 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 26.8014 16.6231 0.713436 47.8478 8.01427 17.503 0.285375
+  surf2grid time = 0.000479698 secs
+  map/comm1/comm2/comm3/comm4/split percent = 25.4473 10.9841 6.11332 5.666 10.2883 32.4056
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 #                    surf one 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75
+#dump_modify	    2 pad 5 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 #                    surf one 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75 grid proc
+#dump_modify	    3 pad 5 scolor * white glinecolor white
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    400
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.04272151    20746        0        0       62    10659 
+     200   0.12255383    35680        0        0       91    17545 
+     300    0.2165432    43428        0        0      112    21186 
+     400    0.3174355    47670        0        0      124    23503 
+Loop time of 0.317512 on 4 procs for 400 steps with 47670 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.076712   | 0.12638    | 0.17606    |  13.9 | 39.80
+Coll    | 0.0056076  | 0.010705   | 0.015819   |   4.9 |  3.37
+Sort    | 0.015505   | 0.022758   | 0.029991   |   4.8 |  7.17
+Comm    | 0.01139    | 0.01177    | 0.012343   |   0.3 |  3.71
+Modify  | 0.022135   | 0.049287   | 0.077257   |  12.2 | 15.52
+Output  | 0.00011587 | 0.00043607 | 0.00067997 |   0.0 |  0.14
+Other   |            | 0.09618    |            |       | 30.29
+
+Particle moves    = 12577116 (12.6M)
+Cells touched     = 13436237 (13.4M)
+Particle comms    = 64692 (64.7K)
+Boundary collides = 44473 (44.5K)
+Boundary exits    = 36647 (36.6K)
+SurfColl checks   = 6196525 (6.2M)
+SurfColl occurs   = 33050 (33K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.90287e+06
+Particle-moves/step: 31442.8
+Cell-touches/particle/step: 1.06831
+Particle comm iterations/step: 1.995
+Particle fraction communicated: 0.00514363
+Particle fraction colliding with boundary: 0.00353603
+Particle fraction exiting boundary: 0.00291378
+Surface-checks/particle/step: 0.492683
+Surface-collisions/particle/step: 0.00262779
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 11917.5 ave 14482 max 9268 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf all 200 10000 rotate 360 0 0 1 5 5 0
+
+run 		    10000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 3.20644 3.20644 3.20644
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     400            0    47670        0        0        0        0 
+     500    0.1073637    50269        0        0      130    25036 
+     600   0.21657681    50457        0        0      139     8883 
+     700   0.33119035    52450        0        0      134     4168 
+     800   0.47379279    51674        0        0      137     4492 
+     900   0.60061598    53086        0        0      145     4926 
+    1000   0.73658466    52123        0        0      133     4917 
+    1100   0.86788368    53810        0        0      141     5000 
+    1200    1.0106497    53108        0        0      170     4881 
+    1300    1.1382313    54622        0        0      137     5040 
+    1400    1.2744598    54000        0        0      148     5326 
+    1500    1.4214475    55292        0        0      170     4884 
+    1600     1.556426    54029        0        0      130     4654 
+    1700    1.6823938    55067        0        0      167     5152 
+    1800    1.8132319    53835        0        0      146     5337 
+    1900    1.9521348    55178        0        0      157     5743 
+    2000    2.0804586    53818        0        0      171     5123 
+    2100    2.2039738    54983        0        0      155     4679 
+    2200    2.3370912    53450        0        0      137     4734 
+    2300    2.4745681    54888        0        0      164     5538 
+    2400    2.5993235    53700        0        0      162     4978 
+    2500     2.717118    54814        0        0      182     6253 
+    2600    2.8376739    53599        0        0      155     4072 
+    2700    2.9540312    54688        0        0      194     5642 
+    2800    3.0731983    53347        0        0      160     4726 
+    2900    3.1884127    54158        0        0      159     5066 
+    3000    3.3057623    52837        0        0      154     3897 
+    3100    3.4408782    53730        0        0      173     5000 
+    3200    3.5585196    52563        0        0      176     4257 
+    3300    3.6719348    53582        0        0      153     5752 
+    3400    3.7893918    52826        0        0      141     4394 
+    3500    3.9034359    53918        0        0      144     5665 
+    3600    4.0227332    52816        0        0      139     4682 
+    3700    4.1370804    54058        0        0      137     6299 
+    3800    4.2536514    53273        0        0      158     5316 
+    3900    4.3714502    54422        0        0      149     7029 
+    4000    4.5112572    53526        0        0      169     4933 
+    4100    4.6301115    54781        0        0      149     6223 
+    4200    4.7539968    53847        0        0      176     5220 
+    4300    4.8733382    55221        0        0      176     5709 
+    4400    4.9987633    54164        0        0      134     5328 
+    4500    5.1199532    55424        0        0      141     6829 
+    4600    5.2424819    54303        0        0      187     5592 
+    4700    5.3645201    55422        0        0      161     6667 
+    4800    5.5072508    54501        0        0      161     5697 
+    4900    5.6293597    55676        0        0      143     5123 
+    5000    5.7523904    54162        0        0      142     4597 
+    5100    5.8745863    55465        0        0      147     6268 
+    5200    5.9983299    54215        0        0      131     4886 
+    5300    6.1184132    55254        0        0      147     7677 
+    5400    6.2393291    53554        0        0      154     6205 
+    5500    6.3596952    54901        0        0      142     6165 
+    5600    6.4987602    53890        0        0      154     4628 
+    5700    6.6163325    55197        0        0      143     4581 
+    5800    6.7427871    53477        0        0      172     4993 
+    5900    6.8743258    54799        0        0      138     5112 
+    6000    7.0165133    53664        0        0      154     5150 
+    6100    7.1543343    54975        0        0      152     5266 
+    6200    7.3022695    53843        0        0      174     4563 
+    6300    7.4450357    55161        0        0      137     5099 
+    6400    7.5969646    54371        0        0      142     5475 
+    6500    7.7273717    55645        0        0      156     5109 
+    6600    7.8641977    54309        0        0      149     4420 
+    6700    7.9898109    55496        0        0      163     5092 
+    6800     8.121351    54188        0        0      157     5036 
+    6900    8.2467701    55464        0        0      178     6250 
+    7000    8.3776338    54257        0        0      154     5107 
+    7100    8.5222375    55201        0        0      176     4969 
+    7200    8.6558251    53753        0        0      158     4953 
+    7300    8.7743835    54905        0        0      164     5738 
+    7400    8.8977978    53758        0        0      167     5249 
+    7500    9.0152721    54799        0        0      146     5837 
+    7600    9.1362073    53469        0        0      172     4353 
+    7700    9.2526691    54573        0        0      151     5711 
+    7800    9.3747497    53351        0        0      165     4600 
+    7900     9.509835    54172        0        0      170     5289 
+    8000     9.627142    53133        0        0      169     4007 
+    8100    9.7413702    54062        0        0      169     4909 
+    8200    9.8579056    52837        0        0      170     4203 
+    8300    9.9705653    54045        0        0      148     5508 
+    8400    10.086033    52983        0        0      162     4455 
+    8500    10.200596    54146        0        0      159     5626 
+    8600    10.318408    52874        0        0      150     4611 
+    8700      10.4331    54179        0        0      175     6397 
+    8800    10.571224    53355        0        0      141     5104 
+    8900    10.688889    54719        0        0      158     7024 
+    9000    10.808625    53693        0        0      154     5319 
+    9100    10.927642    55085        0        0      135     6073 
+    9200    11.053062    53922        0        0      164     5349 
+    9300    11.173916    55267        0        0      152     5291 
+    9400     11.30089    53870        0        0      152     5319 
+    9500     11.41848    55337        0        0      163     6970 
+    9600    11.561608    54118        0        0      146     5119 
+    9700     11.68267    55337        0        0      165     7012 
+    9800    11.805948    54159        0        0      143     5678 
+    9900    11.929199    55554        0        0      140     4659 
+   10000    12.053887    54006        0        0      147     5092 
+   10100    12.176937    55386        0        0      149     6243 
+   10200    12.300908    54038        0        0      151     4574 
+   10300    12.423551    55128        0        0      133     7465 
+   10400    12.567414    53651        0        0      146     5631 
+Loop time of 12.5675 on 4 procs for 10000 steps with 53651 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 5.2079     | 5.6863     | 6.0939     |  16.6 | 45.25
+Coll    | 0.51836    | 0.60084    | 0.65991    |   7.0 |  4.78
+Sort    | 1.0708     | 1.186      | 1.277      |   7.2 |  9.44
+Comm    | 0.36568    | 0.39716    | 0.42215    |   3.4 |  3.16
+Modify  | 1.9648     | 2.5736     | 3.145      |  26.4 | 20.48
+Output  | 0.0027759  | 0.0045431  | 0.009388   |   4.2 |  0.04
+Other   |            | 2.119      |            |       | 16.86
+
+Particle moves    = 548045240 (548M)
+Cells touched     = 680726911 (681M)
+Particle comms    = 5021034 (5.02M)
+Boundary collides = 1923697 (1.92M)
+Boundary exits    = 1992962 (1.99M)
+SurfColl checks   = 51451467 (51.5M)
+SurfColl occurs   = 1470808 (1.47M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.0902e+07
+Particle-moves/step: 54804.5
+Cell-touches/particle/step: 1.2421
+Particle comm iterations/step: 2.2328
+Particle fraction communicated: 0.00916171
+Particle fraction colliding with boundary: 0.00351011
+Particle fraction exiting boundary: 0.00363649
+Surface-checks/particle/step: 0.0938818
+Surface-collisions/particle/step: 0.00268373
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13412.8 ave 16203 max 11561 min
+Histogram: 1 0 1 1 0 0 0 0 0 1
+Cells:      338.5 ave 339 max 338 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 49 ave 65 max 38 min
+Histogram: 1 0 1 0 1 0 0 0 0 1
+EmptyCell: 35.75 ave 45 max 31 min
+Histogram: 2 0 1 0 0 0 0 0 0 1
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/adapt/log.29Jun21.mpi_4.adapt.slide
+++ b/examples/adapt/log.29Jun21.mpi_4.adapt.slide
@@ -1,0 +1,402 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00108767 secs
+  create/ghost percent = 85.2258 14.7742
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000792503 secs
+  reassign/sort/migrate/ghost percent = 70.3971 0.78219 12.3646 16.4561
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.00100732 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 26.3905 17.7751 0.946746 45.6331 9.25444 17.9645 0.35503
+  surf2grid time = 0.000459671 secs
+  map/comm1/comm2/comm3/comm4/split percent = 27.0747 9.85477 6.06846 4.77178 11.2033 31.2241
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  8 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  92 0 8 = cells outside/inside/overlapping surfs
+  8 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.00079155 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 20.6024 19.1566 0.481928 49.2169 10.5422 19.3976 0.451807
+  surf2grid time = 0.000389576 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.1518 11.3831 8.62913 6.42595 5.14076 34.0269
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 #                    surf one 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75
+#dump_modify	    2 pad 5 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 #                    surf one 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005 grid proc
+#dump_modify	    3 pad 5 scolor * white glinecolor white
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    400
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 1.52409 1.52409 1.52409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.040046453    20886        0        0       43     6594 
+     200   0.12218833    35915        0        0      111    13636 
+     300   0.22572517    43695        0        0      128    17108 
+     400   0.34470248    47726        0        0      131    17878 
+Loop time of 0.344794 on 4 procs for 400 steps with 47726 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.050345   | 0.11821    | 0.18551    |  19.5 | 34.29
+Coll    | 0.0036826  | 0.011284   | 0.01891    |   7.1 |  3.27
+Sort    | 0.011714   | 0.022438   | 0.033139   |   7.1 |  6.51
+Comm    | 0.012436   | 0.013357   | 0.014281   |   0.6 |  3.87
+Modify  | 0.015875   | 0.050188   | 0.084483   |  15.2 | 14.56
+Output  | 0.0001471  | 0.00060529 | 0.001009   |   0.0 |  0.18
+Other   |            | 0.1287     |            |       | 37.33
+
+Particle moves    = 12640175 (12.6M)
+Cells touched     = 13533228 (13.5M)
+Particle comms    = 82449 (82.4K)
+Boundary collides = 44967 (45K)
+Boundary exits    = 36591 (36.6K)
+SurfColl checks   = 4543000 (4.54M)
+SurfColl occurs   = 33424 (33.4K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.16502e+06
+Particle-moves/step: 31600.4
+Cell-touches/particle/step: 1.07065
+Particle comm iterations/step: 2.3575
+Particle fraction communicated: 0.00652277
+Particle fraction colliding with boundary: 0.00355747
+Particle fraction exiting boundary: 0.00289482
+Surface-checks/particle/step: 0.35941
+Surface-collisions/particle/step: 0.00264427
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 11931.5 ave 17370 max 6480 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf 1 200 10000 trans 0 -0.9 0
+fix                 11 move/surf 2 200 10000 trans 0 0.9 0
+
+run 		    10000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 4.05534 3.21159 4.89909
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     400            0    47726        0        0        0        0 
+     500   0.12224531    50048        0        0      136    18718 
+     600   0.25719523    50758        0        0      107     9355 
+     700   0.35652471    52232        0        0      125     7282 
+     800   0.46130228    52487        0        0      126     7828 
+     900   0.58375335    53358        0        0      134     7987 
+    1000   0.69006681    53001        0        0      134     6784 
+    1100   0.79426098    54000        0        0      116     6912 
+    1200   0.90239739    53621        0        0      118     7414 
+    1300     1.007493    54351        0        0      124     8008 
+    1400     1.115231    53932        0        0      108     7007 
+    1500    1.2213104    54988        0        0      141     6231 
+    1600    1.3298173    54405        0        0      127     6034 
+    1700    1.4359279    55074        0        0      114     6277 
+    1800    1.5669539    54495        0        0      122     6233 
+    1900    1.6737852    55184        0        0      132     6568 
+    2000    1.7829077    54567        0        0      123     6451 
+    2100    1.8889189    55288        0        0      123     5943 
+    2200      1.99826    54564        0        0      128     6257 
+    2300    2.1049893    55288        0        0      124     6368 
+    2400    2.2141802    54658        0        0      131     6846 
+    2500    2.3210855    55416        0        0      126     6816 
+    2600    2.4308987    54565        0        0      111     6755 
+    2700    2.5587254    55380        0        0      118     7765 
+    2800    2.6687815    54595        0        0      138     7029 
+    2900    2.7755785    55489        0        0      123     6907 
+    3000    2.8856745    54936        0        0      155     7173 
+    3100    2.9931297    55556        0        0      125     6793 
+    3200    3.1031582    54697        0        0      104     6600 
+    3300    3.2092311    55512        0        0      126     7044 
+    3400    3.3192861    54961        0        0      147     7018 
+    3500    3.4269993    55414        0        0      132     6404 
+    3600    3.5478551    54925        0        0      124     6987 
+    3700    3.6662371    55834        0        0      105     6869 
+    3800    3.7765226    55098        0        0      120     5991 
+    3900    3.8840661    55866        0        0      107     5830 
+    4000    3.9948442    55147        0        0      133     6880 
+    4100      4.10233    55681        0        0      113     6590 
+    4200    4.2124999    54972        0        0      137     6243 
+    4300    4.3198805    55663        0        0      112     6258 
+    4400    4.4301136    54924        0        0      137     6710 
+    4500    4.5373464    55778        0        0      132     6948 
+    4600    4.6687024    55065        0        0      119     7224 
+    4700    4.7763116    55739        0        0      135     7037 
+    4800    4.8873258    55458        0        0      135     7338 
+    4900    4.9952357    56206        0        0      155     6842 
+    5000    5.1070461    55329        0        0      126     6669 
+    5100    5.2151072    55899        0        0      111     6474 
+    5200     5.326014    55157        0        0      132     6884 
+    5300      5.43332    55779        0        0      142     6711 
+    5400    5.5438831    55162        0        0      133     6980 
+    5500     5.672174    55931        0        0      138     6739 
+    5600    5.7830918    55294        0        0      134     6688 
+    5700    5.8908567    55958        0        0      120     6163 
+    5800    6.0010028    55392        0        0      123     6453 
+    5900    6.1082256    56050        0        0      123     6376 
+    6000    6.2193253    55615        0        0      120     6098 
+    6100    6.3268647    56133        0        0      108     5333 
+    6200    6.4375818    55531        0        0      131     6037 
+    6300    6.5459745    55978        0        0      128     6168 
+    6400    6.6779685    55493        0        0      148     6474 
+    6500    6.7857592    56015        0        0      118     6128 
+    6600    6.8972704    55398        0        0      122     5883 
+    6700    7.0050285    55943        0        0      147     6075 
+    6800    7.1161325    55368        0        0      127     6310 
+    6900    7.2235761    55823        0        0      114     6554 
+    7000    7.3339572    55372        0        0      138     6943 
+    7100    7.4422877    56180        0        0      122     6777 
+    7200    7.5538111    55363        0        0      129     6774 
+    7300    7.6822314    55982        0        0      124     6926 
+    7400    7.7935133    55364        0        0      130     6882 
+    7500    7.9019356    56109        0        0      120     6869 
+    7600    8.0138187    55307        0        0      114     6919 
+    7700    8.1221611    55851        0        0      110     6968 
+    7800    8.2340508    55045        0        0      160     7941 
+    7900    8.3418195    55929        0        0      127     7210 
+    8000    8.4538836    54982        0        0      141     8544 
+    8100    8.5622902    55780        0        0      125     7961 
+    8200    8.6956763    54787        0        0      120     8589 
+    8300    8.8034027    55636        0        0      129     8512 
+    8400    8.9150701    54844        0        0      131     8252 
+    8500    9.0223739    55716        0        0      120     7879 
+    8600    9.1334682    55112        0        0      112     7651 
+    8700    9.2419899    55976        0        0      138     7478 
+    8800    9.3552439    55293        0        0      144     7833 
+    8900    9.4643228    56152        0        0      130     7042 
+    9000    9.5768685    55134        0        0      122     7362 
+    9100    9.7069154    55941        0        0      121     6451 
+    9200    9.8187544    55196        0        0      122     7361 
+    9300    9.9272416    55735        0        0      133     7277 
+    9400     10.03876    55184        0        0      126     7309 
+    9500    10.146755    55808        0        0       99     6883 
+    9600    10.258136    55131        0        0      128     6302 
+    9700    10.365586    55896        0        0      131     5671 
+    9800     10.47699    55166        0        0      130     6043 
+    9900    10.584624    55923        0        0      116     5449 
+   10000    10.716335    55433        0        0      144     5828 
+   10100    10.824729    56073        0        0      121     6277 
+   10200    10.938579    55546        0        0      120     7213 
+   10300    11.047203    56201        0        0      149     7383 
+   10400    11.160539    55192        0        0      134     7948 
+Loop time of 11.1606 on 4 procs for 10000 steps with 55192 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 5.4426     | 5.7975     | 6.1402     |  14.0 | 51.95
+Coll    | 0.60194    | 0.60632    | 0.6165     |   0.8 |  5.43
+Sort    | 1.2316     | 1.2389     | 1.2447     |   0.5 | 11.10
+Comm    | 0.37894    | 0.40355    | 0.42471    |   2.8 |  3.62
+Modify  | 2.2049     | 2.5684     | 2.9351     |  22.2 | 23.01
+Output  | 0.0024977  | 0.0039188  | 0.0071666  |   3.0 |  0.04
+Other   |            | 0.542      |            |       |  4.86
+
+Particle moves    = 556381580 (556M)
+Cells touched     = 686039773 (686M)
+Particle comms    = 4951690 (4.95M)
+Boundary collides = 1915642 (1.92M)
+Boundary exits    = 2035527 (2.04M)
+SurfColl checks   = 66800573 (66.8M)
+SurfColl occurs   = 1242735 (1.24M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.24631e+07
+Particle-moves/step: 55638.2
+Cell-touches/particle/step: 1.23304
+Particle comm iterations/step: 2.4305
+Particle fraction communicated: 0.00889981
+Particle fraction colliding with boundary: 0.00344304
+Particle fraction exiting boundary: 0.00365851
+Surface-checks/particle/step: 0.120063
+Surface-collisions/particle/step: 0.0022336
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13798 ave 14113 max 13457 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      282.25 ave 310 max 256 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 45.5 ave 53 max 38 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+EmptyCell: 35.5 ave 37 max 34 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+unfix               10
+unfix               11
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 4.05534 3.21159 4.89909
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+   10400            0    55192        0        0        0        0 
+   10500   0.10815859    55979        0        0      135     6986 
+   10600   0.21865106    56517        0        0      145     7140 
+   10700   0.33112049    56906        0        0      134     7287 
+   10800   0.44349456    56919        0        0      132     7420 
+   10900   0.57670188    56968        0        0      146     7284 
+   11000   0.68959856    56930        0        0      128     7095 
+   11100   0.80221152    56935        0        0      140     7552 
+   11200   0.91551542    57044        0        0      133     7418 
+   11300    1.0288341    57098        0        0      131     6933 
+   11400     1.141484    57078        0        0      133     7245 
+   11500    1.2553906    57154        0        0      143     7581 
+   11600    1.3687668    57256        0        0      128     6732 
+   11700    1.5021362    57251        0        0      128     7326 
+   11800    1.6161191    57324        0        0      133     7097 
+   11900    1.7301092    57362        0        0      129     7183 
+   12000    1.8440938    57174        0        0      147     6826 
+   12100    1.9571402    57166        0        0      142     7485 
+   12200    2.0702164    57079        0        0      132     7360 
+   12300    2.1831479    57128        0        0      133     7678 
+   12400    2.2960787    57173        0        0      114     7224 
+Loop time of 2.29616 on 4 procs for 2000 steps with 57173 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.1067     | 1.2084     | 1.2996     |   8.2 | 52.63
+Coll    | 0.12551    | 0.12648    | 0.12821    |   0.3 |  5.51
+Sort    | 0.2554     | 0.2586     | 0.26453    |   0.7 | 11.26
+Comm    | 0.079666   | 0.082122   | 0.08486    |   0.7 |  3.58
+Modify  | 0.44077    | 0.51014    | 0.58281    |   9.5 | 22.22
+Output  | 0.0004766  | 0.000727   | 0.0013795  |   0.0 |  0.03
+Other   |            | 0.1097     |            |       |  4.78
+
+Particle moves    = 114370466 (114M)
+Cells touched     = 141533550 (142M)
+Particle comms    = 1013881 (1.01M)
+Boundary collides = 389806 (0.39M)
+Boundary exits    = 419123 (0.419M)
+SurfColl checks   = 14233770 (14.2M)
+SurfColl occurs   = 257426 (0.257M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.24524e+07
+Particle-moves/step: 57185.2
+Cell-touches/particle/step: 1.2375
+Particle comm iterations/step: 2.4065
+Particle fraction communicated: 0.00886488
+Particle fraction colliding with boundary: 0.00340827
+Particle fraction exiting boundary: 0.00366461
+Surface-checks/particle/step: 0.124453
+Surface-collisions/particle/step: 0.00225081
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 14293.2 ave 14388 max 14150 min
+Histogram: 1 0 0 0 0 1 0 0 1 1
+Cells:      289 ave 322 max 256 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 45.5 ave 53 max 38 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+EmptyCell: 35.5 ave 37 max 34 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/adapt/log.29Jun21.mpi_4.adapt.static
+++ b/examples/adapt/log.29Jun21.mpi_4.adapt.static
@@ -1,0 +1,414 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around set of circles
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00110078 secs
+  create/ghost percent = 85.6833 14.3167
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000780344 secs
+  reassign/sort/migrate/ghost percent = 70.2108 1.46654 11.0602 17.2625
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+# 7 circles, 4 above, 3 below
+
+read_surf           data.circle origin 5 5 0 trans 1.0 0.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  5.01 6.99 xlo xhi
+  4.51195 6.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  6 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  94 0 6 = cells outside/inside/overlapping surfs
+  6 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000988245 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.9349 15.6574 1.27865 46.3691 10.76 19.0832 0.386007
+  surf2grid time = 0.000458241 secs
+  map/comm1/comm2/comm3/comm4/split percent = 27.8356 8.16857 6.08741 6.2435 11.0302 31.9459
+read_surf           data.circle origin 5 5 0 trans -1.0 1.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  100 lines
+  3.01 4.99 xlo xhi
+  5.51195 7.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  88 0 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.000800371 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.4221 18.588 0.446828 50.2532 11.2898 21.1498 0.446828
+  surf2grid time = 0.000402212 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.2004 10.3142 6.16479 6.4019 5.33491 38.5892
+read_surf           data.circle origin 5 5 0 trans 1.0 2.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  150 lines
+  5.01 6.99 xlo xhi
+  6.51195 8.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  16 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  84 0 16 = cells outside/inside/overlapping surfs
+  16 = surf cells with 1,2,etc splits
+  90.7871 90.7871 = cell-wise and global flow volume
+  CPU time = 0.000783682 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.3794 20.8701 0.456343 44.387 14.9072 20.1704 0.547612
+  surf2grid time = 0.000347853 secs
+  map/comm1/comm2/comm3/comm4/split percent = 13.5709 11.5147 6.10007 8.70459 8.15627 44.7567
+read_surf           data.circle origin 5 5 0 trans -1.0 3.5 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  200 lines
+  3.01 4.99 xlo xhi
+  7.51195 9.48805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  20 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  80 0 20 = cells outside/inside/overlapping surfs
+  20 = surf cells with 1,2,etc splits
+  87.7161 87.7161 = cell-wise and global flow volume
+  CPU time = 0.000828266 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 18.3362 22.1934 0.431779 43.9839 15.0547 20.38 0.489349
+  surf2grid time = 0.000364304 secs
+  map/comm1/comm2/comm3/comm4/split percent = 14.6597 13.7435 4.84293 10.2094 10.0785 38.9398
+
+read_surf           data.circle origin 5 5 0 trans -1.5 -1.8 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  250 lines
+  2.51 4.49 xlo xhi
+  2.21195 4.18805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  28 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  71 1 28 = cells outside/inside/overlapping surfs
+  28 = surf cells with 1,2,etc splits
+  84.6451 84.6451 = cell-wise and global flow volume
+  CPU time = 0.000866413 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 17.4463 24.3258 0.467804 43.6159 14.1442 18.0517 0.412768
+  surf2grid time = 0.000377893 secs
+  map/comm1/comm2/comm3/comm4/split percent = 15.836 13.817 7.50789 4.29022 11.041 40.0631
+read_surf           data.circle origin 5 5 0 trans 0.5 -2.8 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  300 lines
+  4.51 6.49 xlo xhi
+  1.21195 3.18805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  34 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  64 2 34 = cells outside/inside/overlapping surfs
+  34 = surf cells with 1,2,etc splits
+  81.5741 81.5741 = cell-wise and global flow volume
+  CPU time = 0.000945091 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 16.0696 25.3027 0.529768 41.3219 16.776 15.0101 0.479314
+  surf2grid time = 0.00039053 secs
+  map/comm1/comm2/comm3/comm4/split percent = 17.5824 15.812 5.31136 5.73871 12.0269 37.1795
+read_surf           data.circle origin 5 5 0 trans -1.5 -3.8 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  350 lines
+  2.51 4.49 xlo xhi
+  0.211954 2.18805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  38 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  59 3 38 = cells outside/inside/overlapping surfs
+  38 = surf cells with 1,2,etc splits
+  78.5032 78.5032 = cell-wise and global flow volume
+  CPU time = 0.000967979 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 15.7389 24.7537 0.394089 43.2266 15.8867 16.2562 0.46798
+  surf2grid time = 0.000418425 secs
+  map/comm1/comm2/comm3/comm4/split percent = 16.0114 15.8405 6.09687 5.69801 13.5613 36.2393
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.04 #                    surf one 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4 scolor * white glinecolor white
+
+#dump                3 image all 100 image2.*.ppm type type pdiam 0.02 #                    surf one 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005 grid proc
+#dump_modify	    3 pad 4 scolor * white glinecolor white
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0360489 0.0360489 0.0360489
+  total     (ave,min,max) = 1.54984 1.54984 1.54984
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.061030865    19943        0        0      225    48190 
+     200   0.22689557    30860        0        0      355    82914 
+     300   0.41031647    35595        0        0      363    95799 
+     400   0.60779834    37933        0        0      366   100411 
+     500   0.81005883    39293        0        0      394   105475 
+Loop time of 0.810146 on 4 procs for 500 steps with 39293 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.051571   | 0.29406    | 0.59174    |  43.3 | 36.30
+Coll    | 0.0015707  | 0.013835   | 0.02715    |  10.2 |  1.71
+Sort    | 0.0030918  | 0.022581   | 0.04213    |  12.3 |  2.79
+Comm    | 0.01608    | 0.030583   | 0.036353   |   4.8 |  3.77
+Modify  | 0.0055721  | 0.058546   | 0.11229    |  21.3 |  7.23
+Output  | 0.00013185 | 0.00094301 | 0.0016432  |   0.0 |  0.12
+Other   |            | 0.3896     |            |       | 48.09
+
+Particle moves    = 14641690 (14.6M)
+Cells touched     = 15591166 (15.6M)
+Particle comms    = 98057 (98.1K)
+Boundary collides = 59667 (59.7K)
+Boundary exits    = 66089 (66.1K)
+SurfColl checks   = 37770890 (37.8M)
+SurfColl occurs   = 147694 (0.148M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 4.51823e+06
+Particle-moves/step: 29283.4
+Cell-touches/particle/step: 1.06485
+Particle comm iterations/step: 2.856
+Particle fraction communicated: 0.00669711
+Particle fraction colliding with boundary: 0.00407514
+Particle fraction exiting boundary: 0.00451375
+Surface-checks/particle/step: 2.57968
+Surface-collisions/particle/step: 0.0100872
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 9823.25 ave 18119 max 1674 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    350 ave 350 max 350 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+fix                 2 adapt 100 all refine coarsen particle 100 80
+fix                 5 balance 200 1.1 rcb cell
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0360489 0.0360489 0.0360489
+  total     (ave,min,max) = 4.08109 3.23734 4.92484
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    39293        0        0        0        0 
+     600    0.2145896    40174        0        0      390   108008 
+     700   0.36080027    40881        0        0      372    30256 
+     800   0.49593163    41217        0        0      402    23583 
+     900   0.59066057    41601        0        0      375    22640 
+    1000   0.68505979    41827        0        0      345    20985 
+    1100   0.77904081    41952        0        0      350    21421 
+    1200   0.87506247    42060        0        0      403    22149 
+    1300   0.97011662    42176        0        0      390    21903 
+    1400    1.0662453    42402        0        0      400    21429 
+    1500    1.1628923    42316        0        0      432    23213 
+    1600    1.2596045    42602        0        0      405    23320 
+    1700    1.3767149    42548        0        0      401    21490 
+    1800    1.4742429    42484        0        0      412    21466 
+    1900    1.5708246    42438        0        0      383    21119 
+    2000    1.6679654    42390        0        0      397    21342 
+    2100    1.7641127    42561        0        0      427    22316 
+    2200    1.8604548    42575        0        0      418    22276 
+    2300    1.9579616    42904        0        0      381    21696 
+    2400    2.0558209    42782        0        0      404    21573 
+    2500    2.1537664    43050        0        0      414    22541 
+Loop time of 2.15383 on 4 procs for 2000 steps with 43050 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.97978    | 1.1374     | 1.2234     |   8.7 | 52.81
+Coll    | 0.053944   | 0.082127   | 0.11063    |   8.3 |  3.81
+Sort    | 0.12647    | 0.16539    | 0.20516    |   8.3 |  7.68
+Comm    | 0.077713   | 0.086397   | 0.093466   |   2.0 |  4.01
+Modify  | 0.23286    | 0.36958    | 0.50866    |  21.1 | 17.16
+Output  | 0.0004766  | 0.00071812 | 0.0013165  |   0.0 |  0.03
+Other   |            | 0.3123     |            |       | 14.50
+
+Particle moves    = 84555613 (84.6M)
+Cells touched     = 103872582 (104M)
+Particle comms    = 1186427 (1.19M)
+Boundary collides = 318550 (0.319M)
+Boundary exits    = 417242 (0.417M)
+SurfColl checks   = 53307879 (53.3M)
+SurfColl occurs   = 792173 (0.792M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.81457e+06
+Particle-moves/step: 42277.8
+Cell-touches/particle/step: 1.22845
+Particle comm iterations/step: 2.3345
+Particle fraction communicated: 0.0140313
+Particle fraction colliding with boundary: 0.00376734
+Particle fraction exiting boundary: 0.00493453
+Surface-checks/particle/step: 0.630448
+Surface-collisions/particle/step: 0.00936866
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10762.5 ave 13405 max 7531 min
+Histogram: 1 0 1 0 0 0 0 0 0 2
+Cells:      184 ave 184 max 184 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 50 ave 58 max 43 min
+Histogram: 1 0 1 0 0 0 1 0 0 1
+EmptyCell: 32.75 ave 37 max 27 min
+Histogram: 1 0 0 0 0 1 0 0 1 1
+Surfs:    350 ave 350 max 350 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+unfix               2
+unfix               5
+
+run                 3000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.95312 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0360489 0.0360489 0.0360489
+  total     (ave,min,max) = 4.50297 3.23734 4.92484
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2500            0    43050        0        0        0        0 
+    2600  0.097182751    43092        0        0      422    22399 
+    2700   0.22708941    43089        0        0      402    21501 
+    2800   0.32478309    43134        0        0      431    21899 
+    2900    0.4216876    43174        0        0      422    22270 
+    3000   0.51866102    42793        0        0      431    22407 
+    3100   0.61527729    42954        0        0      419    22022 
+    3200   0.71213627    42668        0        0      413    21440 
+    3300   0.80903363    42706        0        0      352    20682 
+    3400   0.90611815    42885        0        0      370    21292 
+    3500    1.0031695    42692        0        0      386    21640 
+    3600    1.0999808    42809        0        0      409    21206 
+    3700    1.2169011    42948        0        0      381    21225 
+    3800    1.3138814    43091        0        0      399    21175 
+    3900    1.4110322    43100        0        0      403    21597 
+    4000    1.5076909    42981        0        0      395    21194 
+    4100    1.6040685    42915        0        0      347    20841 
+    4200    1.7001023    42795        0        0      406    21023 
+    4300     1.796962    42962        0        0      401    21037 
+    4400    1.8943207    42996        0        0      398    21576 
+    4500    1.9911826    42840        0        0      422    21565 
+    4600    2.0877025    43040        0        0      384    21466 
+    4700    2.1847689    43057        0        0      385    22103 
+    4800    2.3019016    43044        0        0      404    21417 
+    4900    2.3988504    43025        0        0      387    21449 
+    5000    2.5026326    43174        0        0      405    21676 
+    5100    2.6078632    43120        0        0      387    21172 
+    5200    2.7051089    42997        0        0      393    20850 
+    5300    2.8024306    42966        0        0      394    21358 
+    5400      2.89996    42902        0        0      391    21207 
+    5500    2.9973884    43070        0        0      381    21692 
+Loop time of 2.99747 on 4 procs for 3000 steps with 43070 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.4747     | 1.6889     | 1.9731     |  15.0 | 56.34
+Coll    | 0.078573   | 0.12702    | 0.16626    |   9.9 |  4.24
+Sort    | 0.19271    | 0.25756    | 0.31304    |   9.8 |  8.59
+Comm    | 0.11703    | 0.12755    | 0.14106    |   2.5 |  4.26
+Modify  | 0.28519    | 0.51524    | 0.72284    |  27.5 | 17.19
+Output  | 0.0012736  | 0.0032201  | 0.0052054  |   2.6 |  0.11
+Other   |            | 0.278      |            |       |  9.27
+
+Particle moves    = 129555516 (130M)
+Cells touched     = 160758736 (161M)
+Particle comms    = 1908828 (1.91M)
+Boundary collides = 485532 (0.486M)
+Boundary exits    = 631717 (0.632M)
+SurfColl checks   = 64361661 (64.4M)
+SurfColl occurs   = 1197906 (1.2M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.08054e+07
+Particle-moves/step: 43185.2
+Cell-touches/particle/step: 1.24085
+Particle comm iterations/step: 2.22
+Particle fraction communicated: 0.0147337
+Particle fraction colliding with boundary: 0.00374768
+Particle fraction exiting boundary: 0.00487603
+Surface-checks/particle/step: 0.496788
+Surface-collisions/particle/step: 0.00924628
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10767.5 ave 13491 max 7602 min
+Histogram: 1 0 1 0 0 0 0 0 1 1
+Cells:      184 ave 184 max 184 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 50 ave 58 max 43 min
+Histogram: 1 0 1 0 0 0 1 0 0 1
+EmptyCell: 32.75 ave 37 max 27 min
+Histogram: 1 0 0 0 0 1 0 0 1 1
+Surfs:    350 ave 350 max 350 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/chem/log.29Jun21.mpi_1.chem
+++ b/examples/chem/log.29Jun21.mpi_1.chem
@@ -1,0 +1,124 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# thermal gas in a 3d box with collisions and chemistry
+# particles reflect off global box boundaries
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 1.0e-5 comm/sort yes
+
+boundary	    rr rr rr
+
+create_box  	    0 0.0001 0 0.0001 0 0.0001
+Created orthogonal box = (0 0 0) to (0.0001 0.0001 0.0001)
+create_grid 	    10 10 10
+Created 1000 child grid cells
+  CPU time = 0.00147676 secs
+  create/ghost percent = 60.9299 39.0701
+
+balance_grid        rcb part
+Balance grid migrated 0 cells
+  CPU time = 0.000541449 secs
+  reassign/sort/migrate/ghost percent = 39.498 0.616469 9.90753 49.978
+
+species		    air.species N2 N
+mixture		    air N2 N vstream 0.0 0.0 0.0 temp 20000.0
+mixture             air N2 frac 1.0
+mixture             air N frac 0.0
+
+global              nrho 7.07043E22
+global              fnum 7.07043E5
+
+collide		    vss air air.vss
+react               tce air.tce
+
+create_particles    air n 10000 twopass
+Created 10000 particles
+  CPU time = 0.00544858 secs
+
+stats		    100
+compute             temp temp
+stats_style	    step cpu np nattempt ncoll nreact c_temp
+
+#dump                2 image all 100 image.*.ppm type type pdiam 3.0e-6 #		    size 512 512 gline yes 0.005
+#dump_modify	    2 pad 4
+
+timestep 	    7.00E-9
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.20129 3.20129 3.20129
+Step CPU Np Natt Ncoll Nreact c_temp 
+       0            0    10000        0        0        0    19907.187 
+     100   0.28261876    10182      976      247        2    18834.437 
+     200   0.56835723    10374     1002      267        6    17994.918 
+     300   0.85835147    10521     1029      220        1    17414.299 
+     400     1.149302    10637     1090      251        0    16741.744 
+     500    1.4410603    10734     1101      261        0    16231.286 
+     600    1.7337618    10846     1116      280        0    15723.758 
+     700    2.0293231    10947     1115      269        1    15332.288 
+     800    2.3241892    11015     1163      267        0    14918.196 
+     900    2.6194901    11089     1146      273        0    14632.622 
+    1000     2.916117    11152     1161      266        4     14284.08 
+Loop time of 2.91614 on 1 procs for 1000 steps with 11152 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 2.429      | 2.429      | 2.429      |   0.0 | 83.29
+Coll    | 0.4058     | 0.4058     | 0.4058     |   0.0 | 13.92
+Sort    | 0.077481   | 0.077481   | 0.077481   |   0.0 |  2.66
+Comm    | 0.00104    | 0.00104    | 0.00104    |   0.0 |  0.04
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00082397 | 0.00082397 | 0.00082397 |   0.0 |  0.03
+Other   |            | 0.002011   |            |       |  0.07
+
+Particle moves    = 10692723 (10.7M)
+Cells touched     = 48096295 (48.1M)
+Particle comms    = 0 (0K)
+Boundary collides = 4156093 (4.16M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 1083368 (1.08M)
+Collide occurs    = 261053 (0.261M)
+Reactions         = 1152 (1.15K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.66674e+06
+Particle-moves/step: 10692.7
+Cell-touches/particle/step: 4.49804
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.388684
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0.101318
+Collisions/particle/step: 0.0244141
+Reactions/particle/step: 0.000107737
+
+Gas reaction tallies:
+  style tce #-of-reactions 45
+  reaction N2 + N2 --> N + N + N2: 767
+  reaction N2 + N --> N + N + N: 385
+
+Particles: 11152 ave 11152 max 11152 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1000 ave 1000 max 1000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/chem/log.29Jun21.mpi_4.chem
+++ b/examples/chem/log.29Jun21.mpi_4.chem
@@ -1,0 +1,125 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# thermal gas in a 3d box with collisions and chemistry
+# particles reflect off global box boundaries
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 1.0e-5 comm/sort yes
+
+boundary	    rr rr rr
+
+create_box  	    0 0.0001 0 0.0001 0 0.0001
+Created orthogonal box = (0 0 0) to (0.0001 0.0001 0.0001)
+create_grid 	    10 10 10
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 1000 child grid cells
+  CPU time = 0.00114107 secs
+  create/ghost percent = 83.598 16.402
+
+balance_grid        rcb part
+Balance grid migrated 740 cells
+  CPU time = 0.00139475 secs
+  reassign/sort/migrate/ghost percent = 49.5897 0.205128 15.7949 34.4103
+
+species		    air.species N2 N
+mixture		    air N2 N vstream 0.0 0.0 0.0 temp 20000.0
+mixture             air N2 frac 1.0
+mixture             air N frac 0.0
+
+global              nrho 7.07043E22
+global              fnum 7.07043E5
+
+collide		    vss air air.vss
+react               tce air.tce
+
+create_particles    air n 10000 twopass
+Created 10000 particles
+  CPU time = 0.0023191 secs
+
+stats		    100
+compute             temp temp
+stats_style	    step cpu np nattempt ncoll nreact c_temp
+
+#dump                2 image all 100 image.*.ppm type type pdiam 3.0e-6 #		    size 512 512 gline yes 0.005
+#dump_modify	    2 pad 4
+
+timestep 	    7.00E-9
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.20129 3.20129 3.20129
+Step CPU Np Natt Ncoll Nreact c_temp 
+       0            0    10000        0        0        0    19847.392 
+     100  0.089853048    10175      960      244        1    18855.628 
+     200   0.17986631    10336     1036      274        1    18069.422 
+     300   0.27047372    10504     1031      273        2    17268.684 
+     400   0.36266732    10639     1069      249        1    16754.061 
+     500   0.45473456    10765     1104      258        1     16207.18 
+     600   0.54700089    10863     1114      268        3    15714.254 
+     700    0.6394558    10957     1129      276        0    15269.964 
+     800   0.73232245    11023     1167      253        1    14992.176 
+     900   0.82516551    11096     1185      264        2    14542.509 
+    1000   0.94165802    11173     1169      273        0    14256.889 
+Loop time of 0.94174 on 4 procs for 1000 steps with 11173 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.62847    | 0.63994    | 0.66218    |   1.6 | 67.95
+Coll    | 0.10248    | 0.10339    | 0.10416    |   0.2 | 10.98
+Sort    | 0.022933   | 0.023164   | 0.023502   |   0.1 |  2.46
+Comm    | 0.11019    | 0.11314    | 0.11487    |   0.5 | 12.01
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00054407 | 0.00062519 | 0.00084424 |   0.0 |  0.07
+Other   |            | 0.06147    |            |       |  6.53
+
+Particle moves    = 10695046 (10.7M)
+Cells touched     = 48629805 (48.6M)
+Particle comms    = 2633328 (2.63M)
+Boundary collides = 4153276 (4.15M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 1083829 (1.08M)
+Collide occurs    = 261154 (0.261M)
+Reactions         = 1173 (1.17K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.83917e+06
+Particle-moves/step: 10695
+Cell-touches/particle/step: 4.54695
+Particle comm iterations/step: 2.995
+Particle fraction communicated: 0.246219
+Particle fraction colliding with boundary: 0.388336
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0.101339
+Collisions/particle/step: 0.0244182
+Reactions/particle/step: 0.000109677
+
+Gas reaction tallies:
+  style tce #-of-reactions 45
+  reaction N2 + N2 --> N + N + N2: 770
+  reaction N2 + N --> N + N + N: 403
+
+Particles: 2793.25 ave 2873 max 2705 min
+Histogram: 1 0 0 0 1 0 1 0 0 1
+Cells:      250 ave 250 max 250 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 172.5 ave 240 max 110 min
+Histogram: 1 0 0 0 2 0 0 0 0 1
+EmptyCell: 62.5 ave 130 max 0 min
+Histogram: 1 0 0 0 2 0 0 0 0 1

--- a/examples/circle/log.29Jun21.mpi_1.circle
+++ b/examples/circle/log.29Jun21.mpi_1.circle
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00110292 secs
+  create/ghost percent = 75.227 24.773
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000285387 secs
+  reassign/sort/migrate/ghost percent = 44.528 1.83793 17.3768 36.2573
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000857115 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 22.2531 6.7872 1.91933 54.9652 14.0751 8.9847 0.0278164
+  surf2grid time = 0.000471115 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41.5992 8.40081 14.5749 3.39069 12.247 15.7389
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.062307119    19734        0        0      115     4277 
+     200   0.20585442    31409        0        0      167     6312 
+     300   0.38611889    36779        0        0      181     7702 
+     400   0.58230805    39635        0        0      191     7989 
+     500   0.79324436    41221        0        0      181     8208 
+     600    1.0047901    42136        0        0      194     8631 
+     700    1.2199202    42729        0        0      170     8110 
+     800    1.4371688    43118        0        0      190     8615 
+     900    1.6563129    43309        0        0      203     8253 
+    1000    1.8805072    43387        0        0      181     8370 
+Loop time of 1.88053 on 1 procs for 1000 steps with 43387 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.3522     | 1.3522     | 1.3522     |   0.0 | 71.90
+Coll    | 0.17488    | 0.17488    | 0.17488    |   0.0 |  9.30
+Sort    | 0.2179     | 0.2179     | 0.2179     |   0.0 | 11.59
+Comm    | 0.006896   | 0.006896   | 0.006896   |   0.0 |  0.37
+Modify  | 0.12634    | 0.12634    | 0.12634    |   0.0 |  6.72
+Output  | 0.000211   | 0.000211   | 0.000211   |   0.0 |  0.01
+Other   |            | 0.00215    |            |       |  0.11
+
+Particle moves    = 36515440 (36.5M)
+Cells touched     = 41357244 (41.4M)
+Particle comms    = 0 (0K)
+Boundary collides = 171829 (0.172M)
+Boundary exits    = 167336 (0.167M)
+SurfColl checks   = 7237851 (7.24M)
+SurfColl occurs   = 173634 (0.174M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.94177e+07
+Particle-moves/step: 36515.4
+Cell-touches/particle/step: 1.1326
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00470565
+Particle fraction exiting boundary: 0.00458261
+Surface-checks/particle/step: 0.198213
+Surface-collisions/particle/step: 0.00475508
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 43387 ave 43387 max 43387 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/circle/log.29Jun21.mpi_1.circle.distributed
+++ b/examples/circle/log.29Jun21.mpi_1.circle.distributed
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes surfs explicit/distributed
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00115514 secs
+  create/ghost percent = 76.4293 23.5707
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000355721 secs
+  reassign/sort/migrate/ghost percent = 57.9759 1.13941 10.8579 30.0268
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00102568 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 13.0404 12.3199 1.69689 59.8326 13.1102 6.39238 0.023245
+  surf2grid time = 0.000613689 secs
+  map/comm1/comm2/comm3/comm4/split percent = 32.129 5.28361 10.8392 2.60295 33.411 12.704
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00991821 0.00991821 0.00991821
+  total     (ave,min,max) = 1.52371 1.52371 1.52371
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.062927008    19734        0        0      115     4277 
+     200   0.20228744    31409        0        0      167     6312 
+     300   0.38359785    36779        0        0      181     7702 
+     400   0.58048058    39635        0        0      191     7989 
+     500   0.79304481    41221        0        0      181     8208 
+     600    1.0054266    42136        0        0      194     8631 
+     700    1.2208309    42729        0        0      170     8110 
+     800    1.4388247    43118        0        0      190     8615 
+     900    1.6583755    43309        0        0      203     8253 
+    1000    1.8831284    43387        0        0      181     8370 
+Loop time of 1.88315 on 1 procs for 1000 steps with 43387 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.358      | 1.358      | 1.358      |   0.0 | 72.12
+Coll    | 0.17362    | 0.17362    | 0.17362    |   0.0 |  9.22
+Sort    | 0.21569    | 0.21569    | 0.21569    |   0.0 | 11.45
+Comm    | 0.0069828  | 0.0069828  | 0.0069828  |   0.0 |  0.37
+Modify  | 0.12627    | 0.12627    | 0.12627    |   0.0 |  6.71
+Output  | 0.00020719 | 0.00020719 | 0.00020719 |   0.0 |  0.01
+Other   |            | 0.002337   |            |       |  0.12
+
+Particle moves    = 36515440 (36.5M)
+Cells touched     = 41357244 (41.4M)
+Particle comms    = 0 (0K)
+Boundary collides = 171829 (0.172M)
+Boundary exits    = 167336 (0.167M)
+SurfColl checks   = 7237851 (7.24M)
+SurfColl occurs   = 173634 (0.174M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.93906e+07
+Particle-moves/step: 36515.4
+Cell-touches/particle/step: 1.1326
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00470565
+Particle fraction exiting boundary: 0.00458261
+Surface-checks/particle/step: 0.198213
+Surface-collisions/particle/step: 0.00475508
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 43387 ave 43387 max 43387 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/circle/log.29Jun21.mpi_1.circle.transparent
+++ b/examples/circle/log.29Jun21.mpi_1.circle.transparent
@@ -1,0 +1,184 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle with transparent surfaces in front to tally stats
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000941992 secs
+  create/ghost percent = 84.5609 15.4391
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000158072 secs
+  reassign/sort/migrate/ghost percent = 59.1252 1.65913 20.6637 18.552
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+# data.circle = regular surface particles flow around
+# data.plane1 = line segment with normal into flow
+# data.plane2 = line segment with normal towards circle
+# the two line segments are on top of each other
+
+read_surf           data.circle group circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000649452 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.2129 9.98532 0.991189 51.395 7.41557 6.68135 0.0367107
+  surf2grid time = 0.000333786 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41 11.7143 8.07143 3.92857 14.9286 16.7143
+read_surf           data.plane1 group plane1 transparent
+  2 points
+  51 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000415087 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 11.143 9.82194 1.03389 64.0437 13.9575 9.7645 0.0574383
+  surf2grid time = 0.000265837 secs
+  map/comm1/comm2/comm3/comm4/split percent = 44.6637 13.3632 9.86547 7.53363 5.38117 17.13
+read_surf           data.plane2 group plane2 transparent
+  2 points
+  52 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00030303 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 16.0504 13.3753 1.41621 54.9961 14.1621 10.7002 0.0786782
+  surf2grid time = 0.000166655 secs
+  map/comm1/comm2/comm3/comm4/split percent = 36.7668 12.3033 9.87124 3.86266 10.7296 23.0329
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_collide	    2 transparent
+
+surf_modify         circle collide 1
+surf_modify         plane1 collide 2
+surf_modify         plane2 collide 2
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+compute             plane1 surf plane1 all n ke
+compute             plane2 surf plane2 all n ke
+fix                 plane1 ave/surf plane1 1 100 100 c_plane1[*]
+fix                 plane2 ave/surf plane2 1 100 100 c_plane2[*]
+compute             reduce reduce sum f_plane1[*] f_plane2[*]
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+# the last 4 columns are the particle count and energy flux
+# through the 2 transparent surfaces in front of the circle
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck c_reduce[*]
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00535583 0.00535583 0.00535583
+  total     (ave,min,max) = 1.52074 1.52074 1.52074
+Step CPU Np Natt Ncoll Nscoll Nscheck c_reduce[1] c_reduce[2] c_reduce[3] c_reduce[4] 
+       0            0        0        0        0        0        0            0            0            0            0 
+     100  0.092370987    19683        0        0      308    32858        93.68 1.3832091e-18        19.45 3.614087e-19 
+     200   0.29774642    31429        0        0      346    44092       124.48 1.7101534e-18        58.87 9.2036692e-19 
+     300    0.5622201    36894        0        0      409    49888       125.73 1.711686e-18        73.33 1.0661136e-18 
+     400   0.85625315    39641        0        0      426    52518       126.85  1.73557e-18        81.26 1.1617336e-18 
+     500      1.15765    41078        0        0      405    53554       126.01 1.7343079e-18        83.73 1.1731557e-18 
+     600    1.4661674    42009        0        0      410    54676       127.12 1.7285525e-18        84.77 1.1857523e-18 
+     700     1.781172    42471        0        0      421    55576       125.38 1.690651e-18         87.6 1.2014302e-18 
+     800    2.1013744    43002        0        0      414    56478       127.54 1.7414969e-18        85.73 1.1634047e-18 
+     900    2.4214697    43322        0        0      394    56676       127.25 1.7465237e-18        87.71 1.2039211e-18 
+    1000     2.743084    43496        0        0      408    56716       126.78 1.7449034e-18        87.03 1.176422e-18 
+Loop time of 2.7431 on 1 procs for 1000 steps with 43496 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 2.24       | 2.24       | 2.24       |   0.0 | 81.66
+Coll    | 0.16186    | 0.16186    | 0.16186    |   0.0 |  5.90
+Sort    | 0.20367    | 0.20367    | 0.20367    |   0.0 |  7.42
+Comm    | 0.006881   | 0.006881   | 0.006881   |   0.0 |  0.25
+Modify  | 0.12759    | 0.12759    | 0.12759    |   0.0 |  4.65
+Output  | 0.00027013 | 0.00027013 | 0.00027013 |   0.0 |  0.01
+Other   |            | 0.002861   |            |       |  0.10
+
+Particle moves    = 36496203 (36.5M)
+Cells touched     = 38783299 (38.8M)
+Particle comms    = 0 (0K)
+Boundary collides = 171863 (0.172M)
+Boundary exits    = 167194 (0.167M)
+SurfColl checks   = 48756382 (48.8M)
+SurfColl occurs   = 371193 (0.371M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.33047e+07
+Particle-moves/step: 36496.2
+Cell-touches/particle/step: 1.06267
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00470907
+Particle fraction exiting boundary: 0.00458113
+Surface-checks/particle/step: 1.33593
+Surface-collisions/particle/step: 0.0101707
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 43496 ave 43496 max 43496 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    52 ave 52 max 52 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/circle/log.29Jun21.mpi_4.circle
+++ b/examples/circle/log.29Jun21.mpi_4.circle
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00110173 secs
+  create/ghost percent = 84.5488 15.4512
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000946283 secs
+  reassign/sort/migrate/ghost percent = 64.651 1.10859 14.3613 19.8791
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00104356 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 24.5145 12.3372 0.959561 49.6916 12.4971 16.244 0.434087
+  surf2grid time = 0.00051856 secs
+  map/comm1/comm2/comm3/comm4/split percent = 27.7701 7.95402 7.86207 5.33333 9.88506 30.9885
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.056338549    19726        0        0      110     4139 
+     200   0.12325501    31416        0        0      177     6661 
+     300    0.2033689    36914        0        0      179     7156 
+     400   0.28940415    39533        0        0      197     8003 
+     500   0.37827516    41089        0        0      205     8212 
+     600   0.47119761    42039        0        0      159     8099 
+     700   0.56517005    42715        0        0      186     8545 
+     800   0.65763354    43093        0        0      203     8658 
+     900   0.75073314    43246        0        0      169     8319 
+    1000   0.84447551    43518        0        0      183     8665 
+Loop time of 0.84454 on 4 procs for 1000 steps with 43518 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14077    | 0.35114    | 0.56562    |  35.4 | 41.58
+Coll    | 0.01191    | 0.03445    | 0.056961   |  12.1 |  4.08
+Sort    | 0.032406   | 0.067953   | 0.1042     |  13.1 |  8.05
+Comm    | 0.022781   | 0.02476    | 0.026595   |   0.9 |  2.93
+Modify  | 0.0004375  | 0.034241   | 0.068264   |  18.3 |  4.05
+Output  | 0.00026655 | 0.00097877 | 0.001508   |   0.0 |  0.12
+Other   |            | 0.331      |            |       | 39.19
+
+Particle moves    = 36496435 (36.5M)
+Cells touched     = 41340925 (41.3M)
+Particle comms    = 141471 (0.141M)
+Boundary collides = 172486 (0.172M)
+Boundary exits    = 167316 (0.167M)
+SurfColl checks   = 7199637 (7.2M)
+SurfColl occurs   = 173143 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.08036e+07
+Particle-moves/step: 36496.4
+Cell-touches/particle/step: 1.13274
+Particle comm iterations/step: 1.997
+Particle fraction communicated: 0.0038763
+Particle fraction colliding with boundary: 0.00472611
+Particle fraction exiting boundary: 0.00458445
+Surface-checks/particle/step: 0.19727
+Surface-collisions/particle/step: 0.00474411
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10879.5 ave 16762 max 4993 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/circle/log.29Jun21.mpi_4.circle.distributed
+++ b/examples/circle/log.29Jun21.mpi_4.circle.distributed
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes surfs explicit/distributed
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00111842 secs
+  create/ghost percent = 83.8414 16.1586
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000951529 secs
+  reassign/sort/migrate/ghost percent = 64.1193 1.22776 15.5099 19.1431
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00127316 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 17.8464 22.0225 1.1236 50.0187 8.98876 20.6554 0.149813
+  surf2grid time = 0.000636816 secs
+  map/comm1/comm2/comm3/comm4/split percent = 23.3246 6.17746 5.72819 3.25721 15.4998 39.723
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00262833 0.00257874 0.00267792
+  total     (ave,min,max) = 1.51642 1.51637 1.51647
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.036997557    19726        0        0      110     4139 
+     200   0.12815118    31416        0        0      177     6661 
+     300   0.20880771    36914        0        0      179     7156 
+     400   0.29521561    39533        0        0      197     8003 
+     500   0.38441086    41089        0        0      205     8212 
+     600   0.47770572    42039        0        0      159     8099 
+     700   0.57274032    42715        0        0      186     8545 
+     800   0.66675115    43093        0        0      203     8658 
+     900   0.76049614    43246        0        0      169     8319 
+    1000   0.85499406    43518        0        0      183     8665 
+Loop time of 0.855078 on 4 procs for 1000 steps with 43518 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14124    | 0.35305    | 0.56083    |  34.7 | 41.29
+Coll    | 0.011985   | 0.034358   | 0.056743   |  12.1 |  4.02
+Sort    | 0.03392    | 0.069217   | 0.10617    |  13.1 |  8.09
+Comm    | 0.023001   | 0.033348   | 0.041603   |   4.2 |  3.90
+Modify  | 0.0004735  | 0.034357   | 0.068237   |  18.3 |  4.02
+Output  | 0.00027585 | 0.0011558  | 0.001677   |   1.7 |  0.14
+Other   |            | 0.3296     |            |       | 38.55
+
+Particle moves    = 36496435 (36.5M)
+Cells touched     = 41340925 (41.3M)
+Particle comms    = 141471 (0.141M)
+Boundary collides = 172486 (0.172M)
+Boundary exits    = 167316 (0.167M)
+SurfColl checks   = 7199637 (7.2M)
+SurfColl occurs   = 173143 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.06705e+07
+Particle-moves/step: 36496.4
+Cell-touches/particle/step: 1.13274
+Particle comm iterations/step: 1.997
+Particle fraction communicated: 0.0038763
+Particle fraction colliding with boundary: 0.00472611
+Particle fraction exiting boundary: 0.00458445
+Surface-checks/particle/step: 0.19727
+Surface-collisions/particle/step: 0.00474411
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10879.5 ave 16762 max 4993 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    14 ave 14 max 14 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/circle/log.29Jun21.mpi_4.circle.transparent
+++ b/examples/circle/log.29Jun21.mpi_4.circle.transparent
@@ -1,0 +1,185 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle with transparent surfaces in front to tally stats
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00108886 secs
+  create/ghost percent = 85.1982 14.8018
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000794411 secs
+  reassign/sort/migrate/ghost percent = 71.3085 1.32053 11.0144 16.3565
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+# data.circle = regular surface particles flow around
+# data.plane1 = line segment with normal into flow
+# data.plane2 = line segment with normal towards circle
+# the two line segments are on top of each other
+
+read_surf           data.circle group circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00100613 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.8294 17.2986 0.781991 47.7488 8.34123 17.5592 0.379147
+  surf2grid time = 0.000480413 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.8983 10.9181 5.55831 5.26055 10.2233 30.9181
+read_surf           data.plane1 group plane1 transparent
+  2 points
+  51 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000654936 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 13.7241 19.2938 0.54605 56.1704 10.2657 26.4652 0.43684
+  surf2grid time = 0.00036788 secs
+  map/comm1/comm2/comm3/comm4/split percent = 27.6734 14.906 7.19378 6.67531 3.56448 33.4413
+read_surf           data.plane2 group plane2 transparent
+  2 points
+  52 lines
+  1 1 xlo xhi
+  2 8 ylo yhi
+  0 0 zlo zhi
+  6 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000551462 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 17.3368 23.5625 0.648508 45.8279 12.6243 26.3294 0.734976
+  surf2grid time = 0.000252724 secs
+  map/comm1/comm2/comm3/comm4/split percent = 16.9811 9.5283 5.18868 4.5283 5.28302 48.7736
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_collide	    2 transparent
+
+surf_modify         circle collide 1
+surf_modify         plane1 collide 2
+surf_modify         plane2 collide 2
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+compute             plane1 surf plane1 all n ke
+compute             plane2 surf plane2 all n ke
+fix                 plane1 ave/surf plane1 1 100 100 c_plane1[*]
+fix                 plane2 ave/surf plane2 1 100 100 c_plane2[*]
+compute             reduce reduce sum f_plane1[*] f_plane2[*]
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+# the last 4 columns are the particle count and energy flux
+# through the 2 transparent surfaces in front of the circle
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck c_reduce[*]
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00535583 0.00535583 0.00535583
+  total     (ave,min,max) = 1.51955 1.51955 1.51955
+Step CPU Np Natt Ncoll Nscoll Nscheck c_reduce[1] c_reduce[2] c_reduce[3] c_reduce[4] 
+       0            0        0        0        0        0        0            0            0            0            0 
+     100  0.053400278    19655        0        0      276    32494        93.31 1.3870683e-18        19.48 3.617676e-19 
+     200   0.15592861    31394        0        0      360    44088        124.7 1.7168066e-18        59.78 9.3525328e-19 
+     300   0.29835367    36938        0        0      402    49624       126.31 1.7292708e-18        73.33 1.0666237e-18 
+     400   0.43055367    39610        0        0      406    51826       124.94 1.7164186e-18        80.51 1.1407191e-18 
+     500    0.5675621    41002        0        0      425    53658       126.62 1.7204408e-18        82.41 1.1637699e-18 
+     600   0.70760989    41836        0        0      435    55020       126.44 1.727892e-18           86 1.1825236e-18 
+     700   0.85330057    42728        0        0      418    55930       126.67 1.7353579e-18        85.24 1.1692472e-18 
+     800   0.99620223    42922        0        0      432    55806        126.3 1.7362205e-18        86.74 1.194088e-18 
+     900    1.1400828    43261        0        0      418    56138       125.65 1.7308917e-18        86.41 1.1928741e-18 
+    1000    1.3044896    43411        0        0      400    56476        126.1 1.7174983e-18        87.49 1.2047575e-18 
+Loop time of 1.30458 on 4 procs for 1000 steps with 43411 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14508    | 0.57802    | 1.0199     |  56.9 | 44.31
+Coll    | 0.010016   | 0.035991   | 0.066251   |  13.7 |  2.76
+Sort    | 0.031093   | 0.062159   | 0.093111   |  12.4 |  4.76
+Comm    | 0.026232   | 0.033266   | 0.037976   |   2.4 |  2.55
+Modify  | 0.0027246  | 0.036062   | 0.069713   |  17.5 |  2.76
+Output  | 0.00042653 | 0.00052714 | 0.00080919 |   0.0 |  0.04
+Other   |            | 0.5586     |            |       | 42.82
+
+Particle moves    = 36448356 (36.4M)
+Cells touched     = 38734588 (38.7M)
+Particle comms    = 141438 (0.141M)
+Boundary collides = 172143 (0.172M)
+Boundary exits    = 167301 (0.167M)
+SurfColl checks   = 48567500 (48.6M)
+SurfColl occurs   = 370334 (0.37M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 6.98469e+06
+Particle-moves/step: 36448.4
+Cell-touches/particle/step: 1.06273
+Particle comm iterations/step: 1.998
+Particle fraction communicated: 0.0038805
+Particle fraction colliding with boundary: 0.00472293
+Particle fraction exiting boundary: 0.00459008
+Surface-checks/particle/step: 1.3325
+Surface-collisions/particle/step: 0.0101605
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10852.8 ave 16761 max 4952 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    52 ave 52 max 52 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/collide/log.28Jun21.mpi_1.collideInterspecies
+++ b/examples/collide/log.28Jun21.mpi_1.collideInterspecies
@@ -1,0 +1,118 @@
+SPARTA (26 Feb 2021)
+# thermal gas in a 3d box with collisions
+# particles reflect off global box boundaries
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 1.0e-5 comm/sort yes
+
+boundary	    rr rr rr
+
+create_box  	    0 0.0001 0 0.0001 0 0.0001
+Created orthogonal box = (0 0 0) to (0.0001 0.0001 0.0001)
+create_grid 	    10 10 10
+Created 1000 child grid cells
+  CPU time = 0.00147724 secs
+  create/ghost percent = 59.1672 40.8328
+
+balance_grid        rcb part
+Balance grid migrated 0 cells
+  CPU time = 0.000566006 secs
+  reassign/sort/migrate/ghost percent = 32.9402 0.589722 9.43555 57.0345
+
+species		    6SpeciesAir.species N2 O2 NO N O Ar
+mixture		    air O2 N2 O N vstream 0.0 0.0 0.0 temp 273.1
+mixture		    air O2 frac 0.21
+mixture		    air N2  frac 0.78
+mixture		    air O
+mixture		    air N
+mixture	            air NO
+mixture		    air Ar frac 0.009
+
+
+global              nrho 7.07043E22
+global              fnum 7.07043E6
+
+collide		    vss air 6SpeciesAirII.vss
+
+create_particles    air n 10000
+Created 10000 particles
+  CPU time = 0.00545454 secs
+
+stats		    100
+compute             temp temp
+stats_style	    step cpu np nattempt ncoll c_temp
+
+#compute             1 grid all n
+#region              slab block INF INF INF INF 4.5e-5 5.5e-5
+#dump                2 image all 100 image.*.ppm type type pdiam 3.0e-6 #		    size 512 512 gline yes 0.005 gridx 0.00005 c_1[1]
+#dump_modify	    2 pad 4 region slab
+
+timestep 	    7.00E-9
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.20129 3.20129 3.20129
+Step CPU Np Natt Ncoll c_temp 
+       0            0    10000        0        0    274.39367 
+     100   0.11361766    10000     1435      711    271.74196 
+     200   0.22894788    10000     1459      753    272.78373 
+     300   0.34431267    10000     1434      734    273.35532 
+     400   0.45965672    10000     1467      745    272.68149 
+     500   0.57513618    10000     1460      709    275.31504 
+     600   0.69206214    10000     1450      704    271.90587 
+     700   0.80824852    10000     1454      696    273.96156 
+     800   0.92430043    10000     1476      716    273.66599 
+     900    1.0402892    10000     1483      702    273.56631 
+    1000    1.1564529    10000     1500      685    275.08909 
+Loop time of 1.15647 on 1 procs for 1000 steps with 10000 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.4415     | 0.4415     | 0.4415     |   0.0 | 38.18
+Coll    | 0.64469    | 0.64469    | 0.64469    |   0.0 | 55.75
+Sort    | 0.066432   | 0.066432   | 0.066432   |   0.0 |  5.74
+Comm    | 0.0010109  | 0.0010109  | 0.0010109  |   0.0 |  0.09
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00073862 | 0.00073862 | 0.00073862 |   0.0 |  0.06
+Other   |            | 0.00209    |            |       |  0.18
+
+Particle moves    = 10000000 (10M)
+Cells touched     = 14233052 (14.2M)
+Particle comms    = 0 (0K)
+Boundary collides = 470235 (0.47M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 1458692 (1.46M)
+Collide occurs    = 717791 (0.718M)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 8.64704e+06
+Particle-moves/step: 10000
+Cell-touches/particle/step: 1.42331
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0470235
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0.145869
+Collisions/particle/step: 0.0717791
+Reactions/particle/step: 0
+
+Particles: 10000 ave 10000 max 10000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1000 ave 1000 max 1000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/collide/log.28Jun21.mpi_4.collideInterspecies
+++ b/examples/collide/log.28Jun21.mpi_4.collideInterspecies
@@ -1,0 +1,119 @@
+SPARTA (26 Feb 2021)
+# thermal gas in a 3d box with collisions
+# particles reflect off global box boundaries
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 1.0e-5 comm/sort yes
+
+boundary	    rr rr rr
+
+create_box  	    0 0.0001 0 0.0001 0 0.0001
+Created orthogonal box = (0 0 0) to (0.0001 0.0001 0.0001)
+create_grid 	    10 10 10
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 1000 child grid cells
+  CPU time = 0.00113106 secs
+  create/ghost percent = 84.6543 15.3457
+
+balance_grid        rcb part
+Balance grid migrated 740 cells
+  CPU time = 0.00141406 secs
+  reassign/sort/migrate/ghost percent = 50.177 0.219187 14.871 34.7328
+
+species		    6SpeciesAir.species N2 O2 NO N O Ar
+mixture		    air O2 N2 O N vstream 0.0 0.0 0.0 temp 273.1
+mixture		    air O2 frac 0.21
+mixture		    air N2  frac 0.78
+mixture		    air O
+mixture		    air N
+mixture	            air NO
+mixture		    air Ar frac 0.009
+
+
+global              nrho 7.07043E22
+global              fnum 7.07043E6
+
+collide		    vss air 6SpeciesAirII.vss
+
+create_particles    air n 10000
+Created 10000 particles
+  CPU time = 0.00231671 secs
+
+stats		    100
+compute             temp temp
+stats_style	    step cpu np nattempt ncoll c_temp
+
+#compute             1 grid all n
+#region              slab block INF INF INF INF 4.5e-5 5.5e-5
+#dump                2 image all 100 image.*.ppm type type pdiam 3.0e-6 #		    size 512 512 gline yes 0.005 gridx 0.00005 c_1[1]
+#dump_modify	    2 pad 4 region slab
+
+timestep 	    7.00E-9
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.20129 3.20129 3.20129
+Step CPU Np Natt Ncoll c_temp 
+       0            0    10000        0        0    275.21388 
+     100  0.034012318    10000     1428      714    276.65152 
+     200  0.067716122    10000     1439      718    274.72851 
+     300   0.12093854    10000     1461      703    274.07602 
+     400   0.15464449    10000     1461      729    275.23518 
+     500   0.18829966    10000     1481      736    273.33716 
+     600   0.22177005    10000     1494      726    274.96554 
+     700   0.25551105    10000     1482      697    274.08038 
+     800   0.28942013    10000     1462      701    273.46866 
+     900   0.32304144    10000     1489      715    274.05981 
+    1000   0.35674644    10000     1517      704    275.38063 
+Loop time of 0.356794 on 4 procs for 1000 steps with 10000 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.1137     | 0.11411    | 0.11463    |   0.1 | 31.98
+Coll    | 0.16607    | 0.17116    | 0.18413    |   1.8 | 47.97
+Sort    | 0.019542   | 0.019872   | 0.02028    |   0.2 |  5.57
+Comm    | 0.018317   | 0.01875    | 0.019224   |   0.3 |  5.26
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.0004611  | 0.00060785 | 0.00085568 |   0.0 |  0.17
+Other   |            | 0.03229    |            |       |  9.05
+
+Particle moves    = 10000000 (10M)
+Cells touched     = 14245651 (14.2M)
+Particle comms    = 312077 (0.312M)
+Boundary collides = 471806 (0.472M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 1458735 (1.46M)
+Collide occurs    = 719983 (0.72M)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 7.00684e+06
+Particle-moves/step: 10000
+Cell-touches/particle/step: 1.42457
+Particle comm iterations/step: 1
+Particle fraction communicated: 0.0312077
+Particle fraction colliding with boundary: 0.0471806
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0.145873
+Collisions/particle/step: 0.0719983
+Reactions/particle/step: 0
+
+Particles: 2500 ave 2527 max 2432 min
+Histogram: 1 0 0 0 0 0 0 0 1 2
+Cells:      250 ave 250 max 250 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 172.5 ave 240 max 110 min
+Histogram: 1 0 0 0 2 0 0 0 0 1
+EmptyCell: 62.5 ave 130 max 0 min
+Histogram: 1 0 0 0 2 0 0 0 0 1

--- a/examples/emit/log.29Jun21.mpi_1.emit.face
+++ b/examples/emit/log.29Jun21.mpi_1.emit.face
@@ -1,0 +1,128 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from box face towards circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000963449 secs
+  create/ghost percent = 84.7068 15.2932
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000161886 secs
+  reassign/sort/migrate/ghost percent = 59.9411 1.62003 20.0295 18.4094
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000667572 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.6786 10.1786 1 50.8214 7.32143 6.67857 0.0357143
+  surf2grid time = 0.00033927 secs
+  map/comm1/comm2/comm3/comm4/split percent = 39.9859 12.5088 8.29234 3.86507 15.1089 16.5847
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0090959072     3512        0        0        2      198 
+     200   0.03111577     7010        0        0        3     1990 
+     300  0.069559574    10394        0        0       17     4464 
+Loop time of 0.0695717 on 1 procs for 300 steps with 10394 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.049391   | 0.049391   | 0.049391   |   0.0 | 70.99
+Coll    | 0.0041673  | 0.0041673  | 0.0041673  |   0.0 |  5.99
+Sort    | 0.0077426  | 0.0077426  | 0.0077426  |   0.0 | 11.13
+Comm    | 0.00016928 | 0.00016928 | 0.00016928 |   0.0 |  0.24
+Modify  | 0.0077024  | 0.0077024  | 0.0077024  |   0.0 | 11.07
+Output  | 4.4346e-05 | 4.4346e-05 | 4.4346e-05 |   0.0 |  0.06
+Other   |            | 0.000355   |            |       |  0.51
+
+Particle moves    = 1580484 (1.58M)
+Cells touched     = 1600127 (1.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 949 (0.949K)
+Boundary exits    = 106 (0.106K)
+SurfColl checks   = 416222 (0.416M)
+SurfColl occurs   = 1129 (1.13K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.27173e+07
+Particle-moves/step: 5268.28
+Cell-touches/particle/step: 1.01243
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.000600449
+Particle fraction exiting boundary: 6.70681e-05
+Surface-checks/particle/step: 0.263351
+Surface-collisions/particle/step: 0.000714338
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10394 ave 10394 max 10394 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_1.emit.face.region
+++ b/examples/emit/log.29Jun21.mpi_1.emit.face.region
@@ -1,0 +1,130 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from box face towards circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.00102782 secs
+  create/ghost percent = 85.7806 14.2194
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000157356 secs
+  reassign/sort/migrate/ghost percent = 58.4848 1.66667 21.0606 18.7879
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000746489 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 39.8595 8.1763 0.862344 44.1393 6.96263 5.55733 0.0319387
+  surf2grid time = 0.000329494 secs
+  map/comm1/comm2/comm3/comm4/split percent = 39.725 10.9986 9.04486 3.83502 15.5572 16.8596
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+region              slit block INF INF 4.5 5.5 INF INF
+
+fix		    in emit/face air xlo twopass region slit
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0022203922      339        0        0        0       74 
+     200 0.0050849915      671        0        0        3      484 
+     300 0.0097775459     1003        0        0        1      742 
+Loop time of 0.00978899 on 1 procs for 300 steps with 1003 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0059078  | 0.0059078  | 0.0059078  |   0.0 | 60.35
+Coll    | 0.00055766 | 0.00055766 | 0.00055766 |   0.0 |  5.70
+Sort    | 0.00058961 | 0.00058961 | 0.00058961 |   0.0 |  6.02
+Comm    | 6.6042e-05 | 6.6042e-05 | 6.6042e-05 |   0.0 |  0.67
+Modify  | 0.0024357  | 0.0024357  | 0.0024357  |   0.0 | 24.88
+Output  | 4.53e-05   | 4.53e-05   | 4.53e-05   |   0.0 |  0.46
+Other   |            | 0.0001869  |            |       |  1.91
+
+Particle moves    = 152035 (0.152M)
+Cells touched     = 154155 (0.154M)
+Particle comms    = 0 (0K)
+Boundary collides = 4 (0.004K)
+Boundary exits    = 20 (0.02K)
+SurfColl checks   = 92596 (92.6K)
+SurfColl occurs   = 224 (0.224K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.55312e+07
+Particle-moves/step: 506.783
+Cell-touches/particle/step: 1.01394
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 2.63097e-05
+Particle fraction exiting boundary: 0.000131549
+Surface-checks/particle/step: 0.609044
+Surface-collisions/particle/step: 0.00147334
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1003 ave 1003 max 1003 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_1.emit.surf.boundary
+++ b/examples/emit/log.29Jun21.mpi_1.emit.surf.boundary
@@ -1,0 +1,147 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a 2nd circle used as boundary
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.0010426 secs
+  create/ghost percent = 85.7992 14.2008
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000215054 secs
+  reassign/sort/migrate/ghost percent = 69.0687 1.33038 15.8537 13.7472
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+# 12 would be fine, 12.1 is simply to make arc visible in images
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000642776 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.0816 9.01335 1.44659 51.5579 7.90059 18.1009 0.037092
+  surf2grid time = 0.000331402 secs
+  map/comm1/comm2/comm3/comm4/split percent = 39.6403 10.9353 8.77698 4.02878 15.2518 17.6259
+read_surf           data.circle group boundary invert origin 5 5 0                     atrans 12.1 5 0 scale 4 4 1 clip
+  50 points
+  100 lines
+  clipped to 8 lines
+  0.1 1.21679 xlo xhi
+  0 10 ylo yhi
+  0 0 zlo zhi
+  0.643775 min line length
+  0 0 = number of pushed cells
+  36 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  48 16 36 = cells outside/inside/overlapping surfs
+  36 = surf cells with 1,2,etc splits
+  67.0701 79.238 = cell-wise and global flow volume
+  CPU time = 0.00048852 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 21.4251 14.1532 0.878477 54.8072 8.73597 8.24793 0
+  surf2grid time = 0.000267744 secs
+  map/comm1/comm2/comm3/comm4/split percent = 42.3865 14.5147 10.2404 6.76759 5.69902 18.3437
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/surf air boundary perspecies yes
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00597382 0.00597382 0.00597382
+  total     (ave,min,max) = 1.51977 1.51977 1.51977
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.013996601     3609        0        0        0     4650 
+     200   0.04616046     7230        0        0        5     8506 
+     300  0.098895311    10816        0        0       22    12744 
+Loop time of 0.0989075 on 1 procs for 300 steps with 10816 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.077345   | 0.077345   | 0.077345   |   0.0 | 78.20
+Coll    | 0.0045295  | 0.0045295  | 0.0045295  |   0.0 |  4.58
+Sort    | 0.008368   | 0.008368   | 0.008368   |   0.0 |  8.46
+Comm    | 0.00016809 | 0.00016809 | 0.00016809 |   0.0 |  0.17
+Modify  | 0.0080438  | 0.0080438  | 0.0080438  |   0.0 |  8.13
+Output  | 4.3869e-05 | 4.3869e-05 | 4.3869e-05 |   0.0 |  0.04
+Other   |            | 0.0004089  |            |       |  0.41
+
+Particle moves    = 1630068 (1.63M)
+Cells touched     = 1654475 (1.65M)
+Particle comms    = 0 (0K)
+Boundary collides = 547 (0.547K)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 1989873 (1.99M)
+SurfColl occurs   = 1885 (1.89K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.64807e+07
+Particle-moves/step: 5433.56
+Cell-touches/particle/step: 1.01497
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.000335569
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 1.22073
+Surface-collisions/particle/step: 0.00115639
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10816 ave 10816 max 10816 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    58 ave 58 max 58 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_1.emit.surf.flow
+++ b/examples/emit/log.29Jun21.mpi_1.emit.surf.flow
@@ -1,0 +1,128 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000952005 secs
+  create/ghost percent = 81.3173 18.6827
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000157118 secs
+  reassign/sort/migrate/ghost percent = 58.7253 1.6692 20.4856 19.1199
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000692606 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 27.8141 8.50258 1.30809 54.5611 7.81411 6.33391 0.0344234
+  surf2grid time = 0.000377893 secs
+  map/comm1/comm2/comm3/comm4/split percent = 38.5489 9.40063 7.82334 4.35331 18.2334 18.1073
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/surf air all perspecies yes
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.025549889     5689        0        0        0     9332 
+     200   0.07699585    10918        0        0        1    10972 
+     300   0.14708734    15133        0        0        0    11722 
+Loop time of 0.1471 on 1 procs for 300 steps with 15133 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.11446    | 0.11446    | 0.11446    |   0.0 | 77.81
+Coll    | 0.0068347  | 0.0068347  | 0.0068347  |   0.0 |  4.65
+Sort    | 0.012578   | 0.012578   | 0.012578   |   0.0 |  8.55
+Comm    | 0.00028563 | 0.00028563 | 0.00028563 |   0.0 |  0.19
+Modify  | 0.012426   | 0.012426   | 0.012426   |   0.0 |  8.45
+Output  | 4.4107e-05 | 4.4107e-05 | 4.4107e-05 |   0.0 |  0.03
+Other   |            | 0.0004723  |            |       |  0.32
+
+Particle moves    = 2443836 (2.44M)
+Cells touched     = 2481240 (2.48M)
+Particle comms    = 0 (0K)
+Boundary collides = 1744 (1.74K)
+Boundary exits    = 1905 (1.91K)
+SurfColl checks   = 2778314 (2.78M)
+SurfColl occurs   = 106 (0.106K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.66135e+07
+Particle-moves/step: 8146.12
+Cell-touches/particle/step: 1.01531
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.000713632
+Particle fraction exiting boundary: 0.000779512
+Surface-checks/particle/step: 1.13687
+Surface-collisions/particle/step: 4.33744e-05
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 15133 ave 15133 max 15133 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_1.emit.surf.flow.region
+++ b/examples/emit/log.29Jun21.mpi_1.emit.surf.flow.region
@@ -1,0 +1,130 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.0009408 secs
+  create/ghost percent = 81.2722 18.7278
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00015521 secs
+  reassign/sort/migrate/ghost percent = 60.8295 1.68971 18.4332 19.0476
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00068903 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 28.4083 8.44291 0.968858 53.4256 8.75433 6.7474 0.0692042
+  surf2grid time = 0.000368118 secs
+  map/comm1/comm2/comm3/comm4/split percent = 38.2124 9.90933 8.16062 3.95078 15.0907 20.5311
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+region              slit block INF INF 4.5 5.5 INF INF
+
+fix		    in emit/surf air all perspecies yes region slit
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0040652752      601        0        0        0     1082 
+     200  0.010186434     1079        0        0        0     1388 
+     300  0.017856836     1357        0        0        0     1464 
+Loop time of 0.0178683 on 1 procs for 300 steps with 1357 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.012021   | 0.012021   | 0.012021   |   0.0 | 67.27
+Coll    | 0.00084877 | 0.00084877 | 0.00084877 |   0.0 |  4.75
+Sort    | 0.00096011 | 0.00096011 | 0.00096011 |   0.0 |  5.37
+Comm    | 9.8944e-05 | 9.8944e-05 | 9.8944e-05 |   0.0 |  0.55
+Modify  | 0.003722   | 0.003722   | 0.003722   |   0.0 | 20.83
+Output  | 4.1246e-05 | 4.1246e-05 | 4.1246e-05 |   0.0 |  0.23
+Other   |            | 0.0001764  |            |       |  0.99
+
+Particle moves    = 240688 (0.241M)
+Cells touched     = 244835 (0.245M)
+Particle comms    = 0 (0K)
+Boundary collides = 2 (0.002K)
+Boundary exits    = 482 (0.482K)
+SurfColl checks   = 334226 (0.334M)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.34701e+07
+Particle-moves/step: 802.293
+Cell-touches/particle/step: 1.01723
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 8.30951e-06
+Particle fraction exiting boundary: 0.00200259
+Surface-checks/particle/step: 1.38863
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1357 ave 1357 max 1357 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_1.emit.surf.normal
+++ b/examples/emit/log.29Jun21.mpi_1.emit.surf.normal
@@ -1,0 +1,128 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000954151 secs
+  create/ghost percent = 81.1844 18.8156
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00015831 secs
+  reassign/sort/migrate/ghost percent = 58.4337 1.65663 20.9337 18.9759
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000688791 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 28.3489 8.48044 0.969193 54.0325 8.16892 6.33437 0.0346141
+  surf2grid time = 0.000372171 secs
+  map/comm1/comm2/comm3/comm4/split percent = 38.4369 9.67329 8.13581 4.164 17.0404 18.5778
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/surf air all normal yes perspecies no
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.029076338     6579        0        0        0    10482 
+     200   0.08765769    12566        0        0        0    12372 
+     300   0.16976953    17423        0        0        2    13306 
+Loop time of 0.169785 on 1 procs for 300 steps with 17423 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.13103    | 0.13103    | 0.13103    |   0.0 | 77.17
+Coll    | 0.0079479  | 0.0079479  | 0.0079479  |   0.0 |  4.68
+Sort    | 0.01459    | 0.01459    | 0.01459    |   0.0 |  8.59
+Comm    | 0.00033045 | 0.00033045 | 0.00033045 |   0.0 |  0.19
+Modify  | 0.015379   | 0.015379   | 0.015379   |   0.0 |  9.06
+Output  | 4.8399e-05 | 4.8399e-05 | 4.8399e-05 |   0.0 |  0.03
+Other   |            | 0.000463   |            |       |  0.27
+
+Particle moves    = 2818464 (2.82M)
+Cells touched     = 2862370 (2.86M)
+Particle comms    = 0 (0K)
+Boundary collides = 2210 (2.21K)
+Boundary exits    = 2270 (2.27K)
+SurfColl checks   = 3144902 (3.14M)
+SurfColl occurs   = 163 (0.163K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.66002e+07
+Particle-moves/step: 9394.88
+Cell-touches/particle/step: 1.01558
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.000784115
+Particle fraction exiting boundary: 0.000805403
+Surface-checks/particle/step: 1.11582
+Surface-collisions/particle/step: 5.78329e-05
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 17423 ave 17423 max 17423 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_1.emit.surf.normal.region
+++ b/examples/emit/log.29Jun21.mpi_1.emit.surf.normal.region
@@ -1,0 +1,130 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000925541 secs
+  create/ghost percent = 84.2607 15.7393
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00016284 secs
+  reassign/sort/migrate/ghost percent = 60.4685 1.61054 18.5944 19.3265
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000637293 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.3779 9.12832 1.45903 51.3281 7.7067 7.29517 0.0748223
+  surf2grid time = 0.00032711 secs
+  map/comm1/comm2/comm3/comm4/split percent = 40.3061 10.7143 8.89213 4.00875 15.1603 17.1283
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+region              slit block INF INF 4.5 5.5 INF INF
+
+fix		    in emit/surf air all normal yes perspecies no region slit
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.004383564      697        0        0        0     1252 
+     200  0.011176586     1226        0        0        0     1560 
+     300   0.01998806     1558        0        0        0     1690 
+Loop time of 0.019999 on 1 procs for 300 steps with 1558 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.013924   | 0.013924   | 0.013924   |   0.0 | 69.62
+Coll    | 0.00093675 | 0.00093675 | 0.00093675 |   0.0 |  4.68
+Sort    | 0.001071   | 0.001071   | 0.001071   |   0.0 |  5.36
+Comm    | 0.00011873 | 0.00011873 | 0.00011873 |   0.0 |  0.59
+Modify  | 0.0037251  | 0.0037251  | 0.0037251  |   0.0 | 18.63
+Output  | 4.077e-05  | 4.077e-05  | 4.077e-05  |   0.0 |  0.20
+Other   |            | 0.0001826  |            |       |  0.91
+
+Particle moves    = 276154 (0.276M)
+Cells touched     = 280999 (0.281M)
+Particle comms    = 0 (0K)
+Boundary collides = 3 (0.003K)
+Boundary exits    = 566 (0.566K)
+SurfColl checks   = 383724 (0.384M)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.38084e+07
+Particle-moves/step: 920.513
+Cell-touches/particle/step: 1.01754
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 1.08635e-05
+Particle fraction exiting boundary: 0.00204958
+Surface-checks/particle/step: 1.38953
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1558 ave 1558 max 1558 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.face
+++ b/examples/emit/log.29Jun21.mpi_4.emit.face
@@ -1,0 +1,129 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from box face towards circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00111437 secs
+  create/ghost percent = 84.3389 15.6611
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.00082469 secs
+  reassign/sort/migrate/ghost percent = 67.1581 0.664932 11.246 20.9309
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00118089 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 24.5104 19.7254 0.827781 46.6182 8.31819 21.3406 0.161518
+  surf2grid time = 0.000550508 secs
+  map/comm1/comm2/comm3/comm4/split percent = 23.9065 9.26808 4.9372 5.32698 9.00823 41.5331
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.010769606     3507        0        0        0      196 
+     200  0.024980545     7009        0        0        5     2022 
+     300  0.042320251    10438        0        0       14     4684 
+Loop time of 0.0423962 on 4 procs for 300 steps with 10438 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.010808   | 0.013028   | 0.01632    |   2.0 | 30.73
+Coll    | 0.0010157  | 0.0010793  | 0.0012126  |   0.2 |  2.55
+Sort    | 0.0021834  | 0.0022944  | 0.002465   |   0.2 |  5.41
+Comm    | 0.0046499  | 0.004823   | 0.0049982  |   0.2 | 11.38
+Modify  | 0.012649   | 0.014573   | 0.015976   |   1.2 | 34.37
+Output  | 7.2241e-05 | 0.00011742 | 0.00025249 |   0.0 |  0.28
+Other   |            | 0.006481   |            |       | 15.29
+
+Particle moves    = 1580272 (1.58M)
+Cells touched     = 1599853 (1.6M)
+Particle comms    = 8904 (8.9K)
+Boundary collides = 933 (0.933K)
+Boundary exits    = 89 (0.089K)
+SurfColl checks   = 433912 (0.434M)
+SurfColl occurs   = 1203 (1.2K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.31848e+06
+Particle-moves/step: 5267.57
+Cell-touches/particle/step: 1.01239
+Particle comm iterations/step: 1.94667
+Particle fraction communicated: 0.00563447
+Particle fraction colliding with boundary: 0.000590405
+Particle fraction exiting boundary: 5.63194e-05
+Surface-checks/particle/step: 0.274581
+Surface-collisions/particle/step: 0.000761261
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 2609.5 ave 2755 max 2474 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Cells:      25 ave 45 max 5 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 12.5 ave 16 max 7 min
+Histogram: 1 0 0 0 0 1 0 0 1 1
+EmptyCell: 11.25 ave 15 max 7 min
+Histogram: 1 1 0 0 0 0 0 0 0 2
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.face.region
+++ b/examples/emit/log.29Jun21.mpi_4.emit.face.region
@@ -1,0 +1,131 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from box face towards circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00108981 secs
+  create/ghost percent = 84.1829 15.8171
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000832558 secs
+  reassign/sort/migrate/ghost percent = 67.4971 0.658648 14.8053 17.0389
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000971794 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 27.0854 11.1629 0.785083 49.9509 11.0157 17.1001 0.368008
+  surf2grid time = 0.00048542 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.7682 10.2161 5.64833 5.74656 9.97053 30.3045
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+region              slit block INF INF 4.5 5.5 INF INF
+
+fix		    in emit/face air xlo twopass region slit
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0059826374      363        0        0        0       70 
+     200  0.010633707      703        0        0        2      474 
+     300  0.015581846     1046        0        0        1      804 
+Loop time of 0.015631 on 4 procs for 300 steps with 1046 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0015218  | 0.0016577  | 0.0017962  |   0.3 | 10.61
+Coll    | 0.00019622 | 0.00019771 | 0.00019884 |   0.0 |  1.26
+Sort    | 0.00016403 | 0.0001983  | 0.00022817 |   0.0 |  1.27
+Comm    | 0.0036614  | 0.0037908  | 0.0039694  |   0.2 | 24.25
+Modify  | 0.0059259  | 0.006806   | 0.0076909  |   1.1 | 43.54
+Output  | 6.4135e-05 | 8.8215e-05 | 0.00015736 |   0.0 |  0.56
+Other   |            | 0.002892   |            |       | 18.50
+
+Particle moves    = 159522 (0.16M)
+Cells touched     = 161667 (0.162M)
+Particle comms    = 1048 (1.05K)
+Boundary collides = 9 (0.009K)
+Boundary exits    = 14 (0.014K)
+SurfColl checks   = 92886 (92.9K)
+SurfColl occurs   = 209 (0.209K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.55138e+06
+Particle-moves/step: 531.74
+Cell-touches/particle/step: 1.01345
+Particle comm iterations/step: 1.83667
+Particle fraction communicated: 0.00656963
+Particle fraction colliding with boundary: 5.64186e-05
+Particle fraction exiting boundary: 8.77622e-05
+Surface-checks/particle/step: 0.582277
+Surface-collisions/particle/step: 0.00131016
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 261.5 ave 273 max 251 min
+Histogram: 1 0 0 1 0 1 0 0 0 1
+Cells:      25 ave 45 max 5 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 11 ave 15 max 7 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+EmptyCell: 11 ave 15 max 7 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.surf.boundary
+++ b/examples/emit/log.29Jun21.mpi_4.emit.surf.boundary
@@ -1,0 +1,148 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a 2nd circle used as boundary
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00109172 secs
+  create/ghost percent = 85.7174 14.2826
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000798702 secs
+  reassign/sort/migrate/ghost percent = 67.9403 1.49254 12.6567 17.9104
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+# 12 would be fine, 12.1 is simply to make arc visible in images
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000963449 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 26.0827 16.0109 0.668151 49.0225 8.21579 16.6048 0.346449
+  surf2grid time = 0.000472307 secs
+  map/comm1/comm2/comm3/comm4/split percent = 29.1772 9.08632 5.70419 6.10803 10.7521 30.0353
+read_surf           data.circle group boundary invert origin 5 5 0                     atrans 12.1 5 0 scale 4 4 1 clip
+  50 points
+  100 lines
+  clipped to 8 lines
+  0.1 1.21679 xlo xhi
+  0 10 ylo yhi
+  0 0 zlo zhi
+  0.643775 min line length
+  0 0 = number of pushed cells
+  36 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  48 16 36 = cells outside/inside/overlapping surfs
+  36 = surf cells with 1,2,etc splits
+  67.0701 79.238 = cell-wise and global flow volume
+  CPU time = 0.000819445 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 18.9409 25.6037 0.494617 46.3486 8.61216 19.2028 0.378237
+  surf2grid time = 0.000379801 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.8675 9.85562 7.03076 7.97238 3.64093 36.9115
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/surf air boundary perspecies yes
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00597382 0.00597382 0.00597382
+  total     (ave,min,max) = 1.51977 1.51977 1.51977
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.011890173     3599        0        0        0     4663 
+     200  0.027375698     7198        0        0        9     8496 
+     300  0.049930573    10834        0        0       17    12459 
+Loop time of 0.0499887 on 4 procs for 300 steps with 10834 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.018375   | 0.019585   | 0.021155   |   0.8 | 39.18
+Coll    | 0.0010507  | 0.0011514  | 0.0012317  |   0.2 |  2.30
+Sort    | 0.002176   | 0.0024186  | 0.0028136  |   0.5 |  4.84
+Comm    | 0.0047891  | 0.0050343  | 0.0053556  |   0.3 | 10.07
+Modify  | 0.012584   | 0.014554   | 0.016367   |   1.4 | 29.11
+Output  | 7.1764e-05 | 9.9123e-05 | 0.00017428 |   0.0 |  0.20
+Other   |            | 0.007147   |            |       | 14.30
+
+Particle moves    = 1625925 (1.63M)
+Cells touched     = 1650333 (1.65M)
+Particle comms    = 11085 (11.1K)
+Boundary collides = 559 (0.559K)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 1986025 (1.99M)
+SurfColl occurs   = 1891 (1.89K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 8.13146e+06
+Particle-moves/step: 5419.75
+Cell-touches/particle/step: 1.01501
+Particle comm iterations/step: 1.96667
+Particle fraction communicated: 0.00681766
+Particle fraction colliding with boundary: 0.000343804
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 1.22147
+Surface-collisions/particle/step: 0.00116303
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 2708.5 ave 2944 max 2498 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Cells:      25 ave 50 max 7 min
+Histogram: 2 0 0 0 0 0 1 0 0 1
+GhostCell: 16.5 ave 25 max 10 min
+Histogram: 2 0 0 0 0 0 1 0 0 1
+EmptyCell: 11.75 ave 16 max 8 min
+Histogram: 2 0 0 0 0 0 0 0 1 1
+Surfs:    58 ave 58 max 58 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.surf.flow
+++ b/examples/emit/log.29Jun21.mpi_4.emit.surf.flow
@@ -1,0 +1,129 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00109863 secs
+  create/ghost percent = 84.2665 15.7335
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.00084424 secs
+  reassign/sort/migrate/ghost percent = 65.0664 1.44027 15.3629 18.1305
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000977993 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 26.7431 15.5534 0.877621 49.0249 7.80107 15.9678 0.365675
+  surf2grid time = 0.00047946 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.3938 10.0945 5.76827 6.26554 10.3928 29.2889
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/surf air all perspecies yes
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.012773514     5683        0        0        0     9354 
+     200    0.0325315    11032        0        0        0    11022 
+     300  0.057681322    15213        0        0        2    11604 
+Loop time of 0.0577316 on 4 procs for 300 steps with 15213 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.028656   | 0.030881   | 0.032273   |   0.8 | 53.49
+Coll    | 0.001693   | 0.0017154  | 0.0017598  |   0.1 |  2.97
+Sort    | 0.0039291  | 0.0040914  | 0.0041754  |   0.2 |  7.09
+Comm    | 0.0045643  | 0.0048577  | 0.0050488  |   0.3 |  8.41
+Modify  | 0.0109     | 0.011319   | 0.011631   |   0.3 | 19.61
+Output  | 6.5804e-05 | 9.1732e-05 | 0.00016713 |   0.0 |  0.16
+Other   |            | 0.004776   |            |       |  8.27
+
+Particle moves    = 2462707 (2.46M)
+Cells touched     = 2500598 (2.5M)
+Particle comms    = 5145 (5.15K)
+Boundary collides = 1756 (1.76K)
+Boundary exits    = 1906 (1.91K)
+SurfColl checks   = 2800592 (2.8M)
+SurfColl occurs   = 135 (0.135K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.06645e+07
+Particle-moves/step: 8209.02
+Cell-touches/particle/step: 1.01539
+Particle comm iterations/step: 1.95
+Particle fraction communicated: 0.00208916
+Particle fraction colliding with boundary: 0.000713037
+Particle fraction exiting boundary: 0.000773945
+Surface-checks/particle/step: 1.1372
+Surface-collisions/particle/step: 5.48177e-05
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 3803.25 ave 3870 max 3746 min
+Histogram: 2 0 0 0 0 0 0 1 0 1
+Cells:      25 ave 31 max 20 min
+Histogram: 1 0 0 1 1 0 0 0 0 1
+GhostCell: 17.25 ave 18 max 16 min
+Histogram: 1 0 0 0 0 1 0 0 0 2
+EmptyCell: 12 ave 13 max 11 min
+Histogram: 1 0 0 0 0 2 0 0 0 1
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.surf.flow.region
+++ b/examples/emit/log.29Jun21.mpi_4.emit.surf.flow.region
@@ -1,0 +1,131 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00109768 secs
+  create/ghost percent = 84.1008 15.8992
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000796795 secs
+  reassign/sort/migrate/ghost percent = 70.5566 0.748055 11.7594 16.936
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000937223 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 28.2117 11.422 0.763165 50.2417 9.36149 18.494 0.508776
+  surf2grid time = 0.000470877 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.962 8.96203 6.22785 5.46835 10.4304 29.6203
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+region              slit block INF INF 4.5 5.5 INF INF
+
+fix		    in emit/surf air all perspecies yes region slit
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0056672096      625        0        0        0     1132 
+     200  0.011271954     1111        0        0        0     1472 
+     300  0.017147541     1371        0        0        0     1392 
+Loop time of 0.0171965 on 4 procs for 300 steps with 1371 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0029662  | 0.0034186  | 0.0039864  |   0.8 | 19.88
+Coll    | 0.00027084 | 0.00028211 | 0.00029802 |   0.0 |  1.64
+Sort    | 0.00026155 | 0.00029606 | 0.0003345  |   0.0 |  1.72
+Comm    | 0.0036411  | 0.0037593  | 0.0039113  |   0.2 | 21.86
+Modify  | 0.0063491  | 0.0066029  | 0.0067554  |   0.2 | 38.40
+Output  | 6.9857e-05 | 9.5904e-05 | 0.00016975 |   0.0 |  0.56
+Other   |            | 0.002742   |            |       | 15.94
+
+Particle moves    = 246518 (0.247M)
+Cells touched     = 250745 (0.251M)
+Particle comms    = 914 (0.914K)
+Boundary collides = 6 (0.006K)
+Boundary exits    = 464 (0.464K)
+SurfColl checks   = 343536 (0.344M)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.58383e+06
+Particle-moves/step: 821.727
+Cell-touches/particle/step: 1.01715
+Particle comm iterations/step: 1.72667
+Particle fraction communicated: 0.00370764
+Particle fraction colliding with boundary: 2.4339e-05
+Particle fraction exiting boundary: 0.00188222
+Surface-checks/particle/step: 1.39355
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 342.75 ave 407 max 300 min
+Histogram: 2 0 0 0 0 1 0 0 0 1
+Cells:      25 ave 30 max 20 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 11 ave 12 max 10 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+EmptyCell: 11 ave 12 max 10 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.surf.normal
+++ b/examples/emit/log.29Jun21.mpi_4.emit.surf.normal
@@ -1,0 +1,129 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.0010848 secs
+  create/ghost percent = 85.7143 14.2857
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000837564 secs
+  reassign/sort/migrate/ghost percent = 69.7979 1.11016 11.1016 17.9903
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00096941 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 27.2504 16.3551 0.688637 47.5898 8.11608 17.88 0.368913
+  surf2grid time = 0.00046134 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.0982 9.14729 5.5814 6.51163 10.9044 31.5245
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/surf air all normal yes perspecies no
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.013357639     6582        0        0        0    10468 
+     200  0.034539938    12679        0        0        0    12352 
+     300  0.061902285    17503        0        0        4    13142 
+Loop time of 0.0619553 on 4 procs for 300 steps with 17503 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.034711   | 0.035216   | 0.03598    |   0.3 | 56.84
+Coll    | 0.0019085  | 0.0019489  | 0.0019715  |   0.1 |  3.15
+Sort    | 0.0049105  | 0.0049811  | 0.0050955  |   0.1 |  8.04
+Comm    | 0.0048122  | 0.0051453  | 0.0054786  |   0.4 |  8.30
+Modify  | 0.0096133  | 0.010165   | 0.010674   |   0.4 | 16.41
+Output  | 8.297e-05  | 0.00010693 | 0.000175   |   0.0 |  0.17
+Other   |            | 0.004393   |            |       |  7.09
+
+Particle moves    = 2834389 (2.83M)
+Cells touched     = 2878790 (2.88M)
+Particle comms    = 4047 (4.05K)
+Boundary collides = 2245 (2.25K)
+Boundary exits    = 2338 (2.34K)
+SurfColl checks   = 3125994 (3.13M)
+SurfColl occurs   = 175 (0.175K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.14372e+07
+Particle-moves/step: 9447.96
+Cell-touches/particle/step: 1.01567
+Particle comm iterations/step: 1.93333
+Particle fraction communicated: 0.00142782
+Particle fraction colliding with boundary: 0.000792058
+Particle fraction exiting boundary: 0.000824869
+Surface-checks/particle/step: 1.10288
+Surface-collisions/particle/step: 6.17417e-05
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 4375.75 ave 4387 max 4357 min
+Histogram: 1 0 0 0 0 0 1 0 0 2
+Cells:      25 ave 27 max 23 min
+Histogram: 1 0 0 0 0 2 0 0 0 1
+GhostCell: 14 ave 17 max 11 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+EmptyCell: 11.5 ave 12 max 11 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.29Jun21.mpi_4.emit.surf.normal.region
+++ b/examples/emit/log.29Jun21.mpi_4.emit.surf.normal.region
@@ -1,0 +1,131 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# particles emitted from a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00109792 secs
+  create/ghost percent = 85.5592 14.4408
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000827551 secs
+  reassign/sort/migrate/ghost percent = 67.9343 0.633823 12.1867 19.2452
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000985861 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.0786 16.2031 0.749698 49.7219 8.24667 16.058 0.532044
+  surf2grid time = 0.000490189 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.3619 10.4572 8.99805 5.15564 10.2626 29.572
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+region              slit block INF INF 4.5 5.5 INF INF
+
+fix		    in emit/surf air all normal yes perspecies no region slit
+
+timestep 	    0.0001
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    300
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0057530403      695        0        0        0     1242 
+     200  0.011232853     1235        0        0        0     1550 
+     300  0.017167568     1541        0        0        0     1670 
+Loop time of 0.0172215 on 4 procs for 300 steps with 1541 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.003619   | 0.0037854  | 0.0039923  |   0.2 | 21.98
+Coll    | 0.00029635 | 0.00030518 | 0.00031424 |   0.0 |  1.77
+Sort    | 0.00031281 | 0.00032634 | 0.00034261 |   0.0 |  1.89
+Comm    | 0.0037088  | 0.003839   | 0.0040088  |   0.2 | 22.29
+Modify  | 0.0065184  | 0.0066287  | 0.0067294  |   0.1 | 38.49
+Output  | 6.8903e-05 | 9.2268e-05 | 0.00015926 |   0.0 |  0.54
+Other   |            | 0.002245   |            |       | 13.03
+
+Particle moves    = 275828 (0.276M)
+Cells touched     = 280735 (0.281M)
+Particle comms    = 748 (0.748K)
+Boundary collides = 12 (0.012K)
+Boundary exits    = 584 (0.584K)
+SurfColl checks   = 378116 (0.378M)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 4.00412e+06
+Particle-moves/step: 919.427
+Cell-touches/particle/step: 1.01779
+Particle comm iterations/step: 1.82
+Particle fraction communicated: 0.00271183
+Particle fraction colliding with boundary: 4.35054e-05
+Particle fraction exiting boundary: 0.00211726
+Surface-checks/particle/step: 1.37084
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 385.25 ave 421 max 369 min
+Histogram: 1 2 0 0 0 0 0 0 0 1
+Cells:      25 ave 30 max 20 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 11 ave 12 max 10 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+EmptyCell: 11 ave 12 max 10 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/flowfile/log.29Jun21.mpi_1.flowfile
+++ b/examples/flowfile/log.29Jun21.mpi_1.flowfile
@@ -1,0 +1,111 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow profile input from file
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00110364 secs
+  create/ghost percent = 71.8082 28.1918
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000259876 secs
+  reassign/sort/migrate/ghost percent = 47.156 1.37615 13.8532 37.6147
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+fix		    in emit/face/file air xlo flow.face XLO frac 0.5
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 100 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck f_1 f_1[1] f_1[2]
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck f_1 f_1[1] f_1[2] 
+       0            0        0        0        0        0        0            1            0            1 
+     100  0.010576248     6015        0        0        0        0            1         6015            1 
+     200  0.032655478    12027        0        0        0        0            1        12027            1 
+     300  0.067809582    18003        0        0        0        0            1        18003            1 
+     400   0.11417031    23027        0        0        0        0            1        23027            1 
+     500   0.16955304    26084        0        0        0        0            1        26084            1 
+     600   0.22996521    27868        0        0        0        0            1        27868            1 
+     700   0.29361773    28943        0        0        0        0            1        28943            1 
+     800   0.35896206    29588        0        0        0        0            1        29588            1 
+     900   0.42520094    29849        0        0        0        0            1        29849            1 
+    1000   0.49502945    29946        0        0        0        0            1        29946            1 
+Loop time of 0.495053 on 1 procs for 1000 steps with 29946 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.45477    | 0.45477    | 0.45477    |   0.0 | 91.86
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.0020604  | 0.0020604  | 0.0020604  |   0.0 |  0.42
+Modify  | 0.036577   | 0.036577   | 0.036577   |   0.0 |  7.39
+Output  | 0.0001781  | 0.0001781  | 0.0001781  |   0.0 |  0.04
+Other   |            | 0.001467   |            |       |  0.30
+
+Particle moves    = 21737175 (21.7M)
+Cells touched     = 22674296 (22.7M)
+Particle comms    = 0 (0K)
+Boundary collides = 99 (0.099K)
+Boundary exits    = 30032 (30K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 4.39088e+07
+Particle-moves/step: 21737.2
+Cell-touches/particle/step: 1.04311
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 4.55441e-06
+Particle fraction exiting boundary: 0.0013816
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 29946 ave 29946 max 29946 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/flowfile/log.29Jun21.mpi_4.flowfile
+++ b/examples/flowfile/log.29Jun21.mpi_4.flowfile
@@ -1,0 +1,112 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow profile input from file
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00111341 secs
+  create/ghost percent = 86.167 13.833
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000934839 secs
+  reassign/sort/migrate/ghost percent = 64.2948 1.32619 13.7465 20.6325
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+fix		    in emit/face/file air xlo flow.face XLO frac 0.5
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+fix                 1 balance 100 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck f_1 f_1[1] f_1[2]
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck f_1 f_1[1] f_1[2] 
+       0            0        0        0        0        0        0            1            0            1 
+     100  0.010498047     6008        0        0        0        0    1.0213049         1534    2.0013316 
+     200  0.021145821    11969        0        0        0        0     1.009274         3020    1.4998747 
+     300  0.034884691    17932        0        0        0        0    1.0129378         4541    1.3455275 
+     400   0.05181098    22989        0        0        0        0    1.0105703         5808    1.2270216 
+     500  0.070497274    25992        0        0        0        0    1.0040012         6524    1.1131117 
+     600  0.090791225    27909        0        0        0        0    1.0099968         7047     1.066896 
+     700   0.11195612    28952        0        0        0        0    1.0084277         7299    1.0414479 
+     800   0.13384438    29654        0        0        0        0    1.0089701         7480    1.0252917 
+     900   0.15550351    29975        0        0        0        0    1.0028357         7515     1.017648 
+    1000   0.17735386    30042        0        0        0        0    1.0072565         7565    1.0097863 
+Loop time of 0.177408 on 4 procs for 1000 steps with 30042 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.11403    | 0.11936    | 0.12491    |   1.5 | 67.28
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.017601   | 0.018634   | 0.020072   |   0.7 | 10.50
+Modify  | 0.0070074  | 0.017301   | 0.02794    |   7.8 |  9.75
+Output  | 0.00020671 | 0.00028479 | 0.00051284 |   0.0 |  0.16
+Other   |            | 0.02182    |            |       | 12.30
+
+Particle moves    = 21726748 (21.7M)
+Cells touched     = 22664759 (22.7M)
+Particle comms    = 75451 (75.5K)
+Boundary collides = 102 (0.102K)
+Boundary exits    = 29988 (30K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.06168e+07
+Particle-moves/step: 21726.7
+Cell-touches/particle/step: 1.04317
+Particle comm iterations/step: 1.992
+Particle fraction communicated: 0.00347272
+Particle fraction colliding with boundary: 4.69467e-06
+Particle fraction exiting boundary: 0.00138023
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 7510.5 ave 7565 max 7467 min
+Histogram: 1 0 0 1 1 0 0 0 0 1
+Cells:      100 ave 103 max 98 min
+Histogram: 1 0 1 0 1 0 0 0 0 1
+GhostCell: 26.5 ave 34 max 21 min
+Histogram: 2 0 0 0 0 0 1 0 0 1
+EmptyCell: 21.5 ave 22 max 21 min
+Histogram: 2 0 0 0 0 0 0 0 0 2

--- a/examples/free/log.29Jun21.mpi_1.free
+++ b/examples/free/log.29Jun21.mpi_1.free
@@ -1,0 +1,114 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# thermal gas in a 3d box with free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+# particles reflect off global box boundaries
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 1.0e-5 comm/sort yes
+
+boundary	    rr rr rr
+
+create_box  	    0 0.0001 0 0.0001 0 0.0001
+Created orthogonal box = (0 0 0) to (0.0001 0.0001 0.0001)
+create_grid 	    10 10 10
+Created 1000 child grid cells
+  CPU time = 0.00146604 secs
+  create/ghost percent = 59.0828 40.9172
+
+balance_grid        rcb part
+Balance grid migrated 0 cells
+  CPU time = 0.000530243 secs
+  reassign/sort/migrate/ghost percent = 38.4442 0.629496 10.1169 50.8094
+
+species		    ar.species Ar
+mixture		    air Ar vstream 0.0 0.0 0.0 temp 273.15
+
+global              nrho 7.07043E22
+global              fnum 7.07043E6
+
+create_particles    air n 10000 twopass
+Created 10000 particles
+  CPU time = 0.00464368 secs
+
+stats		    100
+compute             temp temp
+stats_style	    step cpu np nattempt ncoll c_temp
+
+#dump                2 image all 100 image.*.ppm type type pdiam 3.0e-6 #		    size 512 512 gline yes 0.005
+#dump_modify	    2 pad 4
+
+timestep 	    7.00E-9
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.20129 3.20129 3.20129
+Step CPU Np Natt Ncoll c_temp 
+       0            0    10000        0        0    273.86304 
+     100  0.040561914    10000        0        0    273.86304 
+     200  0.081481218    10000        0        0    273.86304 
+     300   0.12299037    10000        0        0    273.86304 
+     400    0.1638639    10000        0        0    273.86304 
+     500   0.20468926    10000        0        0    273.86304 
+     600   0.24554276    10000        0        0    273.86304 
+     700   0.28637004    10000        0        0    273.86304 
+     800   0.32724953    10000        0        0    273.86304 
+     900   0.36807895    10000        0        0    273.86304 
+    1000   0.40891361    10000        0        0    273.86304 
+Loop time of 0.408925 on 1 procs for 1000 steps with 10000 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.40676    | 0.40676    | 0.40676    |   0.0 | 99.47
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.00048566 | 0.00048566 | 0.00048566 |   0.0 |  0.12
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00075507 | 0.00075507 | 0.00075507 |   0.0 |  0.18
+Other   |            | 0.0009279  |            |       |  0.23
+
+Particle moves    = 10000000 (10M)
+Cells touched     = 13599730 (13.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 399938 (0.4M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.44544e+07
+Particle-moves/step: 10000
+Cell-touches/particle/step: 1.35997
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0399938
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10000 ave 10000 max 10000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1000 ave 1000 max 1000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/free/log.29Jun21.mpi_4.free
+++ b/examples/free/log.29Jun21.mpi_4.free
@@ -1,0 +1,115 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# thermal gas in a 3d box with free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+# particles reflect off global box boundaries
+
+seed	    	    12345
+dimension   	    3
+global              gridcut 1.0e-5 comm/sort yes
+
+boundary	    rr rr rr
+
+create_box  	    0 0.0001 0 0.0001 0 0.0001
+Created orthogonal box = (0 0 0) to (0.0001 0.0001 0.0001)
+create_grid 	    10 10 10
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 1000 child grid cells
+  CPU time = 0.00113893 secs
+  create/ghost percent = 85.158 14.842
+
+balance_grid        rcb part
+Balance grid migrated 740 cells
+  CPU time = 0.00146008 secs
+  reassign/sort/migrate/ghost percent = 47.2567 0.21228 19.5134 33.0176
+
+species		    ar.species Ar
+mixture		    air Ar vstream 0.0 0.0 0.0 temp 273.15
+
+global              nrho 7.07043E22
+global              fnum 7.07043E6
+
+create_particles    air n 10000 twopass
+Created 10000 particles
+  CPU time = 0.00219512 secs
+
+stats		    100
+compute             temp temp
+stats_style	    step cpu np nattempt ncoll c_temp
+
+#dump                2 image all 100 image.*.ppm type type pdiam 3.0e-6 #		    size 512 512 gline yes 0.005
+#dump_modify	    2 pad 4
+
+timestep 	    7.00E-9
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.20129 3.20129 3.20129
+Step CPU Np Natt Ncoll c_temp 
+       0            0    10000        0        0    274.13466 
+     100  0.013385296    10000        0        0    274.13466 
+     200   0.02667284    10000        0        0    274.13466 
+     300  0.039799452    10000        0        0    274.13466 
+     400  0.052770853    10000        0        0    274.13466 
+     500  0.065766335    10000        0        0    274.13466 
+     600  0.078804731    10000        0        0    274.13466 
+     700  0.091835976    10000        0        0    274.13466 
+     800   0.10477638    10000        0        0    274.13466 
+     900   0.11779833    10000        0        0    274.13466 
+    1000   0.13083887    10000        0        0    274.13466 
+Loop time of 0.130879 on 4 procs for 1000 steps with 10000 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.10478    | 0.10495    | 0.10535    |   0.1 | 80.19
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.016654   | 0.017049   | 0.017458   |   0.2 | 13.03
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00046158 | 0.0005309  | 0.00072122 |   0.0 |  0.41
+Other   |            | 0.008348   |            |       |  6.38
+
+Particle moves    = 10000000 (10M)
+Cells touched     = 13601504 (13.6M)
+Particle comms    = 264081 (0.264M)
+Boundary collides = 400198 (0.4M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.91017e+07
+Particle-moves/step: 10000
+Cell-touches/particle/step: 1.36015
+Particle comm iterations/step: 1
+Particle fraction communicated: 0.0264081
+Particle fraction colliding with boundary: 0.0400198
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 2500 ave 2555 max 2433 min
+Histogram: 1 0 0 0 1 0 0 1 0 1
+Cells:      250 ave 250 max 250 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 172.5 ave 240 max 110 min
+Histogram: 1 0 0 0 2 0 0 0 0 1
+EmptyCell: 62.5 ave 130 max 0 min
+Histogram: 1 0 0 0 2 0 0 0 0 1

--- a/examples/jagged/log.29Jun21.mpi_1.jagged.2d
+++ b/examples/jagged/log.29Jun21.mpi_1.jagged.2d
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a jagged object
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    100 100 1
+Created 10000 child grid cells
+  CPU time = 0.00673413 secs
+  create/ghost percent = 38.467 61.533
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00367546 secs
+  reassign/sort/migrate/ghost percent = 26.9331 1.3233 7.8944 63.8492
+
+global		    nrho 1.0 fnum 0.001
+global              surfmax 1000
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           sdata.100x100                     origin 0.5 0.5 0.0 trans 4.5 4.5 0.0 scale 9 9 1
+  40006 points
+  20003 lines
+  0.5 9.95 xlo xhi
+  0.5 9.5 ylo yhi
+  0 0 zlo zhi
+  0.0900011 min line length
+  0 0 = number of pushed cells
+  8388 168 = cells overlapping surfs, overlap cells with unmarked corner pts
+  1348 264 8388 = cells outside/inside/overlapping surfs
+  3542 4756 90 = surf cells with 1,2,etc splits
+  55.45 55.45 = cell-wise and global flow volume
+  CPU time = 0.0881817 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 41.0979 10.8343 0.490184 35.1348 12.4428 1.76634 0.000270372
+  surf2grid time = 0.0309825 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.2609 22.4348 4.16622 4.88496 12.7357 25.329
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.005 size 1024 1024 zoom 1.75 #                    #gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 5.45044 5.45044 5.45044
+  surf      (ave,min,max) = 2.06025 2.06025 2.06025
+  total     (ave,min,max) = 7.51068 7.51068 7.51068
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.55672169    21008        0        0    12197   201677 
+     200    2.5818791    38895        0        0    29711   418877 
+     300    5.5215204    49196        0        0    35709   513841 
+     400    8.7919257    54577        0        0    37335   554408 
+     500    12.160931    57611        0        0    38340   574441 
+     600    15.568987    59401        0        0    38525   582608 
+     700    18.993805    60598        0        0    38547   587635 
+     800    22.429905    61388        0        0    38354   591016 
+     900    25.875967    61843        0        0    39018   595514 
+    1000    29.346068    62349        0        0    39587   602071 
+Loop time of 29.3461 on 1 procs for 1000 steps with 62349 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 27.659     | 27.659     | 27.659     |   0.0 | 94.25
+Coll    | 0.62565    | 0.62565    | 0.62565    |   0.0 |  2.13
+Sort    | 0.89069    | 0.89069    | 0.89069    |   0.0 |  3.04
+Comm    | 0.010619   | 0.010619   | 0.010619   |   0.0 |  0.04
+Modify  | 0.15266    | 0.15266    | 0.15266    |   0.0 |  0.52
+Output  | 0.00037503 | 0.00037503 | 0.00037503 |   0.0 |  0.00
+Other   |            | 0.006615   |            |       |  0.02
+
+Particle moves    = 49929170 (49.9M)
+Cells touched     = 85593222 (85.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 166130 (0.166M)
+Boundary exits    = 148279 (0.148M)
+SurfColl checks   = 493614663 (494M)
+SurfColl occurs   = 32762395 (32.8M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.70139e+06
+Particle-moves/step: 49929.2
+Cell-touches/particle/step: 1.71429
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00332731
+Particle fraction exiting boundary: 0.00296979
+Surface-checks/particle/step: 9.8863
+Surface-collisions/particle/step: 0.656177
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 62349 ave 62349 max 62349 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      19782 ave 19782 max 19782 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    20003 ave 20003 max 20003 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/jagged/log.29Jun21.mpi_1.jagged.2d.distributed
+++ b/examples/jagged/log.29Jun21.mpi_1.jagged.2d.distributed
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a jagged object
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes surfs explicit/distributed
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    100 100 1
+Created 10000 child grid cells
+  CPU time = 0.00685453 secs
+  create/ghost percent = 37.8365 62.1635
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00367808 secs
+  reassign/sort/migrate/ghost percent = 27.7176 1.17975 7.05905 64.0436
+
+global		    nrho 1.0 fnum 0.001
+global              surfmax 1000
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           sdata.100x100                     origin 0.5 0.5 0.0 trans 4.5 4.5 0.0 scale 9 9 1
+  40006 points
+  20003 lines
+  0.5 9.95 xlo xhi
+  0.5 9.5 ylo yhi
+  0 0 zlo zhi
+  0.0900011 min line length
+  0 0 = number of pushed cells
+  8388 168 = cells overlapping surfs, overlap cells with unmarked corner pts
+  1348 264 8388 = cells outside/inside/overlapping surfs
+  3542 4756 90 = surf cells with 1,2,etc splits
+  55.45 55.45 = cell-wise and global flow volume
+  CPU time = 0.0978217 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 36.6542 12.269 0.482337 36.7863 13.8081 1.98541 0.000487455
+  surf2grid time = 0.035985 secs
+  map/comm1/comm2/comm3/comm4/split percent = 23.9386 18.8429 3.58771 4.23833 25.3571 22.0424
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.005 size 1024 1024 zoom 1.75 #                    #gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 5.45044 5.45044 5.45044
+  surf      (ave,min,max) = 3.96788 3.96788 3.96788
+  total     (ave,min,max) = 9.41832 9.41832 9.41832
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.58591557    21008        0        0    12197   201677 
+     200    2.6946208    38895        0        0    29711   418877 
+     300    5.7627969    49196        0        0    35709   513841 
+     400    9.1715899    54577        0        0    37335   554408 
+     500    12.700109    57611        0        0    38340   574441 
+     600    16.267206    59401        0        0    38525   582608 
+     700    19.853099    60598        0        0    38547   587635 
+     800    23.455212    61388        0        0    38354   591016 
+     900    27.069695    61843        0        0    39018   595514 
+    1000    30.702846    62349        0        0    39587   602071 
+Loop time of 30.7029 on 1 procs for 1000 steps with 62349 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 29.014     | 29.014     | 29.014     |   0.0 | 94.50
+Coll    | 0.63253    | 0.63253    | 0.63253    |   0.0 |  2.06
+Sort    | 0.88833    | 0.88833    | 0.88833    |   0.0 |  2.89
+Comm    | 0.010606   | 0.010606   | 0.010606   |   0.0 |  0.03
+Modify  | 0.15023    | 0.15023    | 0.15023    |   0.0 |  0.49
+Output  | 0.00035691 | 0.00035691 | 0.00035691 |   0.0 |  0.00
+Other   |            | 0.006848   |            |       |  0.02
+
+Particle moves    = 49929170 (49.9M)
+Cells touched     = 85593222 (85.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 166130 (0.166M)
+Boundary exits    = 148279 (0.148M)
+SurfColl checks   = 493614663 (494M)
+SurfColl occurs   = 32762395 (32.8M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.62621e+06
+Particle-moves/step: 49929.2
+Cell-touches/particle/step: 1.71429
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00332731
+Particle fraction exiting boundary: 0.00296979
+Surface-checks/particle/step: 9.8863
+Surface-collisions/particle/step: 0.656177
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 62349 ave 62349 max 62349 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      19782 ave 19782 max 19782 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    20003 ave 20003 max 20003 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/jagged/log.29Jun21.mpi_4.jagged.2d
+++ b/examples/jagged/log.29Jun21.mpi_4.jagged.2d
@@ -1,0 +1,136 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a jagged object
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    100 100 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 10000 child grid cells
+  CPU time = 0.00145578 secs
+  create/ghost percent = 82.9676 17.0324
+balance_grid        rcb cell
+Balance grid migrated 7400 cells
+  CPU time = 0.00444388 secs
+  reassign/sort/migrate/ghost percent = 28.038 0.901336 35.6993 35.3613
+
+global		    nrho 1.0 fnum 0.001
+global              surfmax 1000
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           sdata.100x100                     origin 0.5 0.5 0.0 trans 4.5 4.5 0.0 scale 9 9 1
+  40006 points
+  20003 lines
+  0.5 9.95 xlo xhi
+  0.5 9.5 ylo yhi
+  0 0 zlo zhi
+  0.0900011 min line length
+  0 0 = number of pushed cells
+  8388 168 = cells overlapping surfs, overlap cells with unmarked corner pts
+  1348 264 8388 = cells outside/inside/overlapping surfs
+  3542 4756 90 = surf cells with 1,2,etc splits
+  55.45 55.45 = cell-wise and global flow volume
+  CPU time = 0.0683765 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 56.5842 19.5832 0.393665 18.072 5.36696 3.55031 0.00418422
+  surf2grid time = 0.012357 secs
+  map/comm1/comm2/comm3/comm4/split percent = 21.6076 19.4312 3.46717 4.61325 26.0646 20.4345
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.005 size 1024 1024 zoom 1.75 #                    #gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 2.57544 2.57544 2.57544
+  surf      (ave,min,max) = 2.06025 2.06025 2.06025
+  total     (ave,min,max) = 4.63568 4.63568 4.63568
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.27187634    21033        0        0    12376   204081 
+     200    1.0368814    38956        0        0    29395   419329 
+     300    2.0678725    49197        0        0    35939   514758 
+     400     3.211683    54610        0        0    37494   555465 
+     500    4.4053192    57386        0        0    37745   570337 
+     600    5.6325359    59223        0        0    38193   580692 
+     700    6.8674841    60527        0        0    38707   588318 
+     800    8.1298096    61159        0        0    38280   588602 
+     900    9.3874753    61703        0        0    38692   595530 
+    1000    10.639396    62033        0        0    38682   596887 
+Loop time of 10.6395 on 4 procs for 1000 steps with 62033 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 4.5121     | 6.9531     | 9.3912     |  91.5 | 65.35
+Coll    | 0.096265   | 0.15604    | 0.22096    |  15.1 |  1.47
+Sort    | 0.27846    | 0.43087    | 0.58405    |  23.0 |  4.05
+Comm    | 0.14594    | 0.19127    | 0.238      |   9.7 |  1.80
+Modify  | 0.0016112  | 0.0436     | 0.08793    |  20.1 |  0.41
+Output  | 0.0003593  | 0.002827   | 0.0046904  |   3.6 |  0.03
+Other   |            | 2.862      |            |       | 26.90
+
+Particle moves    = 49821842 (49.8M)
+Cells touched     = 85437626 (85.4M)
+Particle comms    = 533996 (0.534M)
+Boundary collides = 161927 (0.162M)
+Boundary exits    = 148601 (0.149M)
+SurfColl checks   = 493339878 (493M)
+SurfColl occurs   = 32735390 (32.7M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.17068e+06
+Particle-moves/step: 49821.8
+Cell-touches/particle/step: 1.71486
+Particle comm iterations/step: 18.846
+Particle fraction communicated: 0.0107181
+Particle fraction colliding with boundary: 0.00325012
+Particle fraction exiting boundary: 0.00298265
+Surface-checks/particle/step: 9.90208
+Surface-collisions/particle/step: 0.657049
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 15508.2 ave 23046 max 7948 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      4945.5 ave 5875 max 4018 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 101 ave 101 max 101 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 101 ave 101 max 101 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    20003 ave 20003 max 20003 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/jagged/log.29Jun21.mpi_4.jagged.2d.distributed
+++ b/examples/jagged/log.29Jun21.mpi_4.jagged.2d.distributed
@@ -1,0 +1,136 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a jagged object
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes surfs explicit/distributed
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    100 100 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 10000 child grid cells
+  CPU time = 0.00146031 secs
+  create/ghost percent = 82.6612 17.3388
+balance_grid        rcb cell
+Balance grid migrated 7400 cells
+  CPU time = 0.00446701 secs
+  reassign/sort/migrate/ghost percent = 28.4159 1.07814 35.8881 34.6178
+
+global		    nrho 1.0 fnum 0.001
+global              surfmax 1000
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           sdata.100x100                     origin 0.5 0.5 0.0 trans 4.5 4.5 0.0 scale 9 9 1
+  40006 points
+  20003 lines
+  0.5 9.95 xlo xhi
+  0.5 9.5 ylo yhi
+  0 0 zlo zhi
+  0.0900011 min line length
+  0 0 = number of pushed cells
+  8388 168 = cells overlapping surfs, overlap cells with unmarked corner pts
+  1348 264 8388 = cells outside/inside/overlapping surfs
+  3542 4756 90 = surf cells with 1,2,etc splits
+  55.45 55.45 = cell-wise and global flow volume
+  CPU time = 0.0601401 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 62.3506 6.13925 0.560167 22.5593 8.39062 2.34018 0.00317151
+  surf2grid time = 0.0135672 secs
+  map/comm1/comm2/comm3/comm4/split percent = 20.0474 16.8491 3.42501 4.25622 26.8131 26.1893
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.005 size 1024 1024 zoom 1.75 #                    #gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 2.57544 2.57544 2.57544
+  surf      (ave,min,max) = 1.00196 1.00184 1.00214
+  total     (ave,min,max) = 3.5774 3.57728 3.57758
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.32638764    21033        0        0    12376   204081 
+     200    1.1827469    38956        0        0    29395   419329 
+     300    2.3888752    49197        0        0    35939   514758 
+     400    3.6954854    54610        0        0    37494   555465 
+     500    5.0613325    57386        0        0    37745   570337 
+     600    6.4815555    59223        0        0    38193   580692 
+     700    7.9074202    60527        0        0    38707   588318 
+     800    9.3367479    61159        0        0    38280   588602 
+     900    10.807165    61703        0        0    38692   595530 
+    1000    12.251751    62033        0        0    38682   596887 
+Loop time of 12.2519 on 4 procs for 1000 steps with 62033 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 5.1758     | 8.0566     | 11.045     | 101.3 | 65.76
+Coll    | 0.097386   | 0.16084    | 0.23438    |  15.9 |  1.31
+Sort    | 0.27121    | 0.41961    | 0.57346    |  22.9 |  3.42
+Comm    | 0.14865    | 0.1575     | 0.16547    |   1.5 |  1.29
+Modify  | 0.0017633  | 0.043429   | 0.086819   |  20.0 |  0.35
+Output  | 0.00034833 | 0.0026919  | 0.0045581  |   3.5 |  0.02
+Other   |            | 3.411      |            |       | 27.84
+
+Particle moves    = 49821842 (49.8M)
+Cells touched     = 85437626 (85.4M)
+Particle comms    = 533996 (0.534M)
+Boundary collides = 161927 (0.162M)
+Boundary exits    = 148601 (0.149M)
+SurfColl checks   = 493339878 (493M)
+SurfColl occurs   = 32735390 (32.7M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.01662e+06
+Particle-moves/step: 49821.8
+Cell-touches/particle/step: 1.71486
+Particle comm iterations/step: 18.846
+Particle fraction communicated: 0.0107181
+Particle fraction colliding with boundary: 0.00325012
+Particle fraction exiting boundary: 0.00298265
+Surface-checks/particle/step: 9.90208
+Surface-collisions/particle/step: 0.657049
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 15508.2 ave 23046 max 7948 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      4945.5 ave 5875 max 4018 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostCell: 101 ave 101 max 101 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 101 ave 101 max 101 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    5101.5 ave 5103 max 5100 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/sphere/log.29Jun21.mpi_1.sphere
+++ b/examples/sphere/log.29Jun21.mpi_1.sphere
@@ -1,0 +1,141 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 3d flow around a sphere
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+
+global              gridcut 0.1 comm/sort yes
+
+boundary	    o r r
+
+create_box  	    -2 2 -2 2 -2 2
+Created orthogonal box = (-2 -2 -2) to (2 2 2)
+
+create_grid         20 20 20
+Created 8000 child grid cells
+  CPU time = 0.00572014 secs
+  create/ghost percent = 29.6516 70.3484
+
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00332308 secs
+  reassign/sort/migrate/ghost percent = 24.6736 0.947051 7.27508 67.1043
+
+global		    nrho 1.0 fnum 0.0005
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.sphere
+  602 points
+  1200 triangles
+  -1 1 xlo xhi
+  -1 1 ylo yhi
+  -1 1 zlo zhi
+  0.100631 min triangle edge length
+  0.00439601 min triangle area
+  0 0 = number of pushed cells
+  440 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  7256 304 440 = cells outside/inside/overlapping surfs
+  440 = surf cells with 1,2,etc splits
+  59.8617 59.8617 = cell-wise and global flow volume
+  CPU time = 0.0386853 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 3.71384 3.85251 0.76668 49.8958 41.7711 2.53177 0.00801193
+  surf2grid time = 0.0193024 secs
+  map/comm1/comm2/comm3/comm4/split percent = 18.0719 2.80879 5.85227 1.26235 2.01952 68.3869
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide		    vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#compute             2 surf all all n press ke
+#fix                 save ave/surf all 1 50 50 c_2[*] ave running
+#region              slab block INF INF INF INF -0.1 0.1
+#dump                2 image all 50 image.*.ppm type type pdiam 0.03 #		    view 70 120 size 512 512 axes yes 0.9 0.02 #                    gridz -0.8 proc gline yes 0.005 #                    surf f_save[2] 0.0
+#dump_modify	    2 pad 4 region slab
+#dump_modify         2 cmap surf min max cf 0.0 2 min orange max green
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.151062 0.151062 0.151062
+  total     (ave,min,max) = 1.66486 1.66486 1.66486
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.36333704    51396        0        0      193    25765 
+     200    1.0292757    64211        0        0      257    31509 
+     300    1.7869182    68460        0        0      214    32929 
+     400    2.5749674    70336        0        0      219    33814 
+     500    3.3786507    71338        0        0      233    32626 
+     600    4.1802492    72079        0        0      249    34516 
+     700    4.9962325    72224        0        0      256    34684 
+     800    5.8141637    72387        0        0      258    34128 
+     900    6.6348248    72765        0        0      255    33780 
+    1000    7.4554794    72780        0        0      223    33502 
+Loop time of 7.4555 on 1 procs for 1000 steps with 72780 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 5.3965     | 5.3965     | 5.3965     |   0.0 | 72.38
+Coll    | 0.72432    | 0.72432    | 0.72432    |   0.0 |  9.72
+Sort    | 0.86788    | 0.86788    | 0.86788    |   0.0 | 11.64
+Comm    | 0.023727   | 0.023727   | 0.023727   |   0.0 |  0.32
+Modify  | 0.43669    | 0.43669    | 0.43669    |   0.0 |  5.86
+Output  | 0.00035095 | 0.00035095 | 0.00035095 |   0.0 |  0.00
+Other   |            | 0.006051   |            |       |  0.08
+
+Particle moves    = 66452854 (66.5M)
+Cells touched     = 97635059 (97.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 1126347 (1.13M)
+Boundary exits    = 600841 (0.601M)
+SurfColl checks   = 31556717 (31.6M)
+SurfColl occurs   = 232595 (0.233M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 8.91326e+06
+Particle-moves/step: 66452.9
+Cell-touches/particle/step: 1.46924
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0169496
+Particle fraction exiting boundary: 0.00904161
+Surface-checks/particle/step: 0.474874
+Surface-collisions/particle/step: 0.00350015
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 72780 ave 72780 max 72780 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      8000 ave 8000 max 8000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    1200 ave 1200 max 1200 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/sphere/log.29Jun21.mpi_1.sphere.distributed
+++ b/examples/sphere/log.29Jun21.mpi_1.sphere.distributed
@@ -1,0 +1,141 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 3d flow around a sphere
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+
+global              gridcut 0.1 comm/sort yes surfs explicit/distributed
+
+boundary	    o r r
+
+create_box  	    -2 2 -2 2 -2 2
+Created orthogonal box = (-2 -2 -2) to (2 2 2)
+
+create_grid         20 20 20
+Created 8000 child grid cells
+  CPU time = 0.00579929 secs
+  create/ghost percent = 29.769 70.231
+
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00325322 secs
+  reassign/sort/migrate/ghost percent = 24.4339 0.967387 7.18212 67.4166
+
+global		    nrho 1.0 fnum 0.0005
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.sphere
+  602 points
+  1200 triangles
+  -1 1 xlo xhi
+  -1 1 ylo yhi
+  -1 1 zlo zhi
+  0.100631 min triangle edge length
+  0.00439601 min triangle area
+  0 0 = number of pushed cells
+  440 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  7256 304 440 = cells outside/inside/overlapping surfs
+  440 = surf cells with 1,2,etc splits
+  59.8617 59.8617 = cell-wise and global flow volume
+  CPU time = 0.0411539 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 3.40069 8.08229 0.729382 48.1172 39.6705 2.29416 0.00753134
+  surf2grid time = 0.0198021 secs
+  map/comm1/comm2/comm3/comm4/split percent = 17.717 2.38995 5.81174 1.1715 3.85282 67.7121
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide		    vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#compute             2 surf all all n press ke
+#fix                 save ave/surf all 1 50 50 c_2[*] ave running
+#region              slab block INF INF INF INF -0.1 0.1
+#dump                2 image all 50 image.*.ppm type type pdiam 0.03 #		    view 70 120 size 512 512 axes yes 0.9 0.02 #                    gridz -0.8 proc gline yes 0.005 #                    surf f_save[2] 0.0
+#dump_modify	    2 pad 4 region slab
+#dump_modify         2 cmap surf min max cf 0.0 2 min orange max green
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.292969 0.292969 0.292969
+  total     (ave,min,max) = 1.80676 1.80676 1.80676
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.35746789    51396        0        0      193    25765 
+     200    1.0285254    64211        0        0      257    31509 
+     300     1.786159    68460        0        0      214    32929 
+     400    2.5655465    70336        0        0      219    33814 
+     500    3.3663142    71338        0        0      233    32626 
+     600    4.1734359    72079        0        0      249    34516 
+     700     4.989413    72224        0        0      256    34684 
+     800    5.8050511    72387        0        0      258    34128 
+     900    6.6187968    72765        0        0      255    33780 
+    1000     7.437484    72780        0        0      223    33502 
+Loop time of 7.43751 on 1 procs for 1000 steps with 72780 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 5.4057     | 5.4057     | 5.4057     |   0.0 | 72.68
+Coll    | 0.71455    | 0.71455    | 0.71455    |   0.0 |  9.61
+Sort    | 0.85324    | 0.85324    | 0.85324    |   0.0 | 11.47
+Comm    | 0.023794   | 0.023794   | 0.023794   |   0.0 |  0.32
+Modify  | 0.43435    | 0.43435    | 0.43435    |   0.0 |  5.84
+Output  | 0.00035191 | 0.00035191 | 0.00035191 |   0.0 |  0.00
+Other   |            | 0.005518   |            |       |  0.07
+
+Particle moves    = 66452854 (66.5M)
+Cells touched     = 97635059 (97.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 1126347 (1.13M)
+Boundary exits    = 600841 (0.601M)
+SurfColl checks   = 31556717 (31.6M)
+SurfColl occurs   = 232595 (0.233M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 8.93482e+06
+Particle-moves/step: 66452.9
+Cell-touches/particle/step: 1.46924
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0169496
+Particle fraction exiting boundary: 0.00904161
+Surface-checks/particle/step: 0.474874
+Surface-collisions/particle/step: 0.00350015
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 72780 ave 72780 max 72780 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      8000 ave 8000 max 8000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    1200 ave 1200 max 1200 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/sphere/log.29Jun21.mpi_4.sphere
+++ b/examples/sphere/log.29Jun21.mpi_4.sphere
@@ -1,0 +1,142 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 3d flow around a sphere
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+
+global              gridcut 0.1 comm/sort yes
+
+boundary	    o r r
+
+create_box  	    -2 2 -2 2 -2 2
+Created orthogonal box = (-2 -2 -2) to (2 2 2)
+
+create_grid         20 20 20
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 8000 child grid cells
+  CPU time = 0.00140214 secs
+  create/ghost percent = 83.5232 16.4768
+
+balance_grid        rcb cell
+Balance grid migrated 5600 cells
+  CPU time = 0.00419998 secs
+  reassign/sort/migrate/ghost percent = 26.6292 0.590372 29.9784 42.802
+
+global		    nrho 1.0 fnum 0.0005
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.sphere
+  602 points
+  1200 triangles
+  -1 1 xlo xhi
+  -1 1 ylo yhi
+  -1 1 zlo zhi
+  0.100631 min triangle edge length
+  0.00439601 min triangle area
+  0 0 = number of pushed cells
+  440 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  7256 304 440 = cells outside/inside/overlapping surfs
+  440 = surf cells with 1,2,etc splits
+  59.8617 59.8617 = cell-wise and global flow volume
+  CPU time = 0.0144117 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 12.0635 11.3653 0.856949 41.8333 33.8809 4.03825 0.0992605
+  surf2grid time = 0.00602889 secs
+  map/comm1/comm2/comm3/comm4/split percent = 18.468 3.78851 6.40645 1.64511 4.93139 62.5934
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide		    vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#compute             2 surf all all n press ke
+#fix                 save ave/surf all 1 50 50 c_2[*] ave running
+#region              slab block INF INF INF INF -0.1 0.1
+#dump                2 image all 50 image.*.ppm type type pdiam 0.03 #		    view 70 120 size 512 512 axes yes 0.9 0.02 #                    gridz -0.8 proc gline yes 0.005 #                    surf f_save[2] 0.0
+#dump_modify	    2 pad 4 region slab
+#dump_modify         2 cmap surf min max cf 0.0 2 min orange max green
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.151062 0.151062 0.151062
+  total     (ave,min,max) = 1.66486 1.66486 1.66486
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.15431857    51450        0        0      210    26250 
+     200   0.41596651    64437        0        0      247    32440 
+     300   0.67842269    68434        0        0      234    32019 
+     400   0.94810534    70487        0        0      267    34618 
+     500    1.2241404    71395        0        0      227    32693 
+     600    1.5208938    71978        0        0      245    33816 
+     700    1.8027008    72675        0        0      241    33353 
+     800    2.0852327    72957        0        0      235    34621 
+     900    2.3889229    72919        0        0      233    34269 
+    1000    2.6737154    73254        0        0      263    35667 
+Loop time of 2.67384 on 4 procs for 1000 steps with 73254 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.0087     | 1.3897     | 1.7547     |  30.7 | 51.97
+Coll    | 0.1054     | 0.12946    | 0.15205    |   6.0 |  4.84
+Sort    | 0.28339    | 0.33197    | 0.37819    |   8.0 | 12.42
+Comm    | 0.068604   | 0.078475   | 0.085946   |   2.5 |  2.93
+Modify  | 0.0012255  | 0.11881    | 0.23657    |  34.0 |  4.44
+Output  | 0.00046706 | 0.0013666  | 0.0018702  |   1.5 |  0.05
+Other   |            | 0.6241     |            |       | 23.34
+
+Particle moves    = 66568783 (66.6M)
+Cells touched     = 97796939 (97.8M)
+Particle comms    = 963303 (0.963M)
+Boundary collides = 1128402 (1.13M)
+Boundary exits    = 601342 (0.601M)
+SurfColl checks   = 31509521 (31.5M)
+SurfColl occurs   = 231849 (0.232M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 6.22407e+06
+Particle-moves/step: 66568.8
+Cell-touches/particle/step: 1.46911
+Particle comm iterations/step: 1
+Particle fraction communicated: 0.0144708
+Particle fraction colliding with boundary: 0.0169509
+Particle fraction exiting boundary: 0.00903339
+Surface-checks/particle/step: 0.473338
+Surface-collisions/particle/step: 0.00348285
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 18313.5 ave 22683 max 13903 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      2000 ave 2000 max 2000 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 420 ave 420 max 420 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    1200 ave 1200 max 1200 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/sphere/log.29Jun21.mpi_4.sphere.distributed
+++ b/examples/sphere/log.29Jun21.mpi_4.sphere.distributed
@@ -1,0 +1,142 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 3d flow around a sphere
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    3
+
+global              gridcut 0.1 comm/sort yes surfs explicit/distributed
+
+boundary	    o r r
+
+create_box  	    -2 2 -2 2 -2 2
+Created orthogonal box = (-2 -2 -2) to (2 2 2)
+
+create_grid         20 20 20
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 8000 child grid cells
+  CPU time = 0.0013938 secs
+  create/ghost percent = 83.3219 16.6781
+
+balance_grid        rcb cell
+Balance grid migrated 5600 cells
+  CPU time = 0.00419497 secs
+  reassign/sort/migrate/ghost percent = 26.7235 0.613811 29.605 43.0577
+
+global		    nrho 1.0 fnum 0.0005
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.sphere
+  602 points
+  1200 triangles
+  -1 1 xlo xhi
+  -1 1 ylo yhi
+  -1 1 zlo zhi
+  0.100631 min triangle edge length
+  0.00439601 min triangle area
+  0 0 = number of pushed cells
+  440 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  7256 304 440 = cells outside/inside/overlapping surfs
+  440 = surf cells with 1,2,etc splits
+  59.8617 59.8617 = cell-wise and global flow volume
+  CPU time = 0.0138597 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 10.9337 7.91303 0.84807 42.7733 37.5318 3.72944 0.0481662
+  surf2grid time = 0.00592828 secs
+  map/comm1/comm2/comm3/comm4/split percent = 18.6527 2.93585 6.3704 1.71727 6.50312 61.661
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide		    vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#compute             2 surf all all n press ke
+#fix                 save ave/surf all 1 50 50 c_2[*] ave running
+#region              slab block INF INF INF INF -0.1 0.1
+#dump                2 image all 50 image.*.ppm type type pdiam 0.03 #		    view 70 120 size 512 512 axes yes 0.9 0.02 #                    gridz -0.8 proc gline yes 0.005 #                    surf f_save[2] 0.0
+#dump_modify	    2 pad 4 region slab
+#dump_modify         2 cmap surf min max cf 0.0 2 min orange max green
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0946045 0.0944824 0.0947266
+  total     (ave,min,max) = 1.6084 1.60828 1.60852
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.15463686    51450        0        0      210    26250 
+     200    0.3983252    64437        0        0      247    32440 
+     300   0.68031669    68434        0        0      234    32019 
+     400   0.95163345    70487        0        0      267    34618 
+     500    1.2293169    71395        0        0      227    32693 
+     600    1.5088356    71978        0        0      245    33816 
+     700    1.8112149    72675        0        0      241    33353 
+     800    2.0948763    72957        0        0      235    34621 
+     900    2.3795395    72919        0        0      233    34269 
+    1000    2.6844175    73254        0        0      263    35667 
+Loop time of 2.68452 on 4 procs for 1000 steps with 73254 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.0004     | 1.3873     | 1.7584     |  31.3 | 51.68
+Coll    | 0.10543    | 0.13034    | 0.15496    |   6.3 |  4.86
+Sort    | 0.26751    | 0.32738    | 0.38313    |   8.9 | 12.20
+Comm    | 0.071628   | 0.083136   | 0.088092   |   2.3 |  3.10
+Modify  | 0.0015144  | 0.11933    | 0.23923    |  34.1 |  4.45
+Output  | 0.0004456  | 0.0013107  | 0.0019286  |   1.8 |  0.05
+Other   |            | 0.6358     |            |       | 23.68
+
+Particle moves    = 66568783 (66.6M)
+Cells touched     = 97796939 (97.8M)
+Particle comms    = 963303 (0.963M)
+Boundary collides = 1128402 (1.13M)
+Boundary exits    = 601342 (0.601M)
+SurfColl checks   = 31509521 (31.5M)
+SurfColl occurs   = 231849 (0.232M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 6.19933e+06
+Particle-moves/step: 66568.8
+Cell-touches/particle/step: 1.46911
+Particle comm iterations/step: 1
+Particle fraction communicated: 0.0144708
+Particle fraction colliding with boundary: 0.0169509
+Particle fraction exiting boundary: 0.00903339
+Surface-checks/particle/step: 0.473338
+Surface-collisions/particle/step: 0.00348285
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 18313.5 ave 22683 max 13903 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      2000 ave 2000 max 2000 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 420 ave 420 max 420 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    383 ave 384 max 382 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+GhostSurf: 92 ave 92 max 92 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/spiky/log.29Jun21.mpi_1.spiky
+++ b/examples/spiky/log.29Jun21.mpi_1.spiky
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a spiky circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+# good test of cut and split cells
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00111151 secs
+  create/ghost percent = 72.5011 27.4989
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000256777 secs
+  reassign/sort/migrate/ghost percent = 45.4039 1.48561 15.4132 37.6973
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.spiky trans 5 5 0 scale 0.4 0.4 1
+  53 points
+  53 lines
+  1.30334 8.69492 xlo xhi
+  1.50769 8.9232 ylo yhi
+  0 0 zlo zhi
+  0.0984942 min line length
+  0 0 = number of pushed cells
+  127 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  268 5 127 = cells outside/inside/overlapping surfs
+  86 40 1 = surf cells with 1,2,etc splits
+  85.4883 85.4883 = cell-wise and global flow volume
+  CPU time = 0.0012691 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 15.9684 5.33534 1.33383 65.4894 11.873 7.06369 0.0187864
+  surf2grid time = 0.000831127 secs
+  map/comm1/comm2/comm3/comm4/split percent = 30.2926 5.1922 8.95009 3.55709 8.00344 41.7384
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.88879 1.88879 1.88879
+  surf      (ave,min,max) = 0.00545883 0.00545883 0.00545883
+  total     (ave,min,max) = 1.89425 1.89425 1.89425
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.073889017    20271        0        0      493    11903 
+     200   0.26339436    33133        0        0      717    20147 
+     300   0.51289582    39805        0        0      827    23805 
+     400   0.78977823    43848        0        0      890    25375 
+     500     1.086158    46419        0        0      905    26974 
+     600    1.3953459    48308        0        0      879    27487 
+     700    1.7173681    49504        0        0      978    28771 
+     800    2.0388374    50343        0        0      998    29117 
+     900    2.3651788    51025        0        0      953    29161 
+    1000    2.6983938    51330        0        0      930    29128 
+Loop time of 2.69842 on 1 procs for 1000 steps with 51330 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 2.0955     | 2.0955     | 2.0955     |   0.0 | 77.66
+Coll    | 0.2166     | 0.2166     | 0.2166     |   0.0 |  8.03
+Sort    | 0.24804    | 0.24804    | 0.24804    |   0.0 |  9.19
+Comm    | 0.0067606  | 0.0067606  | 0.0067606  |   0.0 |  0.25
+Modify  | 0.12889    | 0.12889    | 0.12889    |   0.0 |  4.78
+Output  | 0.00023055 | 0.00023055 | 0.00023055 |   0.0 |  0.01
+Other   |            | 0.002358   |            |       |  0.09
+
+Particle moves    = 41184548 (41.2M)
+Cells touched     = 46753264 (46.8M)
+Particle comms    = 0 (0K)
+Boundary collides = 162419 (0.162M)
+Boundary exits    = 159393 (0.159M)
+SurfColl checks   = 23665295 (23.7M)
+SurfColl occurs   = 804067 (0.804M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.52625e+07
+Particle-moves/step: 41184.5
+Cell-touches/particle/step: 1.13521
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00394369
+Particle fraction exiting boundary: 0.00387021
+Surface-checks/particle/step: 0.574616
+Surface-collisions/particle/step: 0.0195235
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 51330 ave 51330 max 51330 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      483 ave 483 max 483 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    53 ave 53 max 53 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/spiky/log.29Jun21.mpi_4.spiky
+++ b/examples/spiky/log.29Jun21.mpi_4.spiky
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a spiky circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+# good test of cut and split cells
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00110722 secs
+  create/ghost percent = 84.3885 15.6115
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000917435 secs
+  reassign/sort/migrate/ghost percent = 63.9553 0.571726 15.8784 19.5946
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.spiky trans 5 5 0 scale 0.4 0.4 1
+  53 points
+  53 lines
+  1.30334 8.69492 xlo xhi
+  1.50769 8.9232 ylo yhi
+  0 0 zlo zhi
+  0.0984942 min line length
+  0 0 = number of pushed cells
+  127 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  268 5 127 = cells outside/inside/overlapping surfs
+  86 40 1 = surf cells with 1,2,etc splits
+  85.4883 85.4883 = cell-wise and global flow volume
+  CPU time = 0.00132847 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.6159 11.6475 0.717875 58.9914 9.02728 15.6676 0.28715
+  surf2grid time = 0.000783682 secs
+  map/comm1/comm2/comm3/comm4/split percent = 21.6611 4.80681 5.01977 3.92455 6.84515 51.293
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 #                    gline yes 0.005 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.88879 1.88879 1.88879
+  surf      (ave,min,max) = 0.00545883 0.00545883 0.00545883
+  total     (ave,min,max) = 1.89425 1.89425 1.89425
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.043861151    20281        0        0      531    11969 
+     200   0.14042974    33135        0        0      731    20049 
+     300   0.26924276    40003        0        0      779    23318 
+     400   0.40742517    43794        0        0      864    25517 
+     500   0.55475593    46422        0        0      860    26840 
+     600   0.72555995    48285        0        0      884    27283 
+     700   0.88378358    49596        0        0      966    28493 
+     800     1.044467    50312        0        0      896    28504 
+     900    1.2063603    50828        0        0      934    28772 
+    1000    1.3694103    51340        0        0      926    29043 
+Loop time of 1.36949 on 4 procs for 1000 steps with 51340 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.095643   | 0.5398     | 1.0174     |  58.4 | 39.42
+Coll    | 0.008142   | 0.042493   | 0.077878   |  16.4 |  3.10
+Sort    | 0.025388   | 0.078587   | 0.13248    |  17.7 |  5.74
+Comm    | 0.031153   | 0.040432   | 0.045443   |   2.7 |  2.95
+Modify  | 0.000525   | 0.035479   | 0.071525   |  18.6 |  2.59
+Output  | 0.00025678 | 0.0013077  | 0.0021241  |   2.3 |  0.10
+Other   |            | 0.6314     |            |       | 46.10
+
+Particle moves    = 41203743 (41.2M)
+Cells touched     = 46781430 (46.8M)
+Particle comms    = 202396 (0.202M)
+Boundary collides = 163176 (0.163M)
+Boundary exits    = 159494 (0.159M)
+SurfColl checks   = 23557162 (23.6M)
+SurfColl occurs   = 802290 (0.802M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 7.52173e+06
+Particle-moves/step: 41203.7
+Cell-touches/particle/step: 1.13537
+Particle comm iterations/step: 2.923
+Particle fraction communicated: 0.00491208
+Particle fraction colliding with boundary: 0.00396022
+Particle fraction exiting boundary: 0.00387086
+Surface-checks/particle/step: 0.571724
+Surface-collisions/particle/step: 0.0194713
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 12835 ave 22827 max 3309 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      120.75 ave 129 max 114 min
+Histogram: 1 0 1 0 0 1 0 0 0 1
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    53 ave 53 max 53 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/step/log.29Jun21.mpi_1.step
+++ b/examples/step/log.29Jun21.mpi_1.step
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a staircase of steps
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00118351 secs
+  create/ghost percent = 77.2965 22.7035
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000313997 secs
+  reassign/sort/migrate/ghost percent = 54.5938 1.21488 13.2118 30.9795
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf	    data.step trans 5 5 0 scale 0.75 0.75 1                     rotate 45 0 0 1 invert
+  16 points
+  16 lines
+  2.34835 7.65165 xlo xhi
+  2.34835 7.65165 ylo yhi
+  0 0 zlo zhi
+  1.06066 min line length
+  0 0 = number of pushed cells
+  44 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  312 44 44 = cells outside/inside/overlapping surfs
+  44 = surf cells with 1,2,etc splits
+  85.375 85.375 = cell-wise and global flow volume
+  CPU time = 0.000875235 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 16.6984 7.54563 2.0158 60.2016 13.5385 7.38218 0.0272405
+  surf2grid time = 0.000526905 secs
+  map/comm1/comm2/comm3/comm4/split percent = 34.8869 4.93213 12.2624 2.85068 27.4661 13.8914
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 axes yes 0.9 0.02
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00164795 0.00164795 0.00164795
+  total     (ave,min,max) = 1.51544 1.51544 1.51544
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.060959101    20098        0        0      106     2687 
+     200   0.20050645    32380        0        0      165     4564 
+     300   0.38491631    38114        0        0      169     5335 
+     400   0.59152746    41520        0        0      180     5802 
+     500   0.80753112    43444        0        0      190     6152 
+     600    1.0301912    44961        0        0      211     6270 
+     700    1.2584872    45813        0        0      204     6381 
+     800     1.494087    46558        0        0      229     6541 
+     900    1.7334964    47190        0        0      202     6709 
+    1000    1.9716206    47484        0        0      209     6364 
+Loop time of 1.97164 on 1 procs for 1000 steps with 47484 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.4023     | 1.4023     | 1.4023     |   0.0 | 71.12
+Coll    | 0.19379    | 0.19379    | 0.19379    |   0.0 |  9.83
+Sort    | 0.23712    | 0.23712    | 0.23712    |   0.0 | 12.03
+Comm    | 0.0068495  | 0.0068495  | 0.0068495  |   0.0 |  0.35
+Modify  | 0.12838    | 0.12838    | 0.12838    |   0.0 |  6.51
+Output  | 0.00025702 | 0.00025702 | 0.00025702 |   0.0 |  0.01
+Other   |            | 0.002952   |            |       |  0.15
+
+Particle moves    = 38736530 (38.7M)
+Cells touched     = 43908447 (43.9M)
+Particle comms    = 0 (0K)
+Boundary collides = 138216 (0.138M)
+Boundary exits    = 163239 (0.163M)
+SurfColl checks   = 5341989 (5.34M)
+SurfColl occurs   = 172855 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.96469e+07
+Particle-moves/step: 38736.5
+Cell-touches/particle/step: 1.13352
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.0035681
+Particle fraction exiting boundary: 0.00421408
+Surface-checks/particle/step: 0.137906
+Surface-collisions/particle/step: 0.00446233
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 47484 ave 47484 max 47484 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    16 ave 16 max 16 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/step/log.29Jun21.mpi_4.step
+++ b/examples/step/log.29Jun21.mpi_4.step
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a staircase of steps
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00113416 secs
+  create/ghost percent = 83.8343 16.1657
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000934362 secs
+  reassign/sort/migrate/ghost percent = 64.8125 1.04619 14.5956 19.5458
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf	    data.step trans 5 5 0 scale 0.75 0.75 1                     rotate 45 0 0 1 invert
+  16 points
+  16 lines
+  2.34835 7.65165 xlo xhi
+  2.34835 7.65165 ylo yhi
+  0 0 zlo zhi
+  1.06066 min line length
+  0 0 = number of pushed cells
+  44 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  312 44 44 = cells outside/inside/overlapping surfs
+  44 = surf cells with 1,2,etc splits
+  85.375 85.375 = cell-wise and global flow volume
+  CPU time = 0.00116706 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 20.3269 19.9387 1.20531 49.2952 9.23391 22.6558 0.163432
+  surf2grid time = 0.000575304 secs
+  map/comm1/comm2/comm3/comm4/split percent = 25.0725 5.76046 6.3821 4.10278 7.91546 43.0999
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 axes yes 0.9 0.02
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00164795 0.00164795 0.00164795
+  total     (ave,min,max) = 1.51544 1.51544 1.51544
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.036088705    20142        0        0      121     2819 
+     200   0.10534286    32294        0        0      144     4483 
+     300   0.19435382    38292        0        0      186     5402 
+     400   0.28944492    41455        0        0      211     5865 
+     500   0.38871598    43462        0        0      214     6204 
+     600    0.5148747    44884        0        0      213     6251 
+     700   0.68558884    45941        0        0      185     6295 
+     800   0.79229951    46422        0        0      214     6534 
+     900   0.89971828    46926        0        0      221     6362 
+    1000    1.0074079    47347        0        0      182     6426 
+Loop time of 1.00756 on 4 procs for 1000 steps with 47347 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14517    | 0.37157    | 0.66134    |  34.2 | 36.88
+Coll    | 0.013141   | 0.039074   | 0.071115   |  12.6 |  3.88
+Sort    | 0.035486   | 0.075886   | 0.13074    |  13.8 |  7.53
+Comm    | 0.028248   | 0.031297   | 0.033854   |   1.3 |  3.11
+Modify  | 0.00052738 | 0.03389    | 0.068157   |  18.1 |  3.36
+Output  | 0.00028729 | 0.0013171  | 0.0017958  |   1.7 |  0.13
+Other   |            | 0.4545     |            |       | 45.11
+
+Particle moves    = 38687880 (38.7M)
+Cells touched     = 43856941 (43.9M)
+Particle comms    = 220918 (0.221M)
+Boundary collides = 138391 (0.138M)
+Boundary exits    = 163487 (0.163M)
+SurfColl checks   = 5313745 (5.31M)
+SurfColl occurs   = 172051 (0.172M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.59937e+06
+Particle-moves/step: 38687.9
+Cell-touches/particle/step: 1.13361
+Particle comm iterations/step: 1.997
+Particle fraction communicated: 0.00571026
+Particle fraction colliding with boundary: 0.00357712
+Particle fraction exiting boundary: 0.00422579
+Surface-checks/particle/step: 0.137349
+Surface-collisions/particle/step: 0.00444716
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 11836.8 ave 20501 max 5772 min
+Histogram: 2 0 0 0 0 1 0 0 0 1
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    16 ave 16 max 16 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf/log.29Jun21.mpi_1.surf.add
+++ b/examples/surf/log.29Jun21.mpi_1.surf.add
@@ -1,0 +1,224 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00125146 secs
+  create/ghost percent = 68.7941 31.2059
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000261784 secs
+  reassign/sort/migrate/ghost percent = 47.2678 1.36612 14.1166 37.2495
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000911236 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 21.6379 8.00628 1.8315 54.0555 14.4689 8.32025 0.0261643
+  surf2grid time = 0.000492573 secs
+  map/comm1/comm2/comm3/comm4/split percent = 39.4966 7.01839 23.7173 3.00097 11.8103 10.939
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.059314489    20932        0        0       19     1044 
+     200   0.20486569    36099        0        0       56     2593 
+     300   0.39938617    43709        0        0       47     2982 
+     400   0.62634706    48091        0        0       57     3169 
+     500   0.86698866    50656        0        0       53     3366 
+     600    1.1178544    52498        0        0       59     3504 
+     700    1.3768902    53764        0        0       56     3516 
+     800    1.6482439    54779        0        0       65     3484 
+     900    1.9181106    55443        0        0       58     3735 
+    1000    2.1905026    55832        0        0       56     3575 
+Loop time of 2.19052 on 1 procs for 1000 steps with 55832 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.5068     | 1.5068     | 1.5068     |   0.0 | 68.79
+Coll    | 0.26362    | 0.26362    | 0.26362    |   0.0 | 12.03
+Sort    | 0.2821     | 0.2821     | 0.2821     |   0.0 | 12.88
+Comm    | 0.0070813  | 0.0070813  | 0.0070813  |   0.0 |  0.32
+Modify  | 0.12804    | 0.12804    | 0.12804    |   0.0 |  5.85
+Output  | 0.00025845 | 0.00025845 | 0.00025845 |   0.0 |  0.01
+Other   |            | 0.002626   |            |       |  0.12
+
+Particle moves    = 44728572 (44.7M)
+Cells touched     = 50853572 (50.9M)
+Particle comms    = 0 (0K)
+Boundary collides = 149921 (0.15M)
+Boundary exits    = 154891 (0.155M)
+SurfColl checks   = 2948879 (2.95M)
+SurfColl occurs   = 52404 (52.4K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.04191e+07
+Particle-moves/step: 44728.6
+Cell-touches/particle/step: 1.13694
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00335179
+Particle fraction exiting boundary: 0.00346291
+Surface-checks/particle/step: 0.0659283
+Surface-collisions/particle/step: 0.0011716
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 55832 ave 55832 max 55832 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1      		    group 2 particle check
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  368 8 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  2305 deleted particles
+  CPU time = 0.00126004 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 11.4475 5.61968 37.0672 33.3586 12.5071 5.43046 27.3794
+  surf2grid time = 0.000420332 secs
+  map/comm1/comm2/comm3/comm4/split percent = 44.7533 12.9325 15.4282 4.481 6.40953 12.3653
+surf_modify         all collide 1
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 8.27409 8.27409 8.27409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1000            0    53527        0        0        0        0 
+    1100   0.27103996    54016        0        0      141     7545 
+    1200   0.55062723    54742        0        0      123     7464 
+    1300    0.8280983    55144        0        0      123     7561 
+    1400    1.1075971    55565        0        0      137     7710 
+    1500    1.3889072    55768        0        0      133     7788 
+    1600    1.6779668    56022        0        0      134     7754 
+    1700    1.9620676    55835        0        0      134     7805 
+    1800    2.2451291    56043        0        0      124     7579 
+    1900    2.5335872    56081        0        0      128     7571 
+    2000    2.8178728    56361        0        0      108     7522 
+Loop time of 2.81789 on 1 procs for 1000 steps with 56361 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.9606     | 1.9606     | 1.9606     |   0.0 | 69.58
+Coll    | 0.36141    | 0.36141    | 0.36141    |   0.0 | 12.83
+Sort    | 0.35988    | 0.35988    | 0.35988    |   0.0 | 12.77
+Comm    | 0.0096009  | 0.0096009  | 0.0096009  |   0.0 |  0.34
+Modify  | 0.12312    | 0.12312    | 0.12312    |   0.0 |  4.37
+Output  | 0.0002718  | 0.0002718  | 0.0002718  |   0.0 |  0.01
+Other   |            | 0.002968   |            |       |  0.11
+
+Particle moves    = 55610082 (55.6M)
+Cells touched     = 62787963 (62.8M)
+Particle comms    = 0 (0K)
+Boundary collides = 191493 (0.191M)
+Boundary exits    = 207898 (0.208M)
+SurfColl checks   = 7502245 (7.5M)
+SurfColl occurs   = 125977 (0.126M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.97346e+07
+Particle-moves/step: 55610.1
+Cell-touches/particle/step: 1.12908
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00344349
+Particle fraction exiting boundary: 0.00373849
+Surface-checks/particle/step: 0.134908
+Surface-collisions/particle/step: 0.00226536
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 56361 ave 56361 max 56361 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_1.surf.move
+++ b/examples/surf/log.29Jun21.mpi_1.surf.move
@@ -1,0 +1,436 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000945091 secs
+  create/ghost percent = 84.561 15.439
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00015974 secs
+  reassign/sort/migrate/ghost percent = 57.4627 1.64179 20 20.8955
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000664949 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 30.4769 11.151 1.0398 46.5041 10.8283 5.88024 0.0358551
+  surf2grid time = 0.000309229 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41.6345 12.4133 8.40401 3.93215 16.4225 13.1843
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.055136919    20918        0        0       31     3080 
+     200   0.19117332    36005        0        0       47     6622 
+     300   0.37282896    43617        0        0       62     7700 
+     400   0.58409691    48013        0        0       71     8610 
+     500   0.81000447    50729        0        0       55     8456 
+Loop time of 0.810027 on 1 procs for 500 steps with 50729 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.55683    | 0.55683    | 0.55683    |   0.0 | 68.74
+Coll    | 0.084132   | 0.084132   | 0.084132   |   0.0 | 10.39
+Sort    | 0.098967   | 0.098967   | 0.098967   |   0.0 | 12.22
+Comm    | 0.0025785  | 0.0025785  | 0.0025785  |   0.0 |  0.32
+Modify  | 0.066316   | 0.066316   | 0.066316   |   0.0 |  8.19
+Output  | 0.00014734 | 0.00014734 | 0.00014734 |   0.0 |  0.02
+Other   |            | 0.001052   |            |       |  0.13
+
+Particle moves    = 17640116 (17.6M)
+Cells touched     = 18850705 (18.9M)
+Particle comms    = 0 (0K)
+Boundary collides = 59466 (59.5K)
+Boundary exits    = 54593 (54.6K)
+SurfColl checks   = 3017210 (3.02M)
+SurfColl occurs   = 21530 (21.5K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.17772e+07
+Particle-moves/step: 35280.2
+Cell-touches/particle/step: 1.06863
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00337107
+Particle fraction exiting boundary: 0.00309482
+Surface-checks/particle/step: 0.171043
+Surface-collisions/particle/step: 0.00122051
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 50729 ave 50729 max 50729 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans -1 0 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  1881 deleted particles
+  CPU time = 0.000876427 secs
+  sort/surf2grid/ghost/inout/particle percent = 37.7312 25.0544 5.4951 4.27095 27.4483
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    48848        0        0        0        0 
+     600   0.22455573    50538        0        0       67     9912 
+     700   0.45578265    51573        0        0       70     9898 
+     800   0.69130349    52461        0        0       70    10136 
+     900   0.93599987    53020        0        0       60     9492 
+    1000     1.176517    53326        0        0       63     9590 
+Loop time of 1.17653 on 1 procs for 500 steps with 53326 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.82094    | 0.82094    | 0.82094    |   0.0 | 69.78
+Coll    | 0.14332    | 0.14332    | 0.14332    |   0.0 | 12.18
+Sort    | 0.14707    | 0.14707    | 0.14707    |   0.0 | 12.50
+Comm    | 0.0041859  | 0.0041859  | 0.0041859  |   0.0 |  0.36
+Modify  | 0.059793   | 0.059793   | 0.059793   |   0.0 |  5.08
+Output  | 0.00011611 | 0.00011611 | 0.00011611 |   0.0 |  0.01
+Other   |            | 0.00111    |            |       |  0.09
+
+Particle moves    = 25976617 (26M)
+Cells touched     = 27611294 (27.6M)
+Particle comms    = 0 (0K)
+Boundary collides = 86022 (86K)
+Boundary exits    = 100890 (0.101M)
+SurfColl checks   = 4739308 (4.74M)
+SurfColl occurs   = 30852 (30.9K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.20789e+07
+Particle-moves/step: 51953.2
+Cell-touches/particle/step: 1.06293
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00331152
+Particle fraction exiting boundary: 0.00388388
+Surface-checks/particle/step: 0.182445
+Surface-collisions/particle/step: 0.00118768
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 53326 ave 53326 max 53326 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans 0 -1 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  1405 deleted particles
+  CPU time = 0.000961304 secs
+  sort/surf2grid/ghost/inout/particle percent = 37.252 26.1409 4.21627 4.43948 27.9514
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1000            0    51921        0        0        0        0 
+    1100   0.23346949    52243        0        0       58     9786 
+    1200    0.4715116    53130        0        0       65     9632 
+    1300   0.71859479    53567        0        0       76    10150 
+    1400   0.96152353    53940        0        0       78    10052 
+    1500    1.2068017    54231        0        0       69     9758 
+Loop time of 1.20682 on 1 procs for 500 steps with 54231 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.83963    | 0.83963    | 0.83963    |   0.0 | 69.57
+Coll    | 0.14967    | 0.14967    | 0.14967    |   0.0 | 12.40
+Sort    | 0.15186    | 0.15186    | 0.15186    |   0.0 | 12.58
+Comm    | 0.0043628  | 0.0043628  | 0.0043628  |   0.0 |  0.36
+Modify  | 0.060035   | 0.060035   | 0.060035   |   0.0 |  4.97
+Output  | 0.00012517 | 0.00012517 | 0.00012517 |   0.0 |  0.01
+Other   |            | 0.001137   |            |       |  0.09
+
+Particle moves    = 26705888 (26.7M)
+Cells touched     = 28349568 (28.3M)
+Particle comms    = 0 (0K)
+Boundary collides = 87110 (87.1K)
+Boundary exits    = 102973 (0.103M)
+SurfColl checks   = 4705162 (4.71M)
+SurfColl occurs   = 30430 (30.4K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.21291e+07
+Particle-moves/step: 53411.8
+Cell-touches/particle/step: 1.06155
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00326183
+Particle fraction exiting boundary: 0.00385582
+Surface-checks/particle/step: 0.176184
+Surface-collisions/particle/step: 0.00113945
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 54231 ave 54231 max 54231 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans 1 0 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  786 deleted particles
+  CPU time = 0.000905037 secs
+  sort/surf2grid/ghost/inout/particle percent = 41.5964 25.5005 4.42571 4.03056 24.4468
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1500            0    53445        0        0        0        0 
+    1600   0.24068642    54383        0        0       59     9142 
+    1700   0.49522042    55542        0        0       54     8806 
+    1800   0.74906659    56407        0        0       57     9436 
+    1900    1.0060201    56697        0        0       59    10150 
+    2000    1.2658842    57299        0        0       65    10472 
+Loop time of 1.2659 on 1 procs for 500 steps with 57299 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.87365    | 0.87365    | 0.87365    |   0.0 | 69.01
+Coll    | 0.16406    | 0.16406    | 0.16406    |   0.0 | 12.96
+Sort    | 0.1616     | 0.1616     | 0.1616     |   0.0 | 12.77
+Comm    | 0.0044456  | 0.0044456  | 0.0044456  |   0.0 |  0.35
+Modify  | 0.060802   | 0.060802   | 0.060802   |   0.0 |  4.80
+Output  | 0.00013161 | 0.00013161 | 0.00013161 |   0.0 |  0.01
+Other   |            | 0.001221   |            |       |  0.10
+
+Particle moves    = 27939283 (27.9M)
+Cells touched     = 29655039 (29.7M)
+Particle comms    = 0 (0K)
+Boundary collides = 91806 (91.8K)
+Boundary exits    = 101497 (0.101M)
+SurfColl checks   = 4651612 (4.65M)
+SurfColl occurs   = 29739 (29.7K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.20706e+07
+Particle-moves/step: 55878.6
+Cell-touches/particle/step: 1.06141
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00328591
+Particle fraction exiting boundary: 0.00363277
+Surface-checks/particle/step: 0.16649
+Surface-collisions/particle/step: 0.00106442
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 57299 ave 57299 max 57299 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans 0 1 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  1505 deleted particles
+  CPU time = 0.00101471 secs
+  sort/surf2grid/ghost/inout/particle percent = 42.7397 22.11 3.97086 4.3938 26.7857
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2000            0    55794        0        0        0        0 
+    2100   0.25925422    56563        0        0       60     9464 
+    2200   0.51816368    57262        0        0       52     9464 
+    2300   0.78029251    57706        0        0       62     9394 
+    2400    1.0440998    57892        0        0       69    10556 
+    2500     1.317132    58073        0        0       64    10150 
+Loop time of 1.31715 on 1 procs for 500 steps with 58073 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.90008    | 0.90008    | 0.90008    |   0.0 | 68.33
+Coll    | 0.17833    | 0.17833    | 0.17833    |   0.0 | 13.54
+Sort    | 0.1708     | 0.1708     | 0.1708     |   0.0 | 12.97
+Comm    | 0.0045698  | 0.0045698  | 0.0045698  |   0.0 |  0.35
+Modify  | 0.061935   | 0.061935   | 0.061935   |   0.0 |  4.70
+Output  | 0.00013137 | 0.00013137 | 0.00013137 |   0.0 |  0.01
+Other   |            | 0.001315   |            |       |  0.10
+
+Particle moves    = 28728272 (28.7M)
+Cells touched     = 30479602 (30.5M)
+Particle comms    = 0 (0K)
+Boundary collides = 94930 (94.9K)
+Boundary exits    = 103154 (0.103M)
+SurfColl checks   = 4825366 (4.83M)
+SurfColl occurs   = 30946 (30.9K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.18109e+07
+Particle-moves/step: 57456.5
+Cell-touches/particle/step: 1.06096
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00330441
+Particle fraction exiting boundary: 0.00359068
+Surface-checks/particle/step: 0.167966
+Surface-collisions/particle/step: 0.0010772
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 58073 ave 58073 max 58073 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_1.surf.remove
+++ b/examples/surf/log.29Jun21.mpi_1.surf.remove
@@ -1,0 +1,232 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00109625 secs
+  create/ghost percent = 75.2936 24.7064
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000265598 secs
+  reassign/sort/migrate/ghost percent = 46.7684 1.3465 15.3501 36.535
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000855923 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 23.0641 8.55153 1.92201 51.337 15.1253 7.10306 0.0278552
+  surf2grid time = 0.000439405 secs
+  map/comm1/comm2/comm3/comm4/split percent = 42.8649 8.6815 15.4639 3.36408 13.2393 12.0998
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  368 8 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.000716925 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 15.6967 9.14533 2.06186 54.7722 18.3239 8.81277 0.0332557
+  surf2grid time = 0.000392675 secs
+  map/comm1/comm2/comm3/comm4/split percent = 45.9016 13.1148 16.1506 4.37158 6.43594 11.0504
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 1.52409 1.52409 1.52409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.060081244    20907        0        0       49     2305 
+     200   0.21104312    36060        0        0      111     5386 
+     300   0.41278815    43575        0        0      114     6615 
+     400   0.64198613    47826        0        0      106     6776 
+     500   0.89377666    50165        0        0      101     6841 
+     600    1.1497505    51852        0        0      110     7233 
+     700    1.4132097    53017        0        0      125     7415 
+     800     1.681464    53966        0        0      130     7146 
+     900    1.9605689    54520        0        0      120     7670 
+    1000    2.2349491    54679        0        0      124     7202 
+Loop time of 2.23497 on 1 procs for 1000 steps with 54679 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.5675     | 1.5675     | 1.5675     |   0.0 | 70.14
+Coll    | 0.25266    | 0.25266    | 0.25266    |   0.0 | 11.31
+Sort    | 0.27515    | 0.27515    | 0.27515    |   0.0 | 12.31
+Comm    | 0.0067093  | 0.0067093  | 0.0067093  |   0.0 |  0.30
+Modify  | 0.13042    | 0.13042    | 0.13042    |   0.0 |  5.84
+Output  | 0.00022244 | 0.00022244 | 0.00022244 |   0.0 |  0.01
+Other   |            | 0.002275   |            |       |  0.10
+
+Particle moves    = 44272797 (44.3M)
+Cells touched     = 50341168 (50.3M)
+Particle comms    = 0 (0K)
+Boundary collides = 155587 (0.156M)
+Boundary exits    = 156044 (0.156M)
+SurfColl checks   = 6119443 (6.12M)
+SurfColl occurs   = 108460 (0.108M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.98092e+07
+Particle-moves/step: 44272.8
+Cell-touches/particle/step: 1.13707
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00351428
+Particle fraction exiting boundary: 0.0035246
+Surface-checks/particle/step: 0.138221
+Surface-collisions/particle/step: 0.00244981
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 54679 ave 54679 max 54679 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+remove_surf         1
+  removed 50 lines
+  50 lines remain
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000742435 secs
+  sort/surf2grid/particle/ghost percent = 55.2987 44.7013 0.032113 25.4978
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1000            0    54679        0        0        0        0 
+    1100   0.26706553    55374        0        0       66     3663 
+    1200   0.54402113    56251        0        0       61     3649 
+    1300   0.82020736    56685        0        0       53     3637 
+    1400    1.0975926    57140        0        0       64     3741 
+    1500    1.3765595    57406        0        0       62     3654 
+    1600    1.6630738    57435        0        0       65     3871 
+    1700    1.9429493    57441        0        0       74     3947 
+    1800    2.2237082    57633        0        0       58     3663 
+    1900    2.5044594    57548        0        0       58     3703 
+    2000     2.792773    57941        0        0       59     3794 
+Loop time of 2.79279 on 1 procs for 1000 steps with 57941 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.9045     | 1.9045     | 1.9045     |   0.0 | 68.20
+Coll    | 0.37809    | 0.37809    | 0.37809    |   0.0 | 13.54
+Sort    | 0.37177    | 0.37177    | 0.37177    |   0.0 | 13.31
+Comm    | 0.0085359  | 0.0085359  | 0.0085359  |   0.0 |  0.31
+Modify  | 0.12692    | 0.12692    | 0.12692    |   0.0 |  4.54
+Output  | 0.00025558 | 0.00025558 | 0.00025558 |   0.0 |  0.01
+Other   |            | 0.002674   |            |       |  0.10
+
+Particle moves    = 57107499 (57.1M)
+Cells touched     = 64445552 (64.4M)
+Particle comms    = 0 (0K)
+Boundary collides = 189036 (0.189M)
+Boundary exits    = 207470 (0.207M)
+SurfColl checks   = 3715344 (3.72M)
+SurfColl occurs   = 62234 (62.2K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.04482e+07
+Particle-moves/step: 57107.5
+Cell-touches/particle/step: 1.1285
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00331018
+Particle fraction exiting boundary: 0.00363297
+Surface-checks/particle/step: 0.0650588
+Surface-collisions/particle/step: 0.00108977
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 57941 ave 57941 max 57941 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_1.surf.rotate
+++ b/examples/surf/log.29Jun21.mpi_1.surf.rotate
@@ -1,0 +1,286 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00108027 secs
+  create/ghost percent = 74.7296 25.2704
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000291824 secs
+  reassign/sort/migrate/ghost percent = 48.7745 1.71569 14.4608 35.049
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 scale 1.2 0.2 1
+  50 points
+  50 lines
+  1.4 8.6 xlo xhi
+  4.40118 5.59882 ylo yhi
+  0 0 zlo zhi
+  0.0803795 min line length
+  0 0 = number of pushed cells
+  36 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  352 12 36 = cells outside/inside/overlapping surfs
+  36 = surf cells with 1,2,etc splits
+  93.232 93.232 = cell-wise and global flow volume
+  CPU time = 0.000900745 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 21.3605 7.4378 1.93224 55.6114 13.658 7.01429 0.026469
+  surf2grid time = 0.000500917 secs
+  map/comm1/comm2/comm3/comm4/split percent = 45.2642 7.42504 13.1366 3.71252 12.5654 13.9457
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.074530602    20829        0        0       52     3675 
+     200   0.26373124    35738        0        0       94     5913 
+     300   0.51855087    43301        0        0      105     7240 
+     400   0.81444955    47685        0        0      145     8265 
+     500    1.1267471    50318        0        0      139     8592 
+Loop time of 1.12677 on 1 procs for 500 steps with 50318 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.63617    | 0.63617    | 0.63617    |   0.0 | 56.46
+Coll    | 0.08341    | 0.08341    | 0.08341    |   0.0 |  7.40
+Sort    | 0.10694    | 0.10694    | 0.10694    |   0.0 |  9.49
+Comm    | 0.0026703  | 0.0026703  | 0.0026703  |   0.0 |  0.24
+Modify  | 0.29631    | 0.29631    | 0.29631    |   0.0 | 26.30
+Output  | 0.00011921 | 0.00011921 | 0.00011921 |   0.0 |  0.01
+Other   |            | 0.00114    |            |       |  0.10
+
+Particle moves    = 17508313 (17.5M)
+Cells touched     = 19994425 (20M)
+Particle comms    = 0 (0K)
+Boundary collides = 61730 (61.7K)
+Boundary exits    = 55033 (55K)
+SurfColl checks   = 2982723 (2.98M)
+SurfColl occurs   = 45980 (46K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.55385e+07
+Particle-moves/step: 35016.6
+Cell-touches/particle/step: 1.142
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00352575
+Particle fraction exiting boundary: 0.00314325
+Surface-checks/particle/step: 0.17036
+Surface-collisions/particle/step: 0.00262618
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 50318 ave 50318 max 50318 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf all 100 2000 rotate 360 0 0 1 5 5 0
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    50318        0        0        0        0 
+     600   0.32566619    48549        0        0      146     9007 
+     700   0.64420485    47445        0        0      128     7524 
+     800   0.95522857    46989        0        0      122     8163 
+     900    1.2652605    47170        0        0      147     8489 
+    1000    1.5757945    46737        0        0      155     7768 
+    1100    1.8844218    46534        0        0      146     8487 
+    1200    2.1870675    46615        0        0      154     7514 
+    1300    2.4923282    46575        0        0      150     8307 
+    1400    2.8054891    47433        0        0      139     8219 
+    1500    3.1175923    47385        0        0      155     7806 
+    1600    3.4299555    47379        0        0      131     9185 
+    1700    3.7454393    47225        0        0      119     7471 
+    1800    4.0573194    47243        0        0      151     8273 
+    1900    4.3694272    47621        0        0      129     8206 
+    2000    4.6871016    47247        0        0      145     7622 
+    2100    4.9959614    47225        0        0      164     8614 
+    2200    5.3028328    46970        0        0      151     7519 
+    2300    5.6109416    47088        0        0      135     8393 
+    2400    5.9272501    47578        0        0      160     8791 
+    2500    6.2391453    47345        0        0      135     7520 
+Loop time of 6.23916 on 1 procs for 2000 steps with 47345 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 3.497      | 3.497      | 3.497      |   0.0 | 56.05
+Coll    | 0.52501    | 0.52501    | 0.52501    |   0.0 |  8.41
+Sort    | 0.61496    | 0.61496    | 0.61496    |   0.0 |  9.86
+Comm    | 0.015781   | 0.015781   | 0.015781   |   0.0 |  0.25
+Modify  | 1.5809     | 1.5809     | 1.5809     |   0.0 | 25.34
+Output  | 0.00048065 | 0.00048065 | 0.00048065 |   0.0 |  0.01
+Other   |            | 0.005082   |            |       |  0.08
+
+Particle moves    = 98499815 (98.5M)
+Cells touched     = 111421754 (111M)
+Particle comms    = 0 (0K)
+Boundary collides = 352189 (0.352M)
+Boundary exits    = 351286 (0.351M)
+SurfColl checks   = 13845989 (13.8M)
+SurfColl occurs   = 263506 (0.264M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.57873e+07
+Particle-moves/step: 49249.9
+Cell-touches/particle/step: 1.13119
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00357553
+Particle fraction exiting boundary: 0.00356636
+Surface-checks/particle/step: 0.140569
+Surface-collisions/particle/step: 0.00267519
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 47345 ave 47345 max 47345 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+unfix               10
+
+run                 500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 8.26894 8.26894 8.26894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2500            0    47345        0        0        0        0 
+    2600   0.31033421    51171        0        0      138     8694 
+    2700    0.6502471    53467        0        0      151     8891 
+    2800   0.99387598    54455        0        0      152     9284 
+    2900    1.3423297    55009        0        0      141     8987 
+    3000    1.6996589    55560        0        0      135     9172 
+Loop time of 1.69968 on 1 procs for 500 steps with 55560 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.95658    | 0.95658    | 0.95658    |   0.0 | 56.28
+Coll    | 0.14513    | 0.14513    | 0.14513    |   0.0 |  8.54
+Sort    | 0.17062    | 0.17062    | 0.17062    |   0.0 | 10.04
+Comm    | 0.0044074  | 0.0044074  | 0.0044074  |   0.0 |  0.26
+Modify  | 0.42145    | 0.42145    | 0.42145    |   0.0 | 24.80
+Output  | 0.00011754 | 0.00011754 | 0.00011754 |   0.0 |  0.01
+Other   |            | 0.001372   |            |       |  0.08
+
+Particle moves    = 26673985 (26.7M)
+Cells touched     = 30107396 (30.1M)
+Particle comms    = 0 (0K)
+Boundary collides = 92587 (92.6K)
+Boundary exits    = 97104 (97.1K)
+SurfColl checks   = 4314376 (4.31M)
+SurfColl occurs   = 69096 (69.1K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.56935e+07
+Particle-moves/step: 53348
+Cell-touches/particle/step: 1.12872
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00347106
+Particle fraction exiting boundary: 0.0036404
+Surface-checks/particle/step: 0.161745
+Surface-collisions/particle/step: 0.00259039
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 55560 ave 55560 max 55560 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf/log.29Jun21.mpi_1.surf.slide
+++ b/examples/surf/log.29Jun21.mpi_1.surf.slide
@@ -1,0 +1,308 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00110769 secs
+  create/ghost percent = 72.3203 27.6797
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000260353 secs
+  reassign/sort/migrate/ghost percent = 45.8791 1.37363 15.2015 37.5458
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000872374 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 22.7385 10.85 1.96775 50.0137 14.4302 7.37907 0.0273299
+  surf2grid time = 0.000436306 secs
+  map/comm1/comm2/comm3/comm4/split percent = 43.3333 8.52459 15.0273 3.49727 13.1694 12.1311
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  368 8 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.000745773 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 13.7788 9.43095 3.06905 55.7545 17.9668 7.99233 0
+  surf2grid time = 0.000415802 secs
+  map/comm1/comm2/comm3/comm4/split percent = 46.8463 12.6147 16.8005 3.89908 6.07798 10.6651
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 1.52409 1.52409 1.52409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.073227644    20907        0        0       49     2305 
+     200   0.26174712    36060        0        0      111     5386 
+     300   0.51711512    43575        0        0      114     6615 
+     400   0.81275845    47826        0        0      106     6776 
+     500    1.1241541    50165        0        0      101     6841 
+Loop time of 1.12417 on 1 procs for 500 steps with 50165 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.62705    | 0.62705    | 0.62705    |   0.0 | 55.78
+Coll    | 0.089552   | 0.089552   | 0.089552   |   0.0 |  7.97
+Sort    | 0.10705    | 0.10705    | 0.10705    |   0.0 |  9.52
+Comm    | 0.0026951  | 0.0026951  | 0.0026951  |   0.0 |  0.24
+Modify  | 0.29654    | 0.29654    | 0.29654    |   0.0 | 26.38
+Output  | 0.00012445 | 0.00012445 | 0.00012445 |   0.0 |  0.01
+Other   |            | 0.001163   |            |       |  0.10
+
+Particle moves    = 17579205 (17.6M)
+Cells touched     = 20116172 (20.1M)
+Particle comms    = 0 (0K)
+Boundary collides = 62496 (62.5K)
+Boundary exits    = 55186 (55.2K)
+SurfColl checks   = 2453471 (2.45M)
+SurfColl occurs   = 45659 (45.7K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.56374e+07
+Particle-moves/step: 35158.4
+Cell-touches/particle/step: 1.14432
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00355511
+Particle fraction exiting boundary: 0.00313928
+Surface-checks/particle/step: 0.139567
+Surface-collisions/particle/step: 0.00259733
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 50165 ave 50165 max 50165 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf 1 100 2000 trans 0 -0.9 0
+fix                 11 move/surf 2 100 2000 trans 0 0.9 0
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 8.27409 8.27409 8.27409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    50165        0        0        0        0 
+     600   0.32562852    50139        0        0      110     7233 
+     700   0.65865827    50251        0        0      115     9207 
+     800   0.98763537    50619        0        0      104     9392 
+     900    1.3201888    50235        0        0      129    10419 
+    1000    1.6572163    49916        0        0      141    10731 
+    1100    1.9870524    49955        0        0      133    10873 
+    1200    2.3170543    50133        0        0      113    10551 
+    1300    2.6535378    50762        0        0      136    10878 
+    1400     2.988111    51360        0        0      117    10234 
+    1500    3.3248291    51553        0        0      131    10177 
+    1600    3.6687863    52271        0        0      134     9649 
+    1700    4.0067239    51871        0        0      125     7610 
+    1800     4.344768    51827        0        0      109     9410 
+    1900     4.689028    51803        0        0      120     9724 
+    2000    5.0292532    51604        0        0      128    10231 
+    2100    5.3697615    51406        0        0      132    11062 
+    2200     5.714597    51258        0        0      147    11381 
+    2300    6.0532341    51241        0        0      128    11004 
+    2400    6.3905694    51673        0        0      134    11080 
+    2500    6.7361462    52070        0        0      123    10726 
+Loop time of 6.73617 on 1 procs for 2000 steps with 52070 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 3.7438     | 3.7438     | 3.7438     |   0.0 | 55.58
+Coll    | 0.62095    | 0.62095    | 0.62095    |   0.0 |  9.22
+Sort    | 0.66207    | 0.66207    | 0.66207    |   0.0 |  9.83
+Comm    | 0.017666   | 0.017666   | 0.017666   |   0.0 |  0.26
+Modify  | 1.6855     | 1.6855     | 1.6855     |   0.0 | 25.02
+Output  | 0.00051975 | 0.00051975 | 0.00051975 |   0.0 |  0.01
+Other   |            | 0.005654   |            |       |  0.08
+
+Particle moves    = 104287759 (104M)
+Cells touched     = 117908251 (118M)
+Particle comms    = 0 (0K)
+Boundary collides = 364327 (0.364M)
+Boundary exits    = 381621 (0.382M)
+SurfColl checks   = 17783754 (17.8M)
+SurfColl occurs   = 233741 (0.234M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.54818e+07
+Particle-moves/step: 52143.9
+Cell-touches/particle/step: 1.1306
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00349348
+Particle fraction exiting boundary: 0.00365931
+Surface-checks/particle/step: 0.170526
+Surface-collisions/particle/step: 0.00224131
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 52070 ave 52070 max 52070 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+
+unfix               10
+unfix               11
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 6.75 6.75 6.75
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 8.27409 8.27409 8.27409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2500            0    52070        0        0        0        0 
+    2600   0.33904767    54141        0        0      122     9878 
+    2700   0.69245386    55359        0        0      137    10009 
+    2800    1.0568233    55670        0        0      138    10176 
+    2900    1.4178827    56088        0        0      127    10201 
+    3000    1.7802949    56392        0        0      141    10334 
+    3100    2.1489832    56296        0        0      123    10239 
+    3200    2.5130703    56231        0        0      118     9871 
+    3300      2.87659    56511        0        0      135    10253 
+    3400    3.2475867    56599        0        0      128     9782 
+    3500    3.6121597    56523        0        0      143    10058 
+Loop time of 3.61218 on 1 procs for 1000 steps with 56523 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 2.0129     | 2.0129     | 2.0129     |   0.0 | 55.73
+Coll    | 0.34463    | 0.34463    | 0.34463    |   0.0 |  9.54
+Sort    | 0.36128    | 0.36128    | 0.36128    |   0.0 | 10.00
+Comm    | 0.0096064  | 0.0096064  | 0.0096064  |   0.0 |  0.27
+Modify  | 0.88031    | 0.88031    | 0.88031    |   0.0 | 24.37
+Output  | 0.00024176 | 0.00024176 | 0.00024176 |   0.0 |  0.01
+Other   |            | 0.003197   |            |       |  0.09
+
+Particle moves    = 55968827 (56M)
+Cells touched     = 63131269 (63.1M)
+Particle comms    = 0 (0K)
+Boundary collides = 192510 (0.193M)
+Boundary exits    = 206162 (0.206M)
+SurfColl checks   = 9925028 (9.93M)
+SurfColl occurs   = 127235 (0.127M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.54945e+07
+Particle-moves/step: 55968.8
+Cell-touches/particle/step: 1.12797
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00343959
+Particle fraction exiting boundary: 0.00368351
+Surface-checks/particle/step: 0.177331
+Surface-collisions/particle/step: 0.00227332
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 56523 ave 56523 max 56523 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_4.surf.add
+++ b/examples/surf/log.29Jun21.mpi_4.surf.add
@@ -1,0 +1,225 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00108838 secs
+  create/ghost percent = 86.0022 13.9978
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000957251 secs
+  reassign/sort/migrate/ghost percent = 64.8319 0.672478 14.5953 19.9004
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.00105762 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 24.6844 11.7674 1.03697 49.4139 13.0974 17.606 0.338142
+  surf2grid time = 0.000522614 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.6496 7.75547 8.34854 5.33759 9.16971 31.0675
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.035365582    20959        0        0       31     1321 
+     200   0.10145688    36019        0        0       62     2655 
+     300   0.18167162    43751        0        0       57     3018 
+     400   0.28853798    48041        0        0       58     3291 
+     500   0.38170218    50608        0        0       64     3651 
+     600   0.47631264    52527        0        0       55     3355 
+     700   0.57460451    53955        0        0       50     3542 
+     800   0.67200136    54798        0        0       64     3428 
+     900   0.77060246    55185        0        0       76     3944 
+    1000   0.87020755    55593        0        0       74     3918 
+Loop time of 0.870295 on 4 procs for 1000 steps with 55593 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.23536    | 0.38603    | 0.55041    |  20.4 | 44.36
+Coll    | 0.021213   | 0.042142   | 0.05974    |   7.9 |  4.84
+Sort    | 0.060204   | 0.091382   | 0.11891    |   8.0 | 10.50
+Comm    | 0.032218   | 0.049152   | 0.056006   |   4.4 |  5.65
+Modify  | 0.00050426 | 0.035397   | 0.070728   |  18.5 |  4.07
+Output  | 0.00028133 | 0.00085992 | 0.0013039  |   0.0 |  0.10
+Other   |            | 0.2653     |            |       | 30.49
+
+Particle moves    = 44688166 (44.7M)
+Cells touched     = 50809302 (50.8M)
+Particle comms    = 297024 (0.297M)
+Boundary collides = 150200 (0.15M)
+Boundary exits    = 155241 (0.155M)
+SurfColl checks   = 2958944 (2.96M)
+SurfColl occurs   = 52182 (52.2K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.28371e+07
+Particle-moves/step: 44688.2
+Cell-touches/particle/step: 1.13697
+Particle comm iterations/step: 2.441
+Particle fraction communicated: 0.00664659
+Particle fraction colliding with boundary: 0.00336107
+Particle fraction exiting boundary: 0.00347387
+Surface-checks/particle/step: 0.0662131
+Surface-collisions/particle/step: 0.00116769
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13898.2 ave 17811 max 8993 min
+Histogram: 1 0 0 1 0 0 0 0 1 1
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1      		    group 2 particle check
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  368 8 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  2346 deleted particles
+  CPU time = 0.00111508 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 15.8863 14.5606 17.4898 41.9927 10.0706 14.133 12.1873
+  surf2grid time = 0.000468254 secs
+  map/comm1/comm2/comm3/comm4/split percent = 30.7026 9.92872 9.11405 5.34623 4.83707 32.9939
+surf_modify         all collide 1
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 4.05534 3.21159 4.89909
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1000            0    53247        0        0        0        0 
+    1100   0.10060668    54051        0        0      125     6876 
+    1200    0.2062912    54590        0        0      124     7212 
+    1300   0.31432199    55260        0        0      122     7378 
+    1400   0.44448638    55642        0        0      125     7475 
+    1500   0.55510998    55905        0        0      126     7788 
+    1600   0.68008637    56109        0        0      129     7744 
+    1700   0.79233623    56221        0        0      142     7526 
+    1800   0.90353203    56112        0        0      109     7575 
+    1900    1.0150337    56060        0        0      136     7864 
+    2000    1.1262314    56144        0        0      123     7453 
+Loop time of 1.12631 on 4 procs for 1000 steps with 56144 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.28371    | 0.50638    | 0.72494    |  30.7 | 44.96
+Coll    | 0.025453   | 0.056261   | 0.087805   |  13.0 |  5.00
+Sort    | 0.074677   | 0.11576    | 0.16111    |  11.9 | 10.28
+Comm    | 0.038598   | 0.050306   | 0.056557   |   3.1 |  4.47
+Modify  | 0.00086188 | 0.034795   | 0.069229   |  18.2 |  3.09
+Output  | 0.00028014 | 0.0011544  | 0.0017767  |   1.9 |  0.10
+Other   |            | 0.3617     |            |       | 32.11
+
+Particle moves    = 55669007 (55.7M)
+Cells touched     = 62849877 (62.8M)
+Particle comms    = 321143 (0.321M)
+Boundary collides = 191276 (0.191M)
+Boundary exits    = 207764 (0.208M)
+SurfColl checks   = 7528705 (7.53M)
+SurfColl occurs   = 126604 (0.127M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.23565e+07
+Particle-moves/step: 55669
+Cell-touches/particle/step: 1.12899
+Particle comm iterations/step: 2.506
+Particle fraction communicated: 0.00576879
+Particle fraction colliding with boundary: 0.00343595
+Particle fraction exiting boundary: 0.00373213
+Surface-checks/particle/step: 0.135241
+Surface-collisions/particle/step: 0.00227423
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 14036 ave 20423 max 7771 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_4.surf.move
+++ b/examples/surf/log.29Jun21.mpi_4.surf.move
@@ -1,0 +1,437 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 100 child grid cells
+  CPU time = 0.00108981 secs
+  create/ghost percent = 84.2485 15.7515
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000790358 secs
+  reassign/sort/migrate/ghost percent = 69.7436 0.784314 12.006 17.4661
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.00104165 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.4063 17.7157 0.686656 46.6011 9.5903 16.8917 0.320439
+  surf2grid time = 0.00048542 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.6699 10.609 5.64833 4.56778 10.0688 32.9568
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.033916712    20901        0        0       14     3122 
+     200    0.1001997    35945        0        0       53     6650 
+     300   0.19177508    43816        0        0       47     7812 
+     400   0.28949904    47999        0        0       65     8414 
+     500   0.38408399    50612        0        0       62     9296 
+Loop time of 0.384179 on 4 procs for 500 steps with 50612 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.079534   | 0.14961    | 0.23665    |  16.8 | 38.94
+Coll    | 0.006043   | 0.015653   | 0.024828   |   6.4 |  4.07
+Sort    | 0.018365   | 0.032112   | 0.043346   |   6.0 |  8.36
+Comm    | 0.016084   | 0.017218   | 0.018188   |   0.6 |  4.48
+Modify  | 0.00022531 | 0.017527   | 0.035843   |  13.1 |  4.56
+Output  | 0.00013566 | 0.0027124  | 0.0095782  |   7.6 |  0.71
+Other   |            | 0.1494     |            |       | 38.88
+
+Particle moves    = 17632049 (17.6M)
+Cells touched     = 18843631 (18.8M)
+Particle comms    = 122668 (0.123M)
+Boundary collides = 59486 (59.5K)
+Boundary exits    = 54770 (54.8K)
+SurfColl checks   = 3034038 (3.03M)
+SurfColl occurs   = 21569 (21.6K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.14738e+07
+Particle-moves/step: 35264.1
+Cell-touches/particle/step: 1.06871
+Particle comm iterations/step: 2.366
+Particle fraction communicated: 0.0069571
+Particle fraction colliding with boundary: 0.00337374
+Particle fraction exiting boundary: 0.00310628
+Surface-checks/particle/step: 0.172075
+Surface-collisions/particle/step: 0.00122328
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 12653 ave 16390 max 7983 min
+Histogram: 1 0 0 1 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans -1 0 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  1902 deleted particles
+  CPU time = 0.00100994 secs
+  sort/surf2grid/ghost/inout/particle percent = 14.542 47.4032 6.20869 19.0982 12.7479
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.10938 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 3.62832 3.20644 4.89394
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    48710        0        0        0        0 
+     600  0.092022419    50401        0        0       71     9800 
+     700   0.18600965    51556        0        0       68     8722 
+     800   0.28100276    52357        0        0       65     9576 
+     900   0.37642574    52699        0        0       53     9072 
+    1000   0.47471309    53033        0        0       65     9282 
+Loop time of 0.474794 on 4 procs for 500 steps with 53033 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.13591    | 0.21565    | 0.32555    |  15.8 | 45.42
+Coll    | 0.014035   | 0.024503   | 0.032903   |   5.1 |  5.16
+Sort    | 0.036485   | 0.048648   | 0.058772   |   4.2 | 10.25
+Comm    | 0.016048   | 0.017452   | 0.018577   |   0.7 |  3.68
+Modify  | 0.00024796 | 0.017366   | 0.035022   |  13.0 |  3.66
+Output  | 0.00017667 | 0.00036263 | 0.00053191 |   0.0 |  0.08
+Other   |            | 0.1508     |            |       | 31.76
+
+Particle moves    = 25898484 (25.9M)
+Cells touched     = 27528828 (27.5M)
+Particle comms    = 170023 (0.17M)
+Boundary collides = 85994 (86K)
+Boundary exits    = 101007 (0.101M)
+SurfColl checks   = 4695502 (4.7M)
+SurfColl occurs   = 30862 (30.9K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.36367e+07
+Particle-moves/step: 51797
+Cell-touches/particle/step: 1.06295
+Particle comm iterations/step: 2.438
+Particle fraction communicated: 0.00656498
+Particle fraction colliding with boundary: 0.00332043
+Particle fraction exiting boundary: 0.00390011
+Surface-checks/particle/step: 0.181304
+Surface-collisions/particle/step: 0.00119165
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13258.2 ave 16254 max 9595 min
+Histogram: 1 0 1 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans 0 -1 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  1444 deleted particles
+  CPU time = 0.000891924 secs
+  sort/surf2grid/ghost/inout/particle percent = 15.8514 45.576 7.35098 19.0591 12.1625
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 4.05019 3.20644 4.89394
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1000            0    51589        0        0        0        0 
+    1100  0.091908693    52493        0        0       48     8820 
+    1200   0.18849063    53385        0        0       60     9618 
+    1300   0.28580928    53890        0        0       70     9856 
+    1400   0.40406227    54266        0        0       63    10094 
+    1500   0.50223327    54428        0        0       64    10164 
+Loop time of 0.502306 on 4 procs for 500 steps with 54428 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14545    | 0.22444    | 0.33103    |  15.8 | 44.68
+Coll    | 0.016014   | 0.025905   | 0.034829   |   5.1 |  5.16
+Sort    | 0.040361   | 0.051863   | 0.063148   |   4.2 | 10.33
+Comm    | 0.016409   | 0.017987   | 0.019258   |   0.8 |  3.58
+Modify  | 0.00024557 | 0.017172   | 0.034889   |  12.9 |  3.42
+Output  | 0.00019526 | 0.00039089 | 0.00055981 |   0.0 |  0.08
+Other   |            | 0.1645     |            |       | 32.76
+
+Particle moves    = 26791563 (26.8M)
+Cells touched     = 28436601 (28.4M)
+Particle comms    = 171396 (0.171M)
+Boundary collides = 87221 (87.2K)
+Boundary exits    = 102500 (0.102M)
+SurfColl checks   = 4773216 (4.77M)
+SurfColl occurs   = 30765 (30.8K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.33343e+07
+Particle-moves/step: 53583.1
+Cell-touches/particle/step: 1.0614
+Particle comm iterations/step: 2.73
+Particle fraction communicated: 0.00639739
+Particle fraction colliding with boundary: 0.00325554
+Particle fraction exiting boundary: 0.00382583
+Surface-checks/particle/step: 0.178161
+Surface-collisions/particle/step: 0.00114831
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13607 ave 17039 max 10130 min
+Histogram: 1 1 0 0 0 0 0 0 1 1
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans 1 0 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  696 deleted particles
+  CPU time = 0.00083828 secs
+  sort/surf2grid/ghost/inout/particle percent = 19.2264 43.4585 8.24801 19.8805 9.18658
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 4.05019 3.20644 4.89394
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1500            0    53732        0        0        0        0 
+    1600  0.093466043    54687        0        0       63     9464 
+    1700   0.19234276    55802        0        0       72     9870 
+    1800   0.29269004    56474        0        0       59     9408 
+    1900   0.39409947    56965        0        0       57     9730 
+    2000   0.49596977    57244        0        0       58     9618 
+Loop time of 0.496048 on 4 procs for 500 steps with 57244 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.16372    | 0.23139    | 0.33236    |  14.4 | 46.65
+Coll    | 0.015436   | 0.027496   | 0.037112   |   5.8 |  5.54
+Sort    | 0.03859    | 0.053943   | 0.065894   |   5.1 | 10.87
+Comm    | 0.016884   | 0.018542   | 0.019869   |   0.8 |  3.74
+Modify  | 0.00024867 | 0.017401   | 0.034729   |  13.0 |  3.51
+Output  | 0.00013852 | 0.00041157 | 0.00064969 |   0.0 |  0.08
+Other   |            | 0.1469     |            |       | 29.61
+
+Particle moves    = 28039815 (28M)
+Cells touched     = 29761957 (29.8M)
+Particle comms    = 176360 (0.176M)
+Boundary collides = 92145 (92.1K)
+Boundary exits    = 101797 (0.102M)
+SurfColl checks   = 4657814 (4.66M)
+SurfColl occurs   = 29999 (30K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.41316e+07
+Particle-moves/step: 56079.6
+Cell-touches/particle/step: 1.06142
+Particle comm iterations/step: 2.868
+Particle fraction communicated: 0.00628963
+Particle fraction colliding with boundary: 0.00328622
+Particle fraction exiting boundary: 0.00363044
+Surface-checks/particle/step: 0.166114
+Surface-collisions/particle/step: 0.00106987
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 14311 ave 17948 max 9821 min
+Histogram: 1 0 1 0 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+move_surf           all trans 0 1 0
+Moving surfs ...
+  0 0 = number of pushed cells
+  4 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  96 0 4 = cells outside/inside/overlapping surfs
+  4 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  1463 deleted particles
+  CPU time = 0.000971317 secs
+  sort/surf2grid/ghost/inout/particle percent = 17.2067 35.9352 17.8694 17.673 11.3157
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 4.05019 3.20644 4.89394
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2000            0    55781        0        0        0        0 
+    2100   0.10916519    56408        0        0       59     9408 
+    2200   0.21731043    57315        0        0       61     9212 
+    2300   0.32172465    57640        0        0       75     9954 
+    2400   0.44650126    57767        0        0       70    10290 
+    2500   0.55125737    57770        0        0       69    10584 
+Loop time of 0.551374 on 4 procs for 500 steps with 57770 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.16321    | 0.24333    | 0.35092    |  15.5 | 44.13
+Coll    | 0.015712   | 0.029068   | 0.039716   |   5.8 |  5.27
+Sort    | 0.039325   | 0.057848   | 0.073704   |   5.8 | 10.49
+Comm    | 0.018356   | 0.02199    | 0.023971   |   1.5 |  3.99
+Modify  | 0.00026298 | 0.017499   | 0.035097   |  13.0 |  3.17
+Output  | 0.00014925 | 0.0005247  | 0.00074387 |   0.0 |  0.10
+Other   |            | 0.1811     |            |       | 32.85
+
+Particle moves    = 28683260 (28.7M)
+Cells touched     = 30432587 (30.4M)
+Particle comms    = 178617 (0.179M)
+Boundary collides = 94726 (94.7K)
+Boundary exits    = 103376 (0.103M)
+SurfColl checks   = 4808622 (4.81M)
+SurfColl occurs   = 30848 (30.8K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.30053e+07
+Particle-moves/step: 57366.5
+Cell-touches/particle/step: 1.06099
+Particle comm iterations/step: 2.52
+Particle fraction communicated: 0.00622722
+Particle fraction colliding with boundary: 0.00330248
+Particle fraction exiting boundary: 0.00360405
+Surface-checks/particle/step: 0.167646
+Surface-collisions/particle/step: 0.00107547
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 14442.5 ave 18396 max 9423 min
+Histogram: 1 0 0 1 0 0 0 0 0 2
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_4.surf.remove
+++ b/examples/surf/log.29Jun21.mpi_4.surf.remove
@@ -1,0 +1,233 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00114727 secs
+  create/ghost percent = 82.6268 17.3732
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000942469 secs
+  reassign/sort/migrate/ghost percent = 64.9633 0.986592 14.04 20.0101
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.00118947 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 24.1932 11.0042 1.16256 50.1303 13.5097 23.1509 0.140309
+  surf2grid time = 0.000596285 secs
+  map/comm1/comm2/comm3/comm4/split percent = 24.99 6.79728 9.23631 4.59816 8.83647 38.9044
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  368 8 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.00104284 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 18.3813 20.1875 0.640146 50.8916 9.89941 23.8226 0.182899
+  surf2grid time = 0.00053072 secs
+  map/comm1/comm2/comm3/comm4/split percent = 24.7529 7.90656 9.07457 5.79515 4.1779 44.2498
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 1.52409 1.52409 1.52409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.035490751    20931        0        0       63     2725 
+     200   0.10405636    35977        0        0      113     5341 
+     300   0.18934965    43679        0        0      109     6343 
+     400   0.28701067    47737        0        0      122     6837 
+     500   0.38637543    50170        0        0      138     7405 
+     600   0.48835135    51896        0        0      114     7193 
+     700   0.59274411    53187        0        0      105     7137 
+     800   0.69828844    53948        0        0      115     6858 
+     900   0.82555819    54270        0        0      135     7817 
+    1000   0.93332314    54598        0        0      154     7818 
+Loop time of 0.93343 on 4 procs for 1000 steps with 54598 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.20794    | 0.40622    | 0.60897    |  31.0 | 43.52
+Coll    | 0.018023   | 0.042964   | 0.068083   |  12.0 |  4.60
+Sort    | 0.05315    | 0.087002   | 0.12326    |  11.4 |  9.32
+Comm    | 0.040513   | 0.043905   | 0.047043   |   1.1 |  4.70
+Modify  | 0.00062919 | 0.03507    | 0.070207   |  18.4 |  3.76
+Output  | 0.00027084 | 0.0011007  | 0.001529   |   1.5 |  0.12
+Other   |            | 0.3172     |            |       | 33.98
+
+Particle moves    = 44238393 (44.2M)
+Cells touched     = 50303450 (50.3M)
+Particle comms    = 270249 (0.27M)
+Boundary collides = 156003 (0.156M)
+Boundary exits    = 156236 (0.156M)
+SurfColl checks   = 6099455 (6.1M)
+SurfColl occurs   = 108405 (0.108M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.18483e+07
+Particle-moves/step: 44238.4
+Cell-touches/particle/step: 1.1371
+Particle comm iterations/step: 2.449
+Particle fraction communicated: 0.00610892
+Particle fraction colliding with boundary: 0.00352642
+Particle fraction exiting boundary: 0.00353168
+Surface-checks/particle/step: 0.137877
+Surface-collisions/particle/step: 0.00245047
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13649.5 ave 19838 max 7449 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+remove_surf         1
+  removed 50 lines
+  50 lines remain
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.000792265 secs
+  sort/surf2grid/particle/ghost percent = 23.2019 76.7981 0.210653 46.2233
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 4.05019 3.20644 4.89394
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    1000            0    54598        0        0        0        0 
+    1100   0.10717702    55409        0        0       59     3460 
+    1200   0.22281003    56316        0        0       66     3733 
+    1300   0.32615137    56960        0        0       58     3720 
+    1400    0.4293623    57398        0        0       71     3811 
+    1500   0.53245497    57547        0        0       71     3829 
+    1600   0.63563848    57868        0        0       66     3716 
+    1700   0.73912358    57770        0        0       64     3582 
+    1800   0.86194587    57688        0        0       48     3498 
+    1900   0.96412873    57734        0        0       65     3631 
+    2000    1.0661802    57829        0        0       68     3851 
+Loop time of 1.0663 on 4 procs for 1000 steps with 57829 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.3217     | 0.49575    | 0.70104    |  21.5 | 46.49
+Coll    | 0.030486   | 0.057397   | 0.080266   |   8.6 |  5.38
+Sort    | 0.084354   | 0.12024    | 0.15388    |   8.2 | 11.28
+Comm    | 0.041285   | 0.044589   | 0.04752    |   1.1 |  4.18
+Modify  | 0.00078082 | 0.033905   | 0.068006   |  18.0 |  3.18
+Output  | 0.00027299 | 0.0010209  | 0.0014434  |   1.4 |  0.10
+Other   |            | 0.3134     |            |       | 29.39
+
+Particle moves    = 57278795 (57.3M)
+Cells touched     = 64631764 (64.6M)
+Particle comms    = 358459 (0.358M)
+Boundary collides = 189639 (0.19M)
+Boundary exits    = 207430 (0.207M)
+SurfColl checks   = 3737334 (3.74M)
+SurfColl occurs   = 62553 (62.6K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.34293e+07
+Particle-moves/step: 57278.8
+Cell-touches/particle/step: 1.12837
+Particle comm iterations/step: 2.493
+Particle fraction communicated: 0.00625814
+Particle fraction colliding with boundary: 0.00331081
+Particle fraction exiting boundary: 0.00362141
+Surface-checks/particle/step: 0.0652481
+Surface-collisions/particle/step: 0.00109208
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 14457.2 ave 18196 max 9684 min
+Histogram: 1 0 0 1 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/surf/log.29Jun21.mpi_4.surf.rotate
+++ b/examples/surf/log.29Jun21.mpi_4.surf.rotate
@@ -1,0 +1,287 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00111771 secs
+  create/ghost percent = 84.1724 15.8276
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000909805 secs
+  reassign/sort/migrate/ghost percent = 63.6268 0.995807 16.2474 19.13
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 scale 1.2 0.2 1
+  50 points
+  50 lines
+  1.4 8.6 xlo xhi
+  4.40118 5.59882 ylo yhi
+  0 0 zlo zhi
+  0.0803795 min line length
+  0 0 = number of pushed cells
+  36 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  352 12 36 = cells outside/inside/overlapping surfs
+  36 = surf cells with 1,2,etc splits
+  93.232 93.232 = cell-wise and global flow volume
+  CPU time = 0.00109267 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 23.0635 15.6666 0.96007 48.5053 11.8045 15.2084 0.392756
+  surf2grid time = 0.000530005 secs
+  map/comm1/comm2/comm3/comm4/split percent = 27.8453 7.69231 8.81691 5.03824 9.67161 30.9942
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.041843653    20839        0        0       51     3608 
+     200   0.11815643    35735        0        0      115     6411 
+     300   0.20799279    43382        0        0      129     7543 
+     400   0.30452132    47515        0        0      118     8132 
+     500   0.40602612    50137        0        0      126     8504 
+Loop time of 0.406096 on 4 procs for 500 steps with 50137 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.11154    | 0.16291    | 0.21475    |  12.7 | 40.12
+Coll    | 0.0099311  | 0.015782   | 0.02184    |   4.6 |  3.89
+Sort    | 0.024607   | 0.034452   | 0.044032   |   5.0 |  8.48
+Comm    | 0.013975   | 0.01458    | 0.015354   |   0.4 |  3.59
+Modify  | 0.034995   | 0.068921   | 0.10285    |  12.9 | 16.97
+Output  | 0.00015402 | 0.00053895 | 0.00083756 |   0.0 |  0.13
+Other   |            | 0.1089     |            |       | 26.82
+
+Particle moves    = 17483878 (17.5M)
+Cells touched     = 19967538 (20M)
+Particle comms    = 87966 (88K)
+Boundary collides = 61792 (61.8K)
+Boundary exits    = 55290 (55.3K)
+SurfColl checks   = 2968434 (2.97M)
+SurfColl occurs   = 45562 (45.6K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.07634e+07
+Particle-moves/step: 34967.8
+Cell-touches/particle/step: 1.14205
+Particle comm iterations/step: 1.994
+Particle fraction communicated: 0.00503126
+Particle fraction colliding with boundary: 0.00353423
+Particle fraction exiting boundary: 0.00316234
+Surface-checks/particle/step: 0.169781
+Surface-collisions/particle/step: 0.00260594
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 12534.2 ave 15145 max 10017 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf all 100 2000 rotate 360 0 0 1 5 5 0
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.6875 1.6875 1.6875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 3.20644 3.20644 3.20644
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    50137        0        0        0        0 
+     600   0.10562205    48400        0        0      143     8966 
+     700   0.21295905    47479        0        0      164     7917 
+     800   0.35013747    47034        0        0      152     8331 
+     900   0.48125744    47194        0        0      134     8107 
+    1000    0.6246376    46714        0        0      161     7706 
+    1100   0.76461148    46624        0        0      155     8841 
+    1200    0.8990829    46270        0        0      158     7619 
+    1300    1.0347517    46322        0        0      151     8328 
+    1400    1.1691415    47254        0        0      152     8578 
+    1500    1.3182328    47229        0        0      157     7699 
+    1600    1.4369452    47525        0        0      149     8864 
+    1700    1.5420086    47209        0        0      152     7637 
+    1800    1.6567111    46986        0        0      149     8221 
+    1900    1.7868264    47442        0        0      165     8400 
+    2000     1.927819    47174        0        0      152     7562 
+    2100    2.0675271    46977        0        0      162     8616 
+    2200     2.203563    46804        0        0      148     7637 
+    2300    2.3606989    46911        0        0      169     8561 
+    2400    2.4961863    47333        0        0      147     8662 
+    2500    2.6263549    47309        0        0      144     7673 
+Loop time of 2.62643 on 4 procs for 2000 steps with 47309 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.48313    | 0.89776    | 1.3174     |  41.4 | 34.18
+Coll    | 0.042229   | 0.10133    | 0.16737    |  17.7 |  3.86
+Sort    | 0.11974    | 0.19494    | 0.27224    |  16.7 |  7.42
+Comm    | 0.055734   | 0.061464   | 0.066773   |   1.6 |  2.34
+Modify  | 0.17374    | 0.38017    | 0.59057    |  31.9 | 14.47
+Output  | 0.00052381 | 0.00076401 | 0.0014119  |   0.0 |  0.03
+Other   |            | 0.99       |            |       | 37.69
+
+Particle moves    = 98298130 (98.3M)
+Cells touched     = 111198874 (111M)
+Particle comms    = 546228 (0.546M)
+Boundary collides = 350365 (0.35M)
+Boundary exits    = 351090 (0.351M)
+SurfColl checks   = 13903053 (13.9M)
+SurfColl occurs   = 263462 (0.263M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.35664e+06
+Particle-moves/step: 49149.1
+Cell-touches/particle/step: 1.13124
+Particle comm iterations/step: 2.2715
+Particle fraction communicated: 0.00555685
+Particle fraction colliding with boundary: 0.00356431
+Particle fraction exiting boundary: 0.00357169
+Surface-checks/particle/step: 0.141438
+Surface-collisions/particle/step: 0.00268023
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 11827.2 ave 18337 max 5581 min
+Histogram: 1 0 0 0 1 1 0 0 0 1
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+unfix               10
+
+run                 500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 4.05019 3.20644 4.89394
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2500            0    47309        0        0        0        0 
+    2600   0.11685324    50854        0        0      126     8492 
+    2700   0.23046613    53154        0        0      149     8706 
+    2800   0.34344625    54314        0        0      137     8982 
+    2900   0.45617151    55086        0        0      148     9179 
+    3000   0.56902552    55668        0        0      138     8967 
+Loop time of 0.569095 on 4 procs for 500 steps with 55668 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.1763     | 0.24397    | 0.30988    |  10.6 | 42.87
+Coll    | 0.01669    | 0.025969   | 0.035584   |   4.5 |  4.56
+Sort    | 0.042616   | 0.054512   | 0.066187   |   4.2 |  9.58
+Comm    | 0.012855   | 0.013681   | 0.014642   |   0.6 |  2.40
+Modify  | 0.058275   | 0.097327   | 0.13576    |  10.7 | 17.10
+Output  | 0.00020123 | 0.00034165 | 0.00045156 |   0.0 |  0.06
+Other   |            | 0.1333     |            |       | 23.42
+
+Particle moves    = 26617454 (26.6M)
+Cells touched     = 30042873 (30M)
+Particle comms    = 116884 (0.117M)
+Boundary collides = 92576 (92.6K)
+Boundary exits    = 96933 (96.9K)
+SurfColl checks   = 4312315 (4.31M)
+SurfColl occurs   = 69050 (69K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.16929e+07
+Particle-moves/step: 53234.9
+Cell-touches/particle/step: 1.12869
+Particle comm iterations/step: 2
+Particle fraction communicated: 0.00439125
+Particle fraction colliding with boundary: 0.00347802
+Particle fraction exiting boundary: 0.00364171
+Surface-checks/particle/step: 0.162011
+Surface-collisions/particle/step: 0.00259416
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13917 ave 16526 max 11295 min
+Histogram: 1 1 0 0 0 0 0 0 1 1
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf/log.29Jun21.mpi_4.surf.slide
+++ b/examples/surf/log.29Jun21.mpi_4.surf.slide
@@ -1,0 +1,309 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.0203226 secs
+  create/ghost percent = 53.5788 46.4212
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000971794 secs
+  reassign/sort/migrate/ghost percent = 63.7144 0.736016 15.0638 20.4858
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle origin 5 5 0 trans 0.0 2.0 0.0                     scale 0.33 0.33 1 group 1
+  50 points
+  50 lines
+  4.01 5.99 xlo xhi
+  6.01195 7.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  12 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  384 4 12 = cells outside/inside/overlapping surfs
+  12 = surf cells with 1,2,etc splits
+  96.929 96.929 = cell-wise and global flow volume
+  CPU time = 0.0010314 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.0809 10.5178 0.970874 52.1498 11.2806 19.0707 0.462321
+  surf2grid time = 0.000537872 secs
+  map/comm1/comm2/comm3/comm4/split percent = 29.7872 10.2837 7.40248 5.85106 9.44149 28.3245
+read_surf           data.circle origin 5 5 0 trans 0.0 -2.0 0.0                     scale 0.33 0.33 1 group 2
+  50 points
+  100 lines
+  4.01 5.99 xlo xhi
+  2.01195 3.98805 ylo yhi
+  0 0 zlo zhi
+  0.124325 min line length
+  0 0 = number of pushed cells
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  368 8 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  93.858 93.858 = cell-wise and global flow volume
+  CPU time = 0.000929594 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 16.9274 16.7222 0.74378 49.8333 15.7733 17.3121 0.461657
+  surf2grid time = 0.000463247 secs
+  map/comm1/comm2/comm3/comm4/split percent = 30.4683 9.00669 9.21256 8.85229 4.68348 30.6227
+
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass
+fix		    foo grid/check 1 error
+
+timestep 	    0.0001
+
+#dump                2 image all 100 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    500
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 1.52409 1.52409 1.52409
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.041230202    20931        0        0       63     2725 
+     200   0.12406182    35977        0        0      113     5341 
+     300   0.22700405    43679        0        0      109     6343 
+     400   0.34467602    47737        0        0      122     6837 
+     500   0.46400332    50170        0        0      138     7405 
+Loop time of 0.464083 on 4 procs for 500 steps with 50170 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.075926   | 0.16153    | 0.24768    |  21.3 | 34.81
+Coll    | 0.006644   | 0.0164     | 0.026296   |   7.6 |  3.53
+Sort    | 0.019283   | 0.03405    | 0.049557   |   8.0 |  7.34
+Comm    | 0.014911   | 0.016224   | 0.017526   |   0.7 |  3.50
+Modify  | 0.024692   | 0.069713   | 0.11516    |  17.0 | 15.02
+Output  | 0.00014091 | 0.00076008 | 0.0012743  |   0.0 |  0.16
+Other   |            | 0.1654     |            |       | 35.64
+
+Particle moves    = 17568828 (17.6M)
+Cells touched     = 20104040 (20.1M)
+Particle comms    = 112531 (0.113M)
+Boundary collides = 62766 (62.8K)
+Boundary exits    = 55257 (55.3K)
+SurfColl checks   = 2446963 (2.45M)
+SurfColl occurs   = 45685 (45.7K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.46427e+06
+Particle-moves/step: 35137.7
+Cell-touches/particle/step: 1.1443
+Particle comm iterations/step: 2.386
+Particle fraction communicated: 0.00640515
+Particle fraction colliding with boundary: 0.00357258
+Particle fraction exiting boundary: 0.00314517
+Surface-checks/particle/step: 0.139279
+Surface-collisions/particle/step: 0.00260034
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 12542.5 ave 18174 max 6943 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+fix                 5 balance 200 1.1 rcb cell
+
+fix                 10 move/surf 1 100 2000 trans 0 -0.9 0
+fix                 11 move/surf 2 100 2000 trans 0 0.9 0
+
+run 		    2000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 4.05534 3.21159 4.89909
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+     500            0    50170        0        0        0        0 
+     600   0.12452078    50286        0        0      114     7193 
+     700   0.25101495    50446        0        0      111     9304 
+     800   0.37797451    50682        0        0      103     8866 
+     900   0.50666881    50074        0        0      123    10227 
+    1000   0.65460992    49897        0        0      142    10934 
+    1100   0.78270602    49951        0        0      135    10716 
+    1200   0.91122222    50054        0        0      105    10569 
+    1300    1.0399976    50783        0        0      140    10951 
+    1400    1.1701114    51401        0        0      136    10787 
+    1500    1.3003342    51586        0        0      126    10114 
+    1600    1.4311373    52356        0        0      108     9606 
+    1700    1.5813739    52215        0        0      119     7393 
+    1800    1.7115364    51991        0        0      127     9201 
+    1900    1.8422084    51870        0        0      121    10305 
+    2000    1.9723132    51362        0        0      129    10288 
+    2100    2.1019425    51068        0        0      142    11456 
+    2200    2.2316589    50944        0        0      115    10970 
+    2300     2.366679    51122        0        0      136    11068 
+    2400      2.49576    51623        0        0      117    11094 
+    2500    2.6442587    51935        0        0      125    10846 
+Loop time of 2.64435 on 4 procs for 2000 steps with 51935 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.50769    | 0.96389    | 1.4299     |  46.5 | 36.45
+Coll    | 0.044837   | 0.10504    | 0.16555    |  18.5 |  3.97
+Sort    | 0.12837    | 0.21048    | 0.29088    |  16.4 |  7.96
+Comm    | 0.059628   | 0.079957   | 0.090466   |   4.2 |  3.02
+Modify  | 0.19918    | 0.40949    | 0.62322    |  32.8 | 15.49
+Output  | 0.00049233 | 0.00074941 | 0.001421   |   0.0 |  0.03
+Other   |            | 0.8748     |            |       | 33.08
+
+Particle moves    = 104275368 (104M)
+Cells touched     = 117896792 (118M)
+Particle comms    = 605477 (0.605M)
+Boundary collides = 363926 (0.364M)
+Boundary exits    = 381444 (0.381M)
+SurfColl checks   = 17835355 (17.8M)
+SurfColl occurs   = 234339 (0.234M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.85831e+06
+Particle-moves/step: 52137.7
+Cell-touches/particle/step: 1.13063
+Particle comm iterations/step: 2.4625
+Particle fraction communicated: 0.00580652
+Particle fraction colliding with boundary: 0.00349005
+Particle fraction exiting boundary: 0.00365805
+Surface-checks/particle/step: 0.171041
+Surface-collisions/particle/step: 0.00224731
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 12983.8 ave 18988 max 7110 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+
+unfix               10
+unfix               11
+
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 2.53125 1.6875 3.375
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.0102997 0.0102997 0.0102997
+  total     (ave,min,max) = 4.05534 3.21159 4.89909
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+    2500            0    51935        0        0        0        0 
+    2600   0.12905884    53880        0        0      122     9746 
+    2700   0.26228976    55236        0        0      118     9801 
+    2800   0.39701843    55735        0        0      111    10237 
+    2900   0.53248954    56060        0        0      137    10510 
+    3000   0.66843677    56305        0        0      140    10431 
+    3100   0.80442405    56297        0        0      100     9347 
+    3200   0.96001792    56232        0        0      136     9923 
+    3300    1.0962613    56342        0        0      126    10363 
+    3400    1.2333446    56547        0        0      119     9977 
+    3500    1.3700585    56687        0        0      145    10131 
+Loop time of 1.37014 on 4 procs for 1000 steps with 56687 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.28443    | 0.51797    | 0.74517    |  31.5 | 37.80
+Coll    | 0.02585    | 0.057049   | 0.088299   |  13.1 |  4.16
+Sort    | 0.074797   | 0.11448    | 0.15572    |  11.2 |  8.36
+Comm    | 0.031682   | 0.038106   | 0.042271   |   2.0 |  2.78
+Modify  | 0.098534   | 0.20464    | 0.31205    |  23.4 | 14.94
+Output  | 0.00025773 | 0.0010771  | 0.0016735  |   1.9 |  0.08
+Other   |            | 0.4368     |            |       | 31.88
+
+Particle moves    = 55898970 (55.9M)
+Cells touched     = 63042586 (63M)
+Particle comms    = 321939 (0.322M)
+Boundary collides = 191691 (0.192M)
+Boundary exits    = 205888 (0.206M)
+SurfColl checks   = 10003027 (10M)
+SurfColl occurs   = 127712 (0.128M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.01995e+07
+Particle-moves/step: 55899
+Cell-touches/particle/step: 1.1278
+Particle comm iterations/step: 2.526
+Particle fraction communicated: 0.0057593
+Particle fraction colliding with boundary: 0.00342924
+Particle fraction exiting boundary: 0.00368322
+Surface-checks/particle/step: 0.178948
+Surface-collisions/particle/step: 0.00228469
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 14171.8 ave 20237 max 8071 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/surf_collide/log.29Jun21.mpi_1.beam.cll
+++ b/examples/surf_collide/log.29Jun21.mpi_1.beam.cll
@@ -1,0 +1,116 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+Created 125 child grid cells
+  CPU time = 0.000991583 secs
+  create/ghost percent = 83.3133 16.6867
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000187635 secs
+  reassign/sort/migrate/ghost percent = 58.5769 1.52478 18.8056 21.0928
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 cll 300.0 0.8 0.8 0.8 0.8 #partial 0.5
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0028553009     3118        0        0        0        0 
+     200  0.013503551     6225        0        0        0        0 
+     300  0.030805826     8790        0        0        0        0 
+     400  0.051449537     9411        0        0        0        0 
+     500  0.072986603     9577        0        0        0        0 
+     600  0.094851732     9614        0        0        0        0 
+     700   0.11675143     9693        0        0        0        0 
+     800   0.13909245     9682        0        0        0        0 
+     900   0.16105938     9746        0        0        0        0 
+    1000   0.18322611     9743        0        0        0        0 
+Loop time of 0.183238 on 1 procs for 1000 steps with 9743 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.16342    | 0.16342    | 0.16342    |   0.0 | 89.18
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.00093246 | 0.00093246 | 0.00093246 |   0.0 |  0.51
+Modify  | 0.017965   | 0.017965   | 0.017965   |   0.0 |  9.80
+Output  | 0.00014114 | 0.00014114 | 0.00014114 |   0.0 |  0.08
+Other   |            | 0.0007787  |            |       |  0.42
+
+Particle moves    = 6537279 (6.54M)
+Cells touched     = 6842678 (6.84M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 21427 (21.4K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.56765e+07
+Particle-moves/step: 6537.28
+Cell-touches/particle/step: 1.04672
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00428772
+Particle fraction exiting boundary: 0.00327766
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 9743 ave 9743 max 9743 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      125 ave 125 max 125 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.beam.diffuse
+++ b/examples/surf_collide/log.29Jun21.mpi_1.beam.diffuse
@@ -1,0 +1,116 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+Created 125 child grid cells
+  CPU time = 0.00101876 secs
+  create/ghost percent = 74.8888 25.1112
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000187159 secs
+  reassign/sort/migrate/ghost percent = 58.2166 1.52866 19.1083 21.1465
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 diffuse 300 0.5
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0029420853     3118        0        0        0        0 
+     200  0.012749672     6225        0        0        0        0 
+     300  0.029479027     7689        0        0        0        0 
+     400  0.048863649     8262        0        0        0        0 
+     500  0.068861246     8393        0        0        0        0 
+     600  0.089122534     8428        0        0        0        0 
+     700   0.10946655     8419        0        0        0        0 
+     800   0.12976527     8515        0        0        0        0 
+     900   0.15029788     8649        0        0        0        0 
+    1000   0.17104387     8591        0        0        0        0 
+Loop time of 0.171055 on 1 procs for 1000 steps with 8591 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.15111    | 0.15111    | 0.15111    |   0.0 | 88.34
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.00092053 | 0.00092053 | 0.00092053 |   0.0 |  0.54
+Modify  | 0.018207   | 0.018207   | 0.018207   |   0.0 | 10.64
+Output  | 0.00014138 | 0.00014138 | 0.00014138 |   0.0 |  0.08
+Other   |            | 0.0006719  |            |       |  0.39
+
+Particle moves    = 6265625 (6.27M)
+Cells touched     = 6574816 (6.57M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 22579 (22.6K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.66293e+07
+Particle-moves/step: 6265.62
+Cell-touches/particle/step: 1.04935
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00447362
+Particle fraction exiting boundary: 0.00360363
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 8591 ave 8591 max 8591 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      125 ave 125 max 125 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.beam.impulsive
+++ b/examples/surf_collide/log.29Jun21.mpi_1.beam.impulsive
@@ -1,0 +1,118 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    1 1 1
+Created 1 child grid cells
+  CPU time = 0.00097394 secs
+  create/ghost percent = 89.3513 10.6487
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.00012517 secs
+  reassign/sort/migrate/ghost percent = 66.2857 1.90476 21.7143 10.0952
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75 #double 10
+#surf_collide        1 impulsive 1000.0 tempvar 3 500 2000 60 5 75 #step 0.1
+
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0028498173     3118        0        0        0        0 
+     200  0.022492886     6225        0        0        0        0 
+     300  0.046670437     7260        0        0        0        0 
+     400  0.072230339     7486        0        0        0        0 
+     500  0.097846746     7595        0        0        0        0 
+     600   0.12396145     7584        0        0        0        0 
+     700   0.14957833     7547        0        0        0        0 
+     800   0.17509103     7578        0        0        0        0 
+     900    0.2008574     7668        0        0        0        0 
+    1000   0.22725129     7656        0        0        0        0 
+Loop time of 0.227262 on 1 procs for 1000 steps with 7656 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.2069     | 0.2069     | 0.2069     |   0.0 | 91.04
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.00093222 | 0.00093222 | 0.00093222 |   0.0 |  0.41
+Modify  | 0.018598   | 0.018598   | 0.018598   |   0.0 |  8.18
+Output  | 0.00014257 | 0.00014257 | 0.00014257 |   0.0 |  0.06
+Other   |            | 0.0006862  |            |       |  0.30
+
+Particle moves    = 5231166 (5.23M)
+Cells touched     = 5231166 (5.23M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 23514 (23.5K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.30182e+07
+Particle-moves/step: 5231.17
+Cell-touches/particle/step: 1
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00535827
+Particle fraction exiting boundary: 0.00449498
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 7656 ave 7656 max 7656 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1 ave 1 max 1 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.beam.specular
+++ b/examples/surf_collide/log.29Jun21.mpi_1.beam.specular
@@ -1,0 +1,116 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+Created 125 child grid cells
+  CPU time = 0.0010426 secs
+  create/ghost percent = 84.4272 15.5728
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000263214 secs
+  reassign/sort/migrate/ghost percent = 70.9239 1.08696 13.0435 14.9457
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 specular
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0029635429     3101        0        0        0        0 
+     200  0.012051105     6270        0        0        0        0 
+     300  0.028441906     6382        0        0        0        0 
+     400  0.044799328     6354        0        0        0        0 
+     500  0.061118364     6338        0        0        0        0 
+     600  0.077715635     6334        0        0        0        0 
+     700  0.093991518     6389        0        0        0        0 
+     800   0.11028028     6412        0        0        0        0 
+     900   0.12685275     6359        0        0        0        0 
+    1000   0.14315724     6335        0        0        0        0 
+Loop time of 0.143169 on 1 procs for 1000 steps with 6335 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.12298    | 0.12298    | 0.12298    |   0.0 | 85.90
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.00095201 | 0.00095201 | 0.00095201 |   0.0 |  0.66
+Modify  | 0.018422   | 0.018422   | 0.018422   |   0.0 | 12.87
+Output  | 0.00014162 | 0.00014162 | 0.00014162 |   0.0 |  0.10
+Other   |            | 0.0006731  |            |       |  0.47
+
+Particle moves    = 5383479 (5.38M)
+Cells touched     = 5704605 (5.7M)
+Particle comms    = 0 (0K)
+Boundary collides = 28312 (28.3K)
+Boundary exits    = 25108 (25.1K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.76023e+07
+Particle-moves/step: 5383.48
+Cell-touches/particle/step: 1.05965
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00525905
+Particle fraction exiting boundary: 0.0046639
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 6335 ave 6335 max 6335 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      125 ave 125 max 125 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.beam.td
+++ b/examples/surf_collide/log.29Jun21.mpi_1.beam.td
@@ -1,0 +1,120 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    1 1 1
+Created 1 child grid cells
+  CPU time = 0.000949621 secs
+  create/ghost percent = 89.0033 10.9967
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000124454 secs
+  reassign/sort/migrate/ghost percent = 66.092 1.91571 22.0307 9.96169
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide	    1 td 1000.0 #barrier 1000
+#surf_collide	    1 td 500.0 bond 500 0 0
+#surf_collide	    1 td 300.0 initenergy 0.01 0 0
+#surf_collide	    1 td 1000.0 barrier 1000 bond 500 0 0 initenergy 0.01 0 0
+
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0029132366     3118        0        0        0        0 
+     200  0.012589931     6225        0        0        0        0 
+     300  0.028081894     7461        0        0        0        0 
+     400  0.044544697     7628        0        0        0        0 
+     500   0.06104207     7682        0        0        0        0 
+     600  0.077718973     7701        0        0        0        0 
+     700   0.09440279     7763        0        0        0        0 
+     800   0.11120486     7772        0        0        0        0 
+     900   0.12806582     7847        0        0        0        0 
+    1000   0.14507294     7765        0        0        0        0 
+Loop time of 0.145084 on 1 procs for 1000 steps with 7765 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.12488    | 0.12488    | 0.12488    |   0.0 | 86.08
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.0010335  | 0.0010335  | 0.0010335  |   0.0 |  0.71
+Modify  | 0.018386   | 0.018386   | 0.018386   |   0.0 | 12.67
+Output  | 0.00013971 | 0.00013971 | 0.00013971 |   0.0 |  0.10
+Other   |            | 0.0006413  |            |       |  0.44
+
+Particle moves    = 5391255 (5.39M)
+Cells touched     = 5391255 (5.39M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 23405 (23.4K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.71596e+07
+Particle-moves/step: 5391.26
+Cell-touches/particle/step: 1
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00519916
+Particle fraction exiting boundary: 0.00434129
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 7765 ave 7765 max 7765 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      1 ave 1 max 1 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.circle.cll
+++ b/examples/surf_collide/log.29Jun21.mpi_1.circle.cll
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.0011611 secs
+  create/ghost percent = 76.8172 23.1828
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000377893 secs
+  reassign/sort/migrate/ghost percent = 32.0505 0.946372 10.347 56.6562
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000971079 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 20.7955 6.01522 1.69408 58.4827 13.0125 6.72723 0.0245519
+  surf2grid time = 0.000567913 secs
+  map/comm1/comm2/comm3/comm4/split percent = 34.5508 6.54912 12.1746 3.44249 10.6213 29.4291
+surf_collide	    1 cll 300.0 0.5 0.5 0.5 0.5 #partial 0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.065821886    19917        0        0      113     4545 
+     200   0.21303654    31881        0        0      166     6506 
+     300   0.40510559    37505        0        0      189     7904 
+     400   0.61391997    40389        0        0      175     8178 
+     500   0.83767509    41814        0        0      177     8411 
+     600    1.0619204    42946        0        0      192     8690 
+     700    1.2900445    43468        0        0      189     8373 
+     800    1.5205333    43928        0        0      202     8708 
+     900    1.7522011    43830        0        0      185     8386 
+    1000     1.989924    44047        0        0      179     8532 
+Loop time of 1.98995 on 1 procs for 1000 steps with 44047 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.4525     | 1.4525     | 1.4525     |   0.0 | 72.99
+Coll    | 0.18023    | 0.18023    | 0.18023    |   0.0 |  9.06
+Sort    | 0.22049    | 0.22049    | 0.22049    |   0.0 | 11.08
+Comm    | 0.0068433  | 0.0068433  | 0.0068433  |   0.0 |  0.34
+Modify  | 0.12743    | 0.12743    | 0.12743    |   0.0 |  6.40
+Output  | 0.0002079  | 0.0002079  | 0.0002079  |   0.0 |  0.01
+Other   |            | 0.002232   |            |       |  0.11
+
+Particle moves    = 37134776 (37.1M)
+Cells touched     = 41965628 (42M)
+Particle comms    = 0 (0K)
+Boundary collides = 170906 (0.171M)
+Boundary exits    = 166676 (0.167M)
+SurfColl checks   = 7394622 (7.39M)
+SurfColl occurs   = 172805 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.86612e+07
+Particle-moves/step: 37134.8
+Cell-touches/particle/step: 1.13009
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00460232
+Particle fraction exiting boundary: 0.00448841
+Surface-checks/particle/step: 0.199129
+Surface-collisions/particle/step: 0.00465345
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 44047 ave 44047 max 44047 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.circle.diffuse
+++ b/examples/surf_collide/log.29Jun21.mpi_1.circle.diffuse
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00110626 secs
+  create/ghost percent = 75.5603 24.4397
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000264645 secs
+  reassign/sort/migrate/ghost percent = 47.2072 2.43243 13.6937 36.6667
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000863314 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 22.8114 7.06987 2.04363 54.0458 14.0293 8.00884 0.0276167
+  surf2grid time = 0.000466585 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41.7987 7.97138 13.7966 3.42361 13.0301 15.8406
+surf_collide	    1 diffuse 300.0 1.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.065437317    20011        0        0      112     4617 
+     200   0.21033645    31738        0        0      163     6510 
+     300   0.39895082    37264        0        0      182     7823 
+     400    0.6051352    40350        0        0      183     7963 
+     500    0.8275919    41774        0        0      176     8323 
+     600    1.0513237    42836        0        0      176     8588 
+     700    1.2786906    43470        0        0      178     8354 
+     800    1.5084529    43653        0        0      202     8843 
+     900    1.7440374    43831        0        0      182     8306 
+    1000    1.9753439    44090        0        0      192     8517 
+Loop time of 1.97536 on 1 procs for 1000 steps with 44090 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.4332     | 1.4332     | 1.4332     |   0.0 | 72.56
+Coll    | 0.18696    | 0.18696    | 0.18696    |   0.0 |  9.46
+Sort    | 0.21806    | 0.21806    | 0.21806    |   0.0 | 11.04
+Comm    | 0.006757   | 0.006757   | 0.006757   |   0.0 |  0.34
+Modify  | 0.12782    | 0.12782    | 0.12782    |   0.0 |  6.47
+Output  | 0.000211   | 0.000211   | 0.000211   |   0.0 |  0.01
+Other   |            | 0.002328   |            |       |  0.12
+
+Particle moves    = 37062368 (37.1M)
+Cells touched     = 41835549 (41.8M)
+Particle comms    = 0 (0K)
+Boundary collides = 166395 (0.166M)
+Boundary exits    = 166633 (0.167M)
+SurfColl checks   = 7386804 (7.39M)
+SurfColl occurs   = 170741 (0.171M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.87623e+07
+Particle-moves/step: 37062.4
+Cell-touches/particle/step: 1.12879
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00448959
+Particle fraction exiting boundary: 0.00449602
+Surface-checks/particle/step: 0.199307
+Surface-collisions/particle/step: 0.00460686
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 44090 ave 44090 max 44090 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.circle.impulsive
+++ b/examples/surf_collide/log.29Jun21.mpi_1.circle.impulsive
@@ -1,0 +1,137 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00109291 secs
+  create/ghost percent = 75.3272 24.6728
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000259638 secs
+  reassign/sort/migrate/ghost percent = 46.1892 1.37741 15.1515 37.2819
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000864983 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 22.9052 7.05623 1.92944 54.1896 13.9195 7.88313 0.0275634
+  surf2grid time = 0.000468731 secs
+  map/comm1/comm2/comm3/comm4/split percent = 42.0651 7.42625 14.5982 3.56053 12.6144 15.7172
+
+#surf_collide        1 impulsive 300.0 softsphere 0.2 50 200 60 5 75
+surf_collide        1 impulsive 300.0 tempvar 1 50 200 60 5 75
+
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.10406065    20922        0        0      110     6350 
+     200   0.30735064    36917        0        0      162     9292 
+     300   0.57904291    46280        0        0      184    11217 
+     400   0.89962149    51593        0        0      195    11849 
+     500    1.2354445    54886        0        0      179    12328 
+     600    1.5858512    56936        0        0      184    12849 
+     700    1.9490421    58455        0        0      183    12474 
+     800    2.3135529    59519        0        0      199    13110 
+     900    2.6839948    60251        0        0      203    12967 
+    1000    3.0614083    60690        0        0      201    12974 
+Loop time of 3.06143 on 1 procs for 1000 steps with 60690 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 2.3528     | 2.3528     | 2.3528     |   0.0 | 76.85
+Coll    | 0.26395    | 0.26395    | 0.26395    |   0.0 |  8.62
+Sort    | 0.30476    | 0.30476    | 0.30476    |   0.0 |  9.95
+Comm    | 0.0072002  | 0.0072002  | 0.0072002  |   0.0 |  0.24
+Modify  | 0.12916    | 0.12916    | 0.12916    |   0.0 |  4.22
+Output  | 0.00026298 | 0.00026298 | 0.00026298 |   0.0 |  0.01
+Other   |            | 0.003268   |            |       |  0.11
+
+Particle moves    = 47950916 (48M)
+Cells touched     = 52843669 (52.8M)
+Particle comms    = 0 (0K)
+Boundary collides = 170525 (0.171M)
+Boundary exits    = 150033 (0.15M)
+SurfColl checks   = 10939362 (10.9M)
+SurfColl occurs   = 172800 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.56629e+07
+Particle-moves/step: 47950.9
+Cell-touches/particle/step: 1.10204
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00355624
+Particle fraction exiting boundary: 0.00312889
+Surface-checks/particle/step: 0.228137
+Surface-collisions/particle/step: 0.00360369
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 60690 ave 60690 max 60690 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.circle.specular
+++ b/examples/surf_collide/log.29Jun21.mpi_1.circle.specular
@@ -1,0 +1,134 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00111127 secs
+  create/ghost percent = 71.6155 28.3845
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000260115 secs
+  reassign/sort/migrate/ghost percent = 46.9294 1.37489 14.0238 37.6719
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000891685 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 21.0963 6.8984 1.87166 56.5241 13.6096 7.6738 0.026738
+  surf2grid time = 0.000504017 secs
+  map/comm1/comm2/comm3/comm4/split percent = 41.5326 6.85904 16.1306 3.31126 12.3463 15.9413
+surf_collide	    1 specular
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.062574625    19684        0        0      133     4228 
+     200   0.19959593    31304        0        0      157     6288 
+     300   0.38035727    36913        0        0      183     7309 
+     400   0.57679582    39670        0        0      178     7983 
+     500   0.78681922    41143        0        0      173     7934 
+     600   0.99761605    42014        0        0      192     8212 
+     700    1.2111335    42501        0        0      207     8471 
+     800     1.427026    42772        0        0      201     8442 
+     900     1.648391    43031        0        0      188     8294 
+    1000    1.8656762    43170        0        0      199     8464 
+Loop time of 1.86569 on 1 procs for 1000 steps with 43170 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.3356     | 1.3356     | 1.3356     |   0.0 | 71.59
+Coll    | 0.18096    | 0.18096    | 0.18096    |   0.0 |  9.70
+Sort    | 0.21393    | 0.21393    | 0.21393    |   0.0 | 11.47
+Comm    | 0.0068133  | 0.0068133  | 0.0068133  |   0.0 |  0.37
+Modify  | 0.12594    | 0.12594    | 0.12594    |   0.0 |  6.75
+Output  | 0.00021434 | 0.00021434 | 0.00021434 |   0.0 |  0.01
+Other   |            | 0.002219   |            |       |  0.12
+
+Particle moves    = 36424274 (36.4M)
+Cells touched     = 41257420 (41.3M)
+Particle comms    = 0 (0K)
+Boundary collides = 171838 (0.172M)
+Boundary exits    = 167473 (0.167M)
+SurfColl checks   = 7207953 (7.21M)
+SurfColl occurs   = 173015 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.95232e+07
+Particle-moves/step: 36424.3
+Cell-touches/particle/step: 1.13269
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00471768
+Particle fraction exiting boundary: 0.00459784
+Surface-checks/particle/step: 0.197889
+Surface-collisions/particle/step: 0.00474999
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 43170 ave 43170 max 43170 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_1.circle.td
+++ b/examples/surf_collide/log.29Jun21.mpi_1.circle.td
@@ -1,0 +1,139 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00110102 secs
+  create/ghost percent = 75.6388 24.3612
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000259876 secs
+  reassign/sort/migrate/ghost percent = 47.2477 1.37615 14.0367 37.3394
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000878096 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 23.1062 7.14092 2.00923 53.6248 14.1189 9.36736 0.0271518
+  surf2grid time = 0.000470877 secs
+  map/comm1/comm2/comm3/comm4/split percent = 42.2785 7.39241 14.4304 3.39241 12.8608 15.6456
+
+surf_collide	    1 td 1000.0 #barrier 1000
+#surf_collide	    1 td 500.0 bond 500 0 0
+#surf_collide	    1 td 300.0 initenergy 0.01 0 0
+#surf_collide	    1 td 1000.0 barrier 1000 bond 500 0 0 initenergy 0.01 0 0
+
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.06389451    18931        0        0      119     3949 
+     200   0.19984984    28398        0        0      163     5567 
+     300   0.36726093    32180        0        0      191     6532 
+     400   0.55065227    33853        0        0      188     6727 
+     500   0.74240208    34643        0        0      181     6877 
+     600   0.93135595    35281        0        0      177     6866 
+     700     1.122076    35551        0        0      179     6622 
+     800    1.3140292    35458        0        0      189     7107 
+     900    1.5057478    35446        0        0      197     6725 
+    1000    1.6991789    35643        0        0      188     6802 
+Loop time of 1.69922 on 1 procs for 1000 steps with 35643 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 1.244      | 1.244      | 1.244      |   0.0 | 73.21
+Coll    | 0.14157    | 0.14157    | 0.14157    |   0.0 |  8.33
+Sort    | 0.1799     | 0.1799     | 0.1799     |   0.0 | 10.59
+Comm    | 0.0068383  | 0.0068383  | 0.0068383  |   0.0 |  0.40
+Modify  | 0.12449    | 0.12449    | 0.12449    |   0.0 |  7.33
+Output  | 0.00023246 | 0.00023246 | 0.00023246 |   0.0 |  0.01
+Other   |            | 0.002228   |            |       |  0.13
+
+Particle moves    = 31107764 (31.1M)
+Cells touched     = 35994224 (36M)
+Particle comms    = 0 (0K)
+Boundary collides = 172472 (0.172M)
+Boundary exits    = 175080 (0.175M)
+SurfColl checks   = 6067907 (6.07M)
+SurfColl occurs   = 173578 (0.174M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.83071e+07
+Particle-moves/step: 31107.8
+Cell-touches/particle/step: 1.15708
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00554434
+Particle fraction exiting boundary: 0.00562818
+Surface-checks/particle/step: 0.195061
+Surface-collisions/particle/step: 0.00557989
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 35643 ave 35643 max 35643 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.beam.cll
+++ b/examples/surf_collide/log.29Jun21.mpi_4.beam.cll
@@ -1,0 +1,117 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 125 child grid cells
+  CPU time = 0.00110316 secs
+  create/ghost percent = 85.3037 14.6963
+balance_grid        rcb cell
+Balance grid migrated 105 cells
+  CPU time = 0.000887156 secs
+  reassign/sort/migrate/ghost percent = 66.81 1.3706 11.9592 19.8603
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 cll 300.0 0.8 0.8 0.8 0.8 #partial 0.5
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0038728714     3118        0        0        0        0 
+     200  0.017991304     6225        0        0        0        0 
+     300   0.03277421     8796        0        0        0        0 
+     400  0.047351122     9425        0        0        0        0 
+     500  0.062609911     9581        0        0        0        0 
+     600  0.077745438     9643        0        0        0        0 
+     700  0.092471123     9703        0        0        0        0 
+     800   0.10736299     9747        0        0        0        0 
+     900   0.12224197     9786        0        0        0        0 
+    1000   0.13743091     9768        0        0        0        0 
+Loop time of 0.137482 on 4 procs for 1000 steps with 9768 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.025679   | 0.043512   | 0.069081   |   8.2 | 31.65
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.024425   | 0.026785   | 0.028314   |   0.9 | 19.48
+Modify  | 0.00015783 | 0.0048838  | 0.019003   |  11.7 |  3.55
+Output  | 0.0001688  | 0.00024396 | 0.00046515 |   0.0 |  0.18
+Other   |            | 0.06206    |            |       | 45.14
+
+Particle moves    = 6552135 (6.55M)
+Cells touched     = 6857152 (6.86M)
+Particle comms    = 184478 (0.184M)
+Boundary collides = 28030 (28K)
+Boundary exits    = 21402 (21.4K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.19145e+07
+Particle-moves/step: 6552.14
+Cell-touches/particle/step: 1.04655
+Particle comm iterations/step: 1.823
+Particle fraction communicated: 0.0281554
+Particle fraction colliding with boundary: 0.00427799
+Particle fraction exiting boundary: 0.00326642
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 2442 ave 4565 max 365 min
+Histogram: 1 0 1 0 0 0 0 1 0 1
+Cells:      31.25 ave 32 max 31 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+GhostCell: 48.75 ave 49 max 48 min
+Histogram: 1 0 0 0 0 0 0 0 0 3
+EmptyCell: 35 ave 35 max 35 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.beam.diffuse
+++ b/examples/surf_collide/log.29Jun21.mpi_4.beam.diffuse
@@ -1,0 +1,117 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 125 child grid cells
+  CPU time = 0.00111675 secs
+  create/ghost percent = 83.2408 16.7592
+balance_grid        rcb cell
+Balance grid migrated 105 cells
+  CPU time = 0.000898123 secs
+  reassign/sort/migrate/ghost percent = 65.8614 1.03531 10.3531 22.7502
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 diffuse 300 0.5
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0038602352     3118        0        0        0        0 
+     200  0.017963171     6225        0        0        0        0 
+     300  0.032907248     7656        0        0        0        0 
+     400   0.04717207     8146        0        0        0        0 
+     500  0.061753273     8392        0        0        0        0 
+     600   0.07652998     8416        0        0        0        0 
+     700  0.090640783     8454        0        0        0        0 
+     800   0.10503316     8499        0        0        0        0 
+     900   0.11948943     8506        0        0        0        0 
+    1000   0.13394976     8558        0        0        0        0 
+Loop time of 0.134014 on 4 procs for 1000 steps with 8558 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.027784   | 0.039867   | 0.051647   |   5.7 | 29.75
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.025784   | 0.02756    | 0.029188   |   0.7 | 20.57
+Modify  | 0.00017238 | 0.0049037  | 0.019057   |  11.7 |  3.66
+Output  | 0.00016093 | 0.00029182 | 0.00068307 |   0.0 |  0.22
+Other   |            | 0.06139    |            |       | 45.81
+
+Particle moves    = 6239344 (6.24M)
+Cells touched     = 6548784 (6.55M)
+Particle comms    = 196264 (0.196M)
+Boundary collides = 28030 (28K)
+Boundary exits    = 22612 (22.6K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.16393e+07
+Particle-moves/step: 6239.34
+Cell-touches/particle/step: 1.04959
+Particle comm iterations/step: 1.801
+Particle fraction communicated: 0.0314559
+Particle fraction colliding with boundary: 0.00449246
+Particle fraction exiting boundary: 0.0036241
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 2139.5 ave 3703 max 605 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      31.25 ave 32 max 31 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+GhostCell: 48.75 ave 49 max 48 min
+Histogram: 1 0 0 0 0 0 0 0 0 3
+EmptyCell: 35 ave 35 max 35 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.beam.impulsive
+++ b/examples/surf_collide/log.29Jun21.mpi_4.beam.impulsive
@@ -1,0 +1,119 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    1 1 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 1 child grid cells
+  CPU time = 0.00093317 secs
+  create/ghost percent = 86.0245 13.9755
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000718355 secs
+  reassign/sort/migrate/ghost percent = 78.46 1.09525 8.03186 12.4129
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75 #double 10
+#surf_collide        1 impulsive 1000.0 tempvar 3 500 2000 60 5 75 #step 0.1
+
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 0.435669 0.0762939 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 0.435669 0.0762939 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0033578873     3118        0        0        0        0 
+     200  0.024575233     6225        0        0        0        0 
+     300  0.051789045     7260        0        0        0        0 
+     400  0.081036568     7486        0        0        0        0 
+     500   0.12609196     7595        0        0        0        0 
+     600   0.18399906     7584        0        0        0        0 
+     700   0.22838092     7547        0        0        0        0 
+     800   0.25738049     7578        0        0        0        0 
+     900   0.28499746     7668        0        0        0        0 
+    1000   0.31303716     7656        0        0        0        0 
+Loop time of 0.313087 on 4 procs for 1000 steps with 7656 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.00023627 | 0.068191   | 0.27202    |  45.1 | 21.78
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.0036263  | 0.0062434  | 0.00735    |   1.9 |  1.99
+Modify  | 0.00011563 | 0.0048403  | 0.018988   |  11.7 |  1.55
+Output  | 0.00016236 | 0.0027564  | 0.010532   |   8.6 |  0.88
+Other   |            | 0.2311     |            |       | 73.80
+
+Particle moves    = 5231166 (5.23M)
+Cells touched     = 5231166 (5.23M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 23514 (23.5K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 4.17709e+06
+Particle-moves/step: 5231.17
+Cell-touches/particle/step: 1
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00535827
+Particle fraction exiting boundary: 0.00449498
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1914 ave 7656 max 0 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+Cells:      0.25 ave 1 max 0 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+GhostCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.beam.specular
+++ b/examples/surf_collide/log.29Jun21.mpi_4.beam.specular
@@ -1,0 +1,117 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 125 child grid cells
+  CPU time = 0.0011065 secs
+  create/ghost percent = 85.2618 14.7382
+balance_grid        rcb cell
+Balance grid migrated 105 cells
+  CPU time = 0.000904322 secs
+  reassign/sort/migrate/ghost percent = 66.57 0.60638 10.9148 21.9088
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 specular
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0037686825     3101        0        0        0        0 
+     200  0.017744541     6270        0        0        0        0 
+     300  0.032322645     6382        0        0        0        0 
+     400  0.045330763     6354        0        0        0        0 
+     500  0.058033705     6338        0        0        0        0 
+     600    0.0703125     6334        0        0        0        0 
+     700  0.082606316     6389        0        0        0        0 
+     800  0.095295906     6412        0        0        0        0 
+     900   0.10805988     6359        0        0        0        0 
+    1000   0.12037158     6335        0        0        0        0 
+Loop time of 0.120424 on 4 procs for 1000 steps with 6335 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.019696   | 0.032669   | 0.039278   |   4.3 | 27.13
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.023626   | 0.024795   | 0.026018   |   0.5 | 20.59
+Modify  | 0.00017118 | 0.0049216  | 0.019133   |  11.7 |  4.09
+Output  | 0.00019717 | 0.00027722 | 0.00050592 |   0.0 |  0.23
+Other   |            | 0.05776    |            |       | 47.96
+
+Particle moves    = 5383479 (5.38M)
+Cells touched     = 5704605 (5.7M)
+Particle comms    = 204034 (0.204M)
+Boundary collides = 28312 (28.3K)
+Boundary exits    = 25108 (25.1K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.11761e+07
+Particle-moves/step: 5383.48
+Cell-touches/particle/step: 1.05965
+Particle comm iterations/step: 1.104
+Particle fraction communicated: 0.0379
+Particle fraction colliding with boundary: 0.00525905
+Particle fraction exiting boundary: 0.0046639
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1583.75 ave 3145 max 0 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      31.25 ave 32 max 31 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+GhostCell: 48.75 ave 49 max 48 min
+Histogram: 1 0 0 0 0 0 0 0 0 3
+EmptyCell: 35 ave 35 max 35 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.beam.td
+++ b/examples/surf_collide/log.29Jun21.mpi_4.beam.td
@@ -1,0 +1,121 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    1 1 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 1 child grid cells
+  CPU time = 0.000921726 secs
+  create/ghost percent = 86.8339 13.1661
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000694513 secs
+  reassign/sort/migrate/ghost percent = 79.7116 1.57913 6.59114 12.1181
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide	    1 td 1000.0 #barrier 1000
+#surf_collide	    1 td 500.0 bond 500 0 0
+#surf_collide	    1 td 300.0 initenergy 0.01 0 0
+#surf_collide	    1 td 1000.0 barrier 1000 bond 500 0 0 initenergy 0.01 0 0
+
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 0.435669 0.0762939 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 0.435669 0.0762939 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.003344059     3118        0        0        0        0 
+     200  0.014043093     6225        0        0        0        0 
+     300  0.030641079     7461        0        0        0        0 
+     400  0.048388958     7628        0        0        0        0 
+     500  0.066290855     7682        0        0        0        0 
+     600  0.084377527     7701        0        0        0        0 
+     700   0.10248232     7763        0        0        0        0 
+     800   0.12069798     7772        0        0        0        0 
+     900   0.13898182     7847        0        0        0        0 
+    1000    0.1573472     7765        0        0        0        0 
+Loop time of 0.157389 on 4 procs for 1000 steps with 7765 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0002315  | 0.033067   | 0.13151    |  31.3 | 21.01
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.0025322  | 0.0028651  | 0.0033815  |   0.6 |  1.82
+Modify  | 0.00011206 | 0.004813   | 0.0189     |  11.7 |  3.06
+Output  | 0.0001502  | 0.00021881 | 0.0004158  |   0.0 |  0.14
+Other   |            | 0.1164     |            |       | 73.97
+
+Particle moves    = 5391255 (5.39M)
+Cells touched     = 5391255 (5.39M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 23405 (23.4K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 8.56361e+06
+Particle-moves/step: 5391.26
+Cell-touches/particle/step: 1
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00519916
+Particle fraction exiting boundary: 0.00434129
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1941.25 ave 7765 max 0 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+Cells:      0.25 ave 1 max 0 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+GhostCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.circle.cll
+++ b/examples/surf_collide/log.29Jun21.mpi_4.circle.cll
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00109839 secs
+  create/ghost percent = 85.4569 14.5431
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.00097084 secs
+  reassign/sort/migrate/ghost percent = 62.4509 1.10511 15.054 21.39
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00101924 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 24.6784 12.0468 1.19298 50.924 11.1579 17.1228 0.561404
+  surf2grid time = 0.000519037 secs
+  map/comm1/comm2/comm3/comm4/split percent = 27.9283 10.7028 7.71704 4.59348 9.83004 29.8576
+surf_collide	    1 cll 300.0 0.5 0.5 0.5 0.5 #partial 0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.038458109    19889        0        0      110     4313 
+     200   0.11004138    31953        0        0      156     6857 
+     300   0.19570827    37557        0        0      180     7402 
+     400    0.2878654    40237        0        0      182     8182 
+     500    0.3879106    41932        0        0      213     8433 
+     600   0.48554277    42824        0        0      153     8398 
+     700   0.58397412    43344        0        0      189     8663 
+     800   0.68293667    43729        0        0      198     8694 
+     900   0.80126953    43978        0        0      177     8486 
+    1000   0.90347052    43993        0        0      187     8698 
+Loop time of 0.903547 on 4 procs for 1000 steps with 43993 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14243    | 0.37508    | 0.60682    |  37.8 | 41.51
+Coll    | 0.011743   | 0.035459   | 0.059504   |  12.6 |  3.92
+Sort    | 0.032225   | 0.069186   | 0.10733    |  13.7 |  7.66
+Comm    | 0.033046   | 0.034264   | 0.03597    |   0.6 |  3.79
+Modify  | 0.00047779 | 0.03479    | 0.070163   |  18.4 |  3.85
+Output  | 0.00026512 | 0.0010117  | 0.0015614  |   1.8 |  0.11
+Other   |            | 0.3538     |            |       | 39.15
+
+Particle moves    = 37082020 (37.1M)
+Cells touched     = 41912001 (41.9M)
+Particle comms    = 141246 (0.141M)
+Boundary collides = 171224 (0.171M)
+Boundary exits    = 166841 (0.167M)
+SurfColl checks   = 7359321 (7.36M)
+SurfColl occurs   = 172697 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.02601e+07
+Particle-moves/step: 37082
+Cell-touches/particle/step: 1.13025
+Particle comm iterations/step: 2.022
+Particle fraction communicated: 0.00380902
+Particle fraction colliding with boundary: 0.00461744
+Particle fraction exiting boundary: 0.00449924
+Surface-checks/particle/step: 0.198461
+Surface-collisions/particle/step: 0.00465716
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10998.2 ave 17174 max 4825 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.circle.diffuse
+++ b/examples/surf_collide/log.29Jun21.mpi_4.circle.diffuse
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00113273 secs
+  create/ghost percent = 84.4033 15.5967
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000947237 secs
+  reassign/sort/migrate/ghost percent = 59.854 1.13265 14.5985 24.4148
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00101519 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 24.3776 12.4002 1.00986 51.5735 10.6388 16.8389 0.305308
+  surf2grid time = 0.000523567 secs
+  map/comm1/comm2/comm3/comm4/split percent = 30.3279 8.37887 8.15118 4.55373 10.5191 30.7832
+surf_collide	    1 diffuse 300.0 1.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.038509369    20044        0        0      106     4496 
+     200   0.11003518    31692        0        0      154     6818 
+     300   0.19600487    37277        0        0      184     7671 
+     400   0.28867459    40276        0        0      183     8156 
+     500   0.38984656    41899        0        0      213     8455 
+     600   0.48857617    42809        0        0      168     8298 
+     700   0.58869934    43465        0        0      189     8594 
+     800   0.68914318    43714        0        0      209     8751 
+     900   0.81033373    43781        0        0      168     8528 
+    1000   0.91197824    44117        0        0      174     8674 
+Loop time of 0.912054 on 4 procs for 1000 steps with 44117 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.13055    | 0.37486    | 0.62716    |  39.8 | 41.10
+Coll    | 0.010831   | 0.036061   | 0.061432   |  13.2 |  3.95
+Sort    | 0.029609   | 0.069754   | 0.11087    |  14.6 |  7.65
+Comm    | 0.023864   | 0.025994   | 0.028099   |   1.0 |  2.85
+Modify  | 0.00045538 | 0.034394   | 0.0687     |  18.3 |  3.77
+Output  | 0.00029016 | 0.0010686  | 0.0016556  |   1.8 |  0.12
+Other   |            | 0.3699     |            |       | 40.56
+
+Particle moves    = 37053073 (37.1M)
+Cells touched     = 41836455 (41.8M)
+Particle comms    = 140392 (0.14M)
+Boundary collides = 167272 (0.167M)
+Boundary exits    = 166717 (0.167M)
+SurfColl checks   = 7363990 (7.36M)
+SurfColl occurs   = 170429 (0.17M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.01565e+07
+Particle-moves/step: 37053.1
+Cell-touches/particle/step: 1.1291
+Particle comm iterations/step: 2.102
+Particle fraction communicated: 0.00378894
+Particle fraction colliding with boundary: 0.00451439
+Particle fraction exiting boundary: 0.00449941
+Surface-checks/particle/step: 0.198742
+Surface-collisions/particle/step: 0.00459959
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 11029.2 ave 17546 max 4543 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.circle.impulsive
+++ b/examples/surf_collide/log.29Jun21.mpi_4.circle.impulsive
@@ -1,0 +1,138 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00112343 secs
+  create/ghost percent = 84.4015 15.5985
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000934601 secs
+  reassign/sort/migrate/ghost percent = 63.9286 0.586735 15.0255 20.4592
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00112438 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 26.2087 14.0373 0.975403 48.7065 10.0721 15.3732 0.360475
+  surf2grid time = 0.000547647 secs
+  map/comm1/comm2/comm3/comm4/split percent = 25.9034 10.2743 7.48803 5.26774 12.9299 29.7344
+
+#surf_collide        1 impulsive 300.0 softsphere 0.2 50 200 60 5 75
+surf_collide        1 impulsive 300.0 tempvar 1 50 200 60 5 75
+
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.049112082    20933        0        0      106     6236 
+     200   0.14848757    36879        0        0      156     9543 
+     300   0.27689004    46316        0        0      182    11024 
+     400   0.41525817    51660        0        0      176    11939 
+     500   0.56149912    54928        0        0      202    12499 
+     600   0.71064448    56769        0        0      149    12462 
+     700   0.88603878    58171        0        0      182    12871 
+     800    1.0413032    59230        0        0      199    13057 
+     900    1.1973052    59845        0        0      183    12701 
+    1000    1.3575974    60464        0        0      183    13031 
+Loop time of 1.35769 on 4 procs for 1000 steps with 60464 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.22542    | 0.60708    | 1.0042     |  48.9 | 44.71
+Coll    | 0.016551   | 0.048287   | 0.080448   |  14.4 |  3.56
+Sort    | 0.048818   | 0.097166   | 0.14853    |  14.9 |  7.16
+Comm    | 0.024274   | 0.026366   | 0.028524   |   0.9 |  1.94
+Modify  | 0.00052977 | 0.034713   | 0.06906    |  18.3 |  2.56
+Output  | 0.00029159 | 0.0012717  | 0.0020053  |   2.1 |  0.09
+Other   |            | 0.5428     |            |       | 39.98
+
+Particle moves    = 47839865 (47.8M)
+Cells touched     = 52732618 (52.7M)
+Particle comms    = 157107 (0.157M)
+Boundary collides = 170716 (0.171M)
+Boundary exits    = 150370 (0.15M)
+SurfColl checks   = 10873500 (10.9M)
+SurfColl occurs   = 172179 (0.172M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 8.80904e+06
+Particle-moves/step: 47839.9
+Cell-touches/particle/step: 1.10227
+Particle comm iterations/step: 1.997
+Particle fraction communicated: 0.00328402
+Particle fraction colliding with boundary: 0.00356849
+Particle fraction exiting boundary: 0.00314319
+Surface-checks/particle/step: 0.22729
+Surface-collisions/particle/step: 0.00359907
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 15116 ave 22903 max 7241 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.circle.specular
+++ b/examples/surf_collide/log.29Jun21.mpi_4.circle.specular
@@ -1,0 +1,135 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.001127 secs
+  create/ghost percent = 83.0548 16.9452
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000967503 secs
+  reassign/sort/migrate/ghost percent = 62.0256 1.3307 13.997 22.6466
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00113916 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.7221 10.4018 1.23483 52.4697 10.1716 23.7547 0.188363
+  surf2grid time = 0.000597715 secs
+  map/comm1/comm2/comm3/comm4/split percent = 26.4061 6.34224 6.50179 4.26805 8.65576 40.9653
+surf_collide	    1 specular
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.036628008    19677        0        0      122     4359 
+     200   0.10390639    31326        0        0      182     6571 
+     300   0.18434954    36910        0        0      168     7231 
+     400   0.27139139    39779        0        0      196     7880 
+     500   0.37109399    41289        0        0      193     8261 
+     600   0.47464848    42174        0        0      182     8295 
+     700   0.56881881    42756        0        0      184     8240 
+     800   0.66429639    42864        0        0      199     8562 
+     900   0.75743318    43267        0        0      182     8491 
+    1000   0.85132623    43534        0        0      224     8701 
+Loop time of 0.851422 on 4 procs for 1000 steps with 43534 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14087    | 0.34831    | 0.55602    |  35.1 | 40.91
+Coll    | 0.011851   | 0.037291   | 0.068018   |  13.2 |  4.38
+Sort    | 0.032616   | 0.068568   | 0.10489    |  13.1 |  8.05
+Comm    | 0.026455   | 0.029133   | 0.031988   |   1.2 |  3.42
+Modify  | 0.0004499  | 0.03456    | 0.068744   |  18.3 |  4.06
+Output  | 0.00030351 | 0.0028761  | 0.0082095  |   5.8 |  0.34
+Other   |            | 0.3307     |            |       | 38.84
+
+Particle moves    = 36549980 (36.5M)
+Cells touched     = 41400161 (41.4M)
+Particle comms    = 141448 (0.141M)
+Boundary collides = 172931 (0.173M)
+Boundary exits    = 167204 (0.167M)
+SurfColl checks   = 7232863 (7.23M)
+SurfColl occurs   = 173636 (0.174M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.0732e+07
+Particle-moves/step: 36550
+Cell-touches/particle/step: 1.1327
+Particle comm iterations/step: 1.999
+Particle fraction communicated: 0.00386999
+Particle fraction colliding with boundary: 0.00473136
+Particle fraction exiting boundary: 0.00457467
+Surface-checks/particle/step: 0.19789
+Surface-collisions/particle/step: 0.00475065
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10883.5 ave 16798 max 4943 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.29Jun21.mpi_4.circle.td
+++ b/examples/surf_collide/log.29Jun21.mpi_4.circle.td
@@ -1,0 +1,140 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00113392 secs
+  create/ghost percent = 83.053 16.947
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.000936985 secs
+  reassign/sort/migrate/ghost percent = 63.6896 1.24682 14.8092 20.2545
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  0 0 = number of pushed cells
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00105071 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 25.2099 11.2321 1.27071 51.4863 10.801 17.8126 0.408441
+  surf2grid time = 0.000540972 secs
+  map/comm1/comm2/comm3/comm4/split percent = 28.3825 9.60776 8.37373 6.96342 9.34332 29.0877
+
+surf_collide	    1 td 1000.0 #barrier 1000
+#surf_collide	    1 td 500.0 bond 500 0 0
+#surf_collide	    1 td 300.0 initenergy 0.01 0 0
+#surf_collide	    1 td 1000.0 barrier 1000 bond 500 0 0 initenergy 0.01 0 0
+
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.03786397    18935        0        0      112     3801 
+     200   0.10475016    28432        0        0      161     5873 
+     300   0.18200803    32176        0        0      183     6306 
+     400   0.26512647    33776        0        0      187     6687 
+     500   0.34807253    34642        0        0      215     6888 
+     600   0.43211532    35095        0        0      140     6581 
+     700   0.53588438    35382        0        0      176     6848 
+     800   0.62077546    35523        0        0      206     7186 
+     900   0.70594764    35651        0        0      186     6793 
+    1000   0.79122639    35732        0        0      171     6942 
+Loop time of 0.791285 on 4 procs for 1000 steps with 35732 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.11804    | 0.32306    | 0.52861    |  36.0 | 40.83
+Coll    | 0.0097322  | 0.028294   | 0.046873   |  11.0 |  3.58
+Sort    | 0.025206   | 0.057547   | 0.090564   |  13.0 |  7.27
+Comm    | 0.023626   | 0.036617   | 0.048531   |   5.9 |  4.63
+Modify  | 0.0004673  | 0.032977   | 0.065571   |  17.9 |  4.17
+Output  | 0.00025964 | 0.00088668 | 0.0013561  |   0.0 |  0.11
+Other   |            | 0.3119     |            |       | 39.42
+
+Particle moves    = 31095407 (31.1M)
+Cells touched     = 35983645 (36M)
+Particle comms    = 143676 (0.144M)
+Boundary collides = 172693 (0.173M)
+Boundary exits    = 175102 (0.175M)
+SurfColl checks   = 6041072 (6.04M)
+SurfColl occurs   = 173166 (0.173M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 9.82434e+06
+Particle-moves/step: 31095.4
+Cell-touches/particle/step: 1.1572
+Particle comm iterations/step: 2.145
+Particle fraction communicated: 0.00462049
+Particle fraction colliding with boundary: 0.00555365
+Particle fraction exiting boundary: 0.00563112
+Surface-checks/particle/step: 0.194275
+Surface-collisions/particle/step: 0.00556886
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 8933 ave 14091 max 3766 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/vibrate/log.29Jun21.mpi_1.vibrate
+++ b/examples/vibrate/log.29Jun21.mpi_1.vibrate
@@ -1,0 +1,128 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# test of vibrational energy modes
+# thermal gas in a 3d box with collisions
+# particles reflect off global box boundaries
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    54345
+dimension   	    3
+timestep 	    5e-9
+global              nrho 1.E22
+global              fnum 10000 comm/sort yes
+
+boundary	    r r r
+create_box  	    0 1e-5 0 1e-5 0 1e-5
+Created orthogonal box = (0 0 0) to (1e-05 1e-05 1e-05)
+create_grid 	    2 2 2
+Created 8 child grid cells
+  CPU time = 0.00087738 secs
+  create/ghost percent = 89.6196 10.3804
+
+species		    co2.species N2 CO2 vibfile co2.species.vib
+
+mixture             mix CO2 frac 0.9
+mixture             mix N2 frac 0.1
+
+mixture             mix group all
+mixture		    mix vstream 0.0 0.0 0.0 temp 20000 trot 20000.00 tvib 10.0
+
+collide		    vss all co2.vss
+collide_modify      vibrate discrete rotate smooth
+fix                 1 vibmode
+
+create_particles    mix n 0 twopass
+Created 1000 particles
+  CPU time = 0.0020442 secs
+
+variable            collrate equal "ncoll*step*2/np"
+
+compute             1 temp
+
+compute             5 thermal/grid all all temp
+compute             St reduce ave c_5[1]
+
+compute             6 tvib/grid all species
+compute             Sv reduce ave c_6[2]
+
+compute             7 grid all all trot tvib
+compute             Sr reduce ave c_7[1]
+compute             Srv reduce ave c_7[2]
+
+variable            tempdiff equal "c_St-c_Sr"
+
+stats_style	    step cpu np nattempt ncoll c_St c_Sr c_Srv c_Sv
+stats		    10
+
+run 		    100
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.875 1.875 1.875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.39014 3.39014 3.39014
+Step CPU Np Natt Ncoll c_St c_Sr c_Srv c_Sv 
+       0            0     1000        0        0    20057.341    22014.068            0            0 
+      10 0.0035810471     1000       39       26    19463.888    22017.225      287.329     595.8383 
+      20 0.0070948601     1000       42       25    19124.706    21932.175    481.68862    845.42574 
+      30  0.010551453     1000       42       31    18761.472    21726.199     716.0272    1038.0393 
+      40  0.013994455     1000       42       29    18317.704    21951.923    1026.3744     1291.115 
+      50  0.017383575     1000       41       28    17744.046    21807.096    1232.3211    1480.2921 
+      60  0.020757437     1000       42       33     17865.06    21531.968     1344.938    1523.7879 
+      70  0.024085283     1000       40       27    17830.094    20939.094     1590.924    1723.0971 
+      80  0.027405024     1000       41       27    17505.582    21131.338    1718.6248    1785.8951 
+      90  0.030740976     1000       42       26    17826.846    19989.863    1877.6859    1912.9077 
+     100  0.034066677     1000       42       30    17769.624    19815.344    2019.3781    2058.3622 
+Loop time of 0.0340817 on 1 procs for 100 steps with 1000 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.030641   | 0.030641   | 0.030641   |   0.0 | 89.90
+Coll    | 0.002254   | 0.002254   | 0.002254   |   0.0 |  6.61
+Sort    | 0.00035763 | 0.00035763 | 0.00035763 |   0.0 |  1.05
+Comm    | 6.1274e-05 | 6.1274e-05 | 6.1274e-05 |   0.0 |  0.18
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00075841 | 0.00075841 | 0.00075841 |   0.0 |  2.23
+Other   |            | 9.298e-06  |            |       |  0.03
+
+Particle moves    = 100000 (0.1M)
+Cells touched     = 326701 (0.327M)
+Particle comms    = 0 (0K)
+Boundary collides = 226767 (0.227M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 4174 (4.17K)
+Collide occurs    = 2910 (2.91K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 2.93413e+06
+Particle-moves/step: 1000
+Cell-touches/particle/step: 3.26701
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 2.26767
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0.04174
+Collisions/particle/step: 0.0291
+Reactions/particle/step: 0
+
+Particles: 1000 ave 1000 max 1000 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      8 ave 8 max 8 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/vibrate/log.29Jun21.mpi_4.vibrate
+++ b/examples/vibrate/log.29Jun21.mpi_4.vibrate
@@ -1,0 +1,128 @@
+SPARTA (26 Feb 2021)
+################################################################################
+# test of vibrational energy modes
+# thermal gas in a 3d box with collisions
+# particles reflect off global box boundaries
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    54345
+dimension   	    3
+timestep 	    5e-9
+global              nrho 1.E22
+global              fnum 10000 comm/sort yes
+
+boundary	    r r r
+create_box  	    0 1e-5 0 1e-5 0 1e-5
+Created orthogonal box = (0 0 0) to (1e-05 1e-05 1e-05)
+create_grid 	    2 2 2
+Created 8 child grid cells
+  CPU time = 0.00114131 secs
+  create/ghost percent = 81.22 18.78
+
+species		    co2.species N2 CO2 vibfile co2.species.vib
+
+mixture             mix CO2 frac 0.9
+mixture             mix N2 frac 0.1
+
+mixture             mix group all
+mixture		    mix vstream 0.0 0.0 0.0 temp 20000 trot 20000.00 tvib 10.0
+
+collide		    vss all co2.vss
+collide_modify      vibrate discrete rotate smooth
+fix                 1 vibmode
+
+create_particles    mix n 0 twopass
+Created 1000 particles
+  CPU time = 0.00163436 secs
+
+variable            collrate equal "ncoll*step*2/np"
+
+compute             1 temp
+
+compute             5 thermal/grid all all temp
+compute             St reduce ave c_5[1]
+
+compute             6 tvib/grid all species
+compute             Sv reduce ave c_6[2]
+
+compute             7 grid all all trot tvib
+compute             Sr reduce ave c_7[1]
+compute             Srv reduce ave c_7[2]
+
+variable            tempdiff equal "c_St-c_Sr"
+
+stats_style	    step cpu np nattempt ncoll c_St c_Sr c_Srv c_Sv
+stats		    10
+
+run 		    100
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 1.875 1.875 1.875
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 3.38913 3.38913 3.38913
+Step CPU Np Natt Ncoll c_St c_Sr c_Srv c_Sv 
+       0            0     1000        0        0    20140.655    19784.434            0            0 
+      10 0.0017282963     1000       40       32     19792.12    19825.117     157.9701    445.95618 
+      20 0.0034081936     1000       41       28    19462.136    19290.776    480.72693    882.34748 
+      30 0.0049240589     1000       42       33    19283.645    19151.225    644.85738    1066.8114 
+      40 0.0064079762     1000       42       29    18898.455    19299.484    828.73277    1274.4816 
+      50 0.0078532696     1000       44       29    18428.357    19480.227    1052.5021    1464.6698 
+      60 0.0093302727     1000       44       36    18404.183    19181.595    1158.0482    1540.9979 
+      70  0.010779619     1000       43       29    17732.093    19875.501    1266.2689    1645.2897 
+      80  0.012262344     1000       44       30    17434.539     19807.92    1391.3268    1791.3138 
+      90  0.013699293     1000       44       29    17190.013     19654.59    1634.4711    1999.4681 
+     100  0.015150309     1000       43       28    17069.251    19365.103    1827.8716    2203.5872 
+Loop time of 0.0152012 on 4 procs for 100 steps with 1000 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0082452  | 0.0084085  | 0.0085649  |   0.1 | 55.31
+Coll    | 0.0007441  | 0.00077188 | 0.00078344 |   0.0 |  5.08
+Sort    | 0.00011015 | 0.00011462 | 0.00011969 |   0.0 |  0.75
+Comm    | 0.0048692  | 0.0051704  | 0.0053749  |   0.3 | 34.01
+Modify  | 0          | 0          | 0          |   0.0 |  0.00
+Output  | 0.00061941 | 0.0006969  | 0.00090122 |   0.0 |  4.58
+Other   |            | 3.886e-05  |            |       |  0.26
+
+Particle moves    = 100000 (0.1M)
+Cells touched     = 331176 (0.331M)
+Particle comms    = 74877 (74.9K)
+Boundary collides = 231174 (0.231M)
+Boundary exits    = 0 (0K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 4225 (4.22K)
+Collide occurs    = 2867 (2.87K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.64461e+06
+Particle-moves/step: 1000
+Cell-touches/particle/step: 3.31176
+Particle comm iterations/step: 1
+Particle fraction communicated: 0.74877
+Particle fraction colliding with boundary: 2.31174
+Particle fraction exiting boundary: 0
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0.04225
+Collisions/particle/step: 0.02867
+Reactions/particle/step: 0
+
+Particles: 250 ave 261 max 239 min
+Histogram: 1 0 1 0 0 0 0 1 0 1
+Cells:      2 ave 2 max 2 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 6 ave 6 max 6 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -23,7 +23,7 @@
 #include "collide.h"
 #include "react.h"
 #include "comm.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "random_mars.h"
 #include "math_const.h"
 #include "memory_kokkos.h"
@@ -1749,12 +1749,12 @@ void CollideVSSKokkos::backup()
 
 #ifdef SPARTA_KOKKOS_EXACT
   if (!random_backup)
-    random_backup = new RanPark(12345 + comm->me);
+    random_backup = new RanKnuth(12345 + comm->me);
   memcpy(random_backup,random,sizeof(random));
 
   if (react) {
     if (!react_random_backup)
-      react_random_backup = new RanPark(12345 + comm->me);
+      react_random_backup = new RanKnuth(12345 + comm->me);
     memcpy(react_random_backup,react->get_random(),sizeof(react->get_random()));
   }
 #endif

--- a/src/KOKKOS/collide_vss_kokkos.h
+++ b/src/KOKKOS/collide_vss_kokkos.h
@@ -238,8 +238,8 @@ class CollideVSSKokkos : public CollideVSS {
   DAT::t_float_3d d_vremax_backup;
   DAT::t_float_3d d_remain_backup;
   DAT::t_int_2d d_nn_last_partner_backup;
-  RanPark* random_backup;
-  RanPark* react_random_backup;
+  RanKnuth* random_backup;
+  RanKnuth* react_random_backup;
 };
 
 }

--- a/src/KOKKOS/create_particles_kokkos.cpp
+++ b/src/KOKKOS/create_particles_kokkos.cpp
@@ -27,7 +27,7 @@
 #include "input.h"
 #include "variable.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory_kokkos.h"
 #include "error.h"
@@ -52,7 +52,7 @@ void CreateParticlesKokkos::create_local(bigint np)
   int dimension = domain->dimension;
 
   int me = comm->me;
-  RanPark *random = new RanPark(update->ranmaster->uniform());
+  RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,me,100);
   Grid::ChildCell *cells = grid->cells;

--- a/src/KOKKOS/fix_balance_kokkos.cpp
+++ b/src/KOKKOS/fix_balance_kokkos.cpp
@@ -27,7 +27,7 @@
 #include "output.h"
 #include "dump.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory_kokkos.h"
 #include "error.h"
 #include "sparta_masks.h"

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -26,7 +26,7 @@
 #include "modify.h"
 #include "geometry.h"
 #include "input.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory_kokkos.h"
 #include "error.h"

--- a/src/KOKKOS/fix_vibmode_kokkos.cpp
+++ b/src/KOKKOS/fix_vibmode_kokkos.cpp
@@ -19,7 +19,7 @@
 #include "collide.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "error.h"
 #include "sparta_masks.h"

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -24,7 +24,7 @@
 #include "mixture.h"
 #include "collide.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory_kokkos.h"
 #include "error.h"
 #include "kokkos.h"

--- a/src/KOKKOS/rand_pool_wrap.cpp
+++ b/src/KOKKOS/rand_pool_wrap.cpp
@@ -16,7 +16,7 @@
 #include "rand_pool_wrap.h"
 #include "sparta.h"
 #include "kokkos.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "random_mars.h"
 #include "update.h"
 
@@ -48,7 +48,7 @@ void RandPoolWrap::destroy()
   }
 }
 
-void RandPoolWrap::init(RanPark* random)
+void RandPoolWrap::init(RanKnuth* random)
 {
   // deallocate pool of RNGs
   if (random_thr) {
@@ -62,9 +62,9 @@ void RandPoolWrap::init(RanPark* random)
   // generate a random number generator instance for
   // all threads != 0. make sure we use unique seeds.
   nthreads = sparta->kokkos->nthreads;
-  random_thr = new RanPark*[nthreads];
+  random_thr = new RanKnuth*[nthreads];
   for (int tid = 1; tid < nthreads; ++tid) {
-    random_thr[tid] = new RanPark(update->ranmaster->uniform());
+    random_thr[tid] = new RanKnuth(update->ranmaster->uniform());
     double seed = update->ranmaster->uniform();
     random_thr[tid]->reset(seed,comm->me + comm->nprocs*tid,100);
   }

--- a/src/KOKKOS/rand_pool_wrap.h
+++ b/src/KOKKOS/rand_pool_wrap.h
@@ -17,13 +17,13 @@
 
 #include "pointers.h"
 #include "kokkos_type.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "error.h"
 
 namespace SPARTA_NS {
 
 struct RandWrap {
-  class RanPark* rng;
+  class RanKnuth* rng;
 
   KOKKOS_INLINE_FUNCTION
   RandWrap() {
@@ -46,13 +46,13 @@ class RandPoolWrap : protected Pointers {
   RandPoolWrap(int, class SPARTA *);
   ~RandPoolWrap();
   void destroy();
-  void init(RanPark*);
+  void init(RanKnuth*);
 
   KOKKOS_INLINE_FUNCTION
   RandWrap get_state() const
   {
 #ifdef SPARTA_KOKKOS_GPU
-    error->all(FLERR,"Cannot use Park RNG with GPUs");
+    error->all(FLERR,"Cannot use Knuth RNG with GPUs");
 #endif
 
     RandWrap rand_wrap;
@@ -75,7 +75,7 @@ class RandPoolWrap : protected Pointers {
   }
 
  private:
-  class RanPark **random_thr;
+  class RanKnuth **random_thr;
   int nthreads;
 };
 

--- a/src/KOKKOS/react_bird_kokkos.cpp
+++ b/src/KOKKOS/react_bird_kokkos.cpp
@@ -24,7 +24,7 @@
 #include "modify.h"
 #include "fix.h"
 #include "fix_ambipolar.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"

--- a/src/KOKKOS/react_tce_kokkos.cpp
+++ b/src/KOKKOS/react_tce_kokkos.cpp
@@ -18,7 +18,7 @@
 #include "react_tce_kokkos.h"
 #include "particle.h"
 #include "collide.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "error.h"
 
 // DEBUG

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -26,7 +26,7 @@
 #include "modify.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "math_extra.h"
 #include "error.h"
@@ -171,7 +171,7 @@ void SurfCollideDiffuseKokkos::pre_collide()
   if (random == NULL) {
     // initialize RNG
 
-    random = new RanPark(update->ranmaster->uniform());
+    random = new RanKnuth(update->ranmaster->uniform());
     double seed = update->ranmaster->uniform();
     random->reset(seed,comm->me,100);
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -38,7 +38,7 @@ SurfCollideStyle(diffuse/kk,SurfCollideDiffuseKokkos)
 #include "modify.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "math_extra_kokkos.h"
 #include "error.h"

--- a/src/adapt_grid.cpp
+++ b/src/adapt_grid.cpp
@@ -32,7 +32,7 @@
 #include "dump.h"
 #include "write_grid.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "hashlittle.h"
 #include "my_page.h"
 #include "math_extra.h"
@@ -493,7 +493,7 @@ void AdaptGrid::setup(int iter)
   // create RNG for style = RANDOM
 
   if (style == RANDOM) {
-    random = new RanPark(update->ranmaster->uniform());
+    random = new RanKnuth(update->ranmaster->uniform());
     double seed = update->ranmaster->uniform();
     random->reset(seed,comm->me,100);
   } else random = NULL;

--- a/src/adapt_grid.h
+++ b/src/adapt_grid.h
@@ -70,7 +70,7 @@ class AdaptGrid : protected Pointers {
   class Fix *fix;
 
   int *childlist;
-  class RanPark *random;
+  class RanKnuth *random;
   class Cut3d *cut3d;
   class Cut2d *cut2d;
 

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -25,7 +25,7 @@
 #include "output.h"
 #include "dump.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 #include "timer.h"
@@ -260,7 +260,7 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
 
   } else if (bstyle == RANDOM) {
     int newproc;
-    RanPark *random = new RanPark(update->ranmaster->uniform());
+    RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
     double seed = update->ranmaster->uniform();
     random->reset(seed,comm->me,100);
 
@@ -275,7 +275,7 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
 
   } else if (bstyle == PROC) {
     int newproc;
-    RanPark *random = new RanPark(update->ranmaster->uniform());
+    RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
     newproc = nprocs * random->uniform();
 
     for (int icell = 0; icell < nglocal; icell++) {

--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -25,7 +25,7 @@
 #include "fix.h"
 #include "fix_ambipolar.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 
@@ -52,7 +52,7 @@ Collide::Collide(SPARTA *sparta, int, char **arg) : Pointers(sparta)
   mixID = new char[n];
   strcpy(mixID,arg[1]);
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 

--- a/src/collide.h
+++ b/src/collide.h
@@ -88,7 +88,7 @@ class Collide : protected Pointers {
 
   char *mixID;               // ID of mixture to use for groups
   class Mixture *mixture;    // ptr to mixture
-  class RanPark *random;     // RNG for collision generation
+  class RanKnuth *random;     // RNG for collision generation
 
   int vre_first;      // 1 for first run after collision style is defined
   int vre_start;      // 1 if reset vre params at start of each run

--- a/src/collide_vss.cpp
+++ b/src/collide_vss.cpp
@@ -24,7 +24,7 @@
 #include "react.h"
 #include "comm.h"
 #include "fix_vibmode.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
@@ -766,7 +766,7 @@ void CollideVSS::EEXCHANGE_ReactingEDisposal(Particle::OnePart *ip,
 
 /* ---------------------------------------------------------------------- */
 
-double CollideVSS::sample_bl(RanPark *random, double Exp_1, double Exp_2)
+double CollideVSS::sample_bl(RanKnuth *random, double Exp_1, double Exp_2)
 {
   double Exp_s = Exp_1 + Exp_2;
   double x,y;

--- a/src/collide_vss.h
+++ b/src/collide_vss.h
@@ -94,7 +94,7 @@ class CollideVSS : public Collide {
                                    Particle::OnePart *,
                                    Particle::OnePart *);
 
-  double sample_bl(RanPark *, double, double);
+  double sample_bl(RanKnuth *, double, double);
   double rotrel (int, double);
   double vibrel (int, double);
 

--- a/src/create_grid.cpp
+++ b/src/create_grid.cpp
@@ -21,7 +21,7 @@
 #include "region.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 
@@ -505,7 +505,7 @@ void CreateGrid::create_random()
   double lo[3],hi[3];
   Stack *s;
 
-  RanPark *random = new RanPark(update->ranmaster->uniform());
+  RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
 
   // loop over all ntotal cells
   // only add cell if this proc is the random owner

--- a/src/create_particles.cpp
+++ b/src/create_particles.cpp
@@ -27,7 +27,7 @@
 #include "input.h"
 #include "variable.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
@@ -424,7 +424,7 @@ void CreateParticles::create_single()
 
   // add the particle
 
-  RanPark *random = new RanPark(update->ranmaster->uniform());
+  RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
 
   if (iwhich >= 0) {
     int id = MAXSMALLINT*random->uniform();
@@ -452,7 +452,7 @@ void CreateParticles::create_local(bigint np)
   int dimension = domain->dimension;
 
   int me = comm->me;
-  RanPark *random = new RanPark(update->ranmaster->uniform());
+  RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,me,100);
 
@@ -643,7 +643,7 @@ void CreateParticles::create_local_twopass(bigint np)
   int dimension = domain->dimension;
 
   int me = comm->me;
-  RanPark *random = new RanPark(update->ranmaster->uniform());
+  RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,me,100);
 
@@ -941,7 +941,7 @@ void CreateParticles::create_all(bigint n)
   double zprd = domain->zprd;
 
   int me = comm->me;
-  RanPark *random = new RandomPark(update->ranmaster->uniform());
+  RanKnuth *random = new RandomPark(update->ranmaster->uniform());
 
   int icell,id;
   double x,y,z;

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -30,7 +30,7 @@
 #include "marching_squares.h"
 #include "marching_cubes.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 
@@ -202,7 +202,7 @@ FixAblate::FixAblate(SPARTA *sparta, int narg, char **arg) :
 
   random = NULL;
   if (which == RANDOM) {
-    random = new RanPark(update->ranmaster->uniform());
+    random = new RanKnuth(update->ranmaster->uniform());
     //double seed = update->ranmaster->uniform();
     //random->reset(seed,comm->me,100);
   }

--- a/src/fix_ablate.h
+++ b/src/fix_ablate.h
@@ -90,7 +90,7 @@ class FixAblate : public Fix {
 
   class MarchingSquares *ms;
   class MarchingCubes *mc;
-  class RanPark *random;
+  class RanKnuth *random;
 
   void create_surfs(int);
   void set_delta_random();

--- a/src/fix_ambipolar.cpp
+++ b/src/fix_ambipolar.cpp
@@ -20,7 +20,7 @@
 #include "particle.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
@@ -62,7 +62,7 @@ FixAmbipolar::FixAmbipolar(SPARTA *sparta, int narg, char **arg) :
 
   // random = RNG for electron velocity creation
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 

--- a/src/fix_ambipolar.h
+++ b/src/fix_ambipolar.h
@@ -41,7 +41,7 @@ class FixAmbipolar : public Fix {
  private:
   int maxion;                 // length of ions vector
   int ionindex,velindex;      // indices into particle custom data structs
-  class RanPark *random;
+  class RanKnuth *random;
 };
 
 }

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -27,7 +27,7 @@
 #include "output.h"
 #include "dump.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 #include "timer.h"
@@ -118,7 +118,7 @@ FixBalance::FixBalance(SPARTA *sparta, int narg, char **arg) :
   rcb = NULL;
 
   if (bstyle == RANDOM || bstyle == PROC)
-    random = new RanPark(update->ranmaster->uniform());
+    random = new RanKnuth(update->ranmaster->uniform());
   if (bstyle == BISECTION) rcb = new RCB(sparta);
 
   // compute initial outputs

--- a/src/fix_balance.h
+++ b/src/fix_balance.h
@@ -48,7 +48,7 @@ class FixBalance : public Fix {
   double imbfinal;              // imbalance factor after last rebalancing
   double maxperproc;            // max atoms or CPU cost on any processor
 
-  class RanPark *random;
+  class RanKnuth *random;
   class RCB *rcb;
 
   double imbalance_factor(double &);

--- a/src/fix_emit.cpp
+++ b/src/fix_emit.cpp
@@ -21,7 +21,7 @@
 #include "grid.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
@@ -47,7 +47,7 @@ FixEmit::FixEmit(SPARTA *sparta, int narg, char **arg) :
   // RNG
 
   int me = comm->me;
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,me,100);
 

--- a/src/fix_emit.h
+++ b/src/fix_emit.h
@@ -33,7 +33,7 @@ class FixEmit : public Fix {
  protected:
   int perspecies;
   class Region *region;
-  class RanPark *random;
+  class RanKnuth *random;
   int nsingle,ntotal;
 
   int ntask;           // # of insert tasks in underlying child class

--- a/src/fix_emit_face.cpp
+++ b/src/fix_emit_face.cpp
@@ -26,7 +26,7 @@
 #include "modify.h"
 #include "geometry.h"
 #include "input.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"

--- a/src/fix_emit_face_file.cpp
+++ b/src/fix_emit_face_file.cpp
@@ -27,7 +27,7 @@
 #include "comm.h"
 #include "modify.h"
 #include "geometry.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -26,7 +26,7 @@
 #include "cut3d.h"
 #include "input.h"
 #include "comm.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_extra.h"
 #include "math_const.h"
 #include "memory.h"

--- a/src/fix_vibmode.cpp
+++ b/src/fix_vibmode.cpp
@@ -19,7 +19,7 @@
 #include "collide.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "error.h"
 
@@ -40,7 +40,7 @@ FixVibmode::FixVibmode(SPARTA *sparta, int narg, char **arg) :
 
   // random = RNG for vibrational mode initialization
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 

--- a/src/fix_vibmode.h
+++ b/src/fix_vibmode.h
@@ -37,7 +37,7 @@ class FixVibmode : public Fix {
  protected:
   int maxmode;           // max # of vibrational modes for any species
   int vibmodeindex;      // index into particle custom data structs
-  class RanPark *random;
+  class RanKnuth *random;
 };
 
 }

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -25,7 +25,7 @@
 #include "math_extra.h"
 #include "update.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "error.h"
 #include "memory.h"
@@ -262,7 +262,7 @@ void Image::view_params(double boxxlo, double boxxhi, double boxylo,
 
   if (ssao) {
     if (!random) {
-      random = new RanPark(update->ranmaster->uniform());
+      random = new RanKnuth(update->ranmaster->uniform());
       double seed = update->ranmaster->uniform();
       random->reset(seed,me,100);
     }

--- a/src/image.h
+++ b/src/image.h
@@ -134,7 +134,7 @@ class Image : protected Pointers {
 
   // SSAO RNG
 
-  class RanPark *random;
+  class RanKnuth *random;
 
   // internal methods
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -24,7 +24,7 @@
 #include "mixture.h"
 #include "collide.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 #include "fix_vibmode.h"
@@ -160,7 +160,7 @@ void Particle::init()
   // RNG for particle weighting
 
   if (!wrandom) {
-    wrandom = new RanPark(update->ranmaster->uniform());
+    wrandom = new RanKnuth(update->ranmaster->uniform());
     double seed = update->ranmaster->uniform();
     wrandom->reset(seed,me,100);
   }
@@ -1006,7 +1006,7 @@ int Particle::find_mixture(char *id)
    only a function of species index and species properties
 ------------------------------------------------------------------------- */
 
-double Particle::erot(int isp, double temp_thermal, RanPark *erandom)
+double Particle::erot(int isp, double temp_thermal, RanKnuth *erandom)
 {
   double eng,a,erm,b;
   int rotstyle = NONE;
@@ -1042,7 +1042,7 @@ double Particle::erot(int isp, double temp_thermal, RanPark *erandom)
      -1 if not defined for this model
 ------------------------------------------------------------------------- */
 
-double Particle::evib(int isp, double temp_thermal, RanPark *erandom)
+double Particle::evib(int isp, double temp_thermal, RanKnuth *erandom)
 {
   double eng,a,erm,b;
 

--- a/src/particle.h
+++ b/src/particle.h
@@ -152,8 +152,8 @@ class Particle : protected Pointers {
   void add_mixture(int, char **);
   int find_species(char *);
   int find_mixture(char *);
-  double erot(int, double, class RanPark *);
-  double evib(int, double, class RanPark *);
+  double erot(int, double, class RanKnuth *);
+  double evib(int, double, class RanKnuth *);
 
   void write_restart_species(FILE *fp);
   void read_restart_species(FILE *fp);
@@ -195,7 +195,7 @@ class Particle : protected Pointers {
   RotFile *filerot;         // list of species rotation info read from file
   VibFile *filevib;         // list of species vibration info read from file
 
-  class RanPark *wrandom;   // RNG for particle weighting
+  class RanKnuth *wrandom;   // RNG for particle weighting
 
   // extra custom vectors/arrays for per-particle data
   // ncustom > 0 if there are any extra arrays

--- a/src/random_knuth.cpp
+++ b/src/random_knuth.cpp
@@ -14,6 +14,7 @@
 
 #include "math.h"
 #include "random_knuth.h"
+#include "stdlib.h"
 
 using namespace SPARTA_NS;
 
@@ -71,7 +72,7 @@ double RanKnuth::uniform()
 {
   int i,ii,k,mj,mk;
 
-  if (not_init == 0) {
+  if (not_init == 1) {
     not_init = 0;
     mj = labs(MSEED-labs(seed));
     mj %= MBIG;

--- a/src/random_knuth.h
+++ b/src/random_knuth.h
@@ -12,16 +12,16 @@
    See the README file in the top-level SPARTA directory.
 ------------------------------------------------------------------------- */
 
-#ifndef SPARTA_RAN_PARK_H
-#define SPARTA_RAN_PARK_H
+#ifndef SPARTA_RAN_KNUTH_H
+#define SPARTA_RAN_KNUTH_H
 
 namespace SPARTA_NS {
 
-class RanPark {
+class RanKnuth {
  public:
-  RanPark(int);
-  RanPark(double);
-  ~RanPark() {}
+  RanKnuth(int);
+  RanKnuth(double);
+  ~RanKnuth() {}
   void reset(double, int, int);
   double uniform();
   double gaussian();
@@ -29,6 +29,8 @@ class RanPark {
  private:
   int seed,save;
   double second;
+  int not_init,inext,inextp;
+  int ma[56];
 };
 
 }

--- a/src/react.cpp
+++ b/src/react.cpp
@@ -19,7 +19,7 @@
 #include "comm.h"
 #include "input.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "error.h"
 
 using namespace SPARTA_NS;
@@ -36,7 +36,7 @@ React::React(SPARTA *sparta, int, char **arg) : Pointers(sparta)
   recomb_boost = 1000.0;
   recomb_boost_inverse = 0.001;
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 

--- a/src/react.h
+++ b/src/react.h
@@ -47,10 +47,10 @@ class React : protected Pointers {
   virtual double extract_tally(int) = 0;
 
   void modify_params(int, char **);
-  RanPark* get_random() { return random; }
+  RanKnuth* get_random() { return random; }
 
  protected:
-  class RanPark *random;
+  class RanKnuth *random;
 };
 
 }

--- a/src/react_bird.cpp
+++ b/src/react_bird.cpp
@@ -24,7 +24,7 @@
 #include "modify.h"
 #include "fix.h"
 #include "fix_ambipolar.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"

--- a/src/react_qk.cpp
+++ b/src/react_qk.cpp
@@ -19,7 +19,7 @@
 #include "update.h"
 #include "particle.h"
 #include "collide.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "error.h"
 

--- a/src/react_tce.cpp
+++ b/src/react_tce.cpp
@@ -18,7 +18,7 @@
 #include "react_tce.h"
 #include "particle.h"
 #include "collide.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "error.h"
 
 using namespace SPARTA_NS;

--- a/src/react_tce_qk.cpp
+++ b/src/react_tce_qk.cpp
@@ -18,7 +18,7 @@
 #include "react_tce_qk.h"
 #include "update.h"
 #include "collide.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "memory.h"
 #include "error.h"
 

--- a/src/scale_particles.cpp
+++ b/src/scale_particles.cpp
@@ -21,7 +21,7 @@
 #include "mixture.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "error.h"
 
 using namespace SPARTA_NS;
@@ -48,7 +48,7 @@ void ScaleParticles::command(int narg, char **arg)
 
   // RNG for cloning/deletion
 
-  RanPark *random = new RanPark(update->ranmaster->uniform());
+  RanKnuth *random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 

--- a/src/surf_collide_cll.cpp
+++ b/src/surf_collide_cll.cpp
@@ -35,7 +35,7 @@
 #include "modify.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "math_extra.h"
 #include "error.h"
@@ -123,7 +123,7 @@ SurfCollideCLL::SurfCollideCLL(SPARTA *sparta, int narg, char **arg) :
 
   // initialize RNG
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 }

--- a/src/surf_collide_cll.h
+++ b/src/surf_collide_cll.h
@@ -54,7 +54,7 @@ class SurfCollideCLL : public SurfCollide {
   int tvar;                  // index of equal-style variable
 
   double vstream[3];
-  class RanPark *random;     // RNG for particle reflection
+  class RanKnuth *random;     // RNG for particle reflection
 
   void cll(Particle::OnePart *, double *);
 };

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -26,7 +26,7 @@
 #include "modify.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "math_extra.h"
 #include "error.h"
@@ -99,7 +99,7 @@ SurfCollideDiffuse::SurfCollideDiffuse(SPARTA *sparta, int narg, char **arg) :
 
   // initialize RNG
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 }

--- a/src/surf_collide_diffuse.h
+++ b/src/surf_collide_diffuse.h
@@ -49,7 +49,7 @@ class SurfCollideDiffuse : public SurfCollide {
   int tvar;                  // index of equal-style variable
 
   double vstream[3];
-  class RanPark *random;     // RNG for particle reflection
+  class RanKnuth *random;     // RNG for particle reflection
 
   void diffuse(Particle::OnePart *, double *);
 };

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -31,7 +31,7 @@
 #include "modify.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "math_extra.h"
 #include "error.h"
@@ -134,7 +134,7 @@ SurfCollideImpulsive::SurfCollideImpulsive(SPARTA *sparta, int narg, char **arg)
 
   // initialize RNG
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 }

--- a/src/surf_collide_impulsive.h
+++ b/src/surf_collide_impulsive.h
@@ -58,7 +58,7 @@ class SurfCollideImpulsive : public SurfCollide {
   int tvar;                  // index of equal-style variable
 
   double vstream[3];
-  class RanPark *random;     // RNG for particle reflection
+  class RanKnuth *random;     // RNG for particle reflection
 
   void impulsive(Particle::OnePart *, double *);
 };

--- a/src/surf_collide_td.cpp
+++ b/src/surf_collide_td.cpp
@@ -30,7 +30,7 @@
 #include "modify.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "math_extra.h"
 #include "error.h"
@@ -94,7 +94,7 @@ SurfCollideTD::SurfCollideTD(SPARTA *sparta, int narg, char **arg) :
 
   // initialize RNG
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 }

--- a/src/surf_collide_td.h
+++ b/src/surf_collide_td.h
@@ -52,7 +52,7 @@ class SurfCollideTD : public SurfCollide {
   int tvar;                  // index of equal-style variable
 
   double vstream[3];
-  class RanPark *random;     // RNG for particle reflection
+  class RanKnuth *random;     // RNG for particle reflection
 
   void td(Particle::OnePart *, double *);
 };

--- a/src/surf_react_global.cpp
+++ b/src/surf_react_global.cpp
@@ -18,7 +18,7 @@
 #include "update.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_extra.h"
 #include "error.h"
 
@@ -47,7 +47,7 @@ SurfReactGlobal::SurfReactGlobal(SPARTA *sparta, int narg, char **arg) :
 
   // initialize RNG
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 }

--- a/src/surf_react_global.h
+++ b/src/surf_react_global.h
@@ -37,7 +37,7 @@ class SurfReactGlobal : public SurfReact {
 
  private:
   double prob_create,prob_destroy;
-  class RanPark *random;     // RNG for reaction probabilities
+  class RanKnuth *random;     // RNG for reaction probabilities
 };
 
 }

--- a/src/surf_react_prob.cpp
+++ b/src/surf_react_prob.cpp
@@ -18,7 +18,7 @@
 #include "update.h"
 #include "comm.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_extra.h"
 #include "error.h"
 
@@ -44,7 +44,7 @@ SurfReactProb::SurfReactProb(SPARTA *sparta, int narg, char **arg) :
 
   // initialize RNG
 
-  random = new RanPark(update->ranmaster->uniform());
+  random = new RanKnuth(update->ranmaster->uniform());
   double seed = update->ranmaster->uniform();
   random->reset(seed,comm->me,100);
 }

--- a/src/surf_react_prob.h
+++ b/src/surf_react_prob.h
@@ -33,7 +33,7 @@ class SurfReactProb : public SurfReact {
   int react(Particle::OnePart *&, double *, Particle::OnePart *&);
 
  private:
-  class RanPark *random;     // RNG for reaction probabilities
+  class RanKnuth *random;     // RNG for reaction probabilities
 };
 
 }

--- a/src/update.h
+++ b/src/update.h
@@ -96,7 +96,7 @@ class Update : protected Pointers {
  protected:
   int me,nprocs;
   int maxmigrate;            // max # of particles in mlist
-  class RanPark *random;     // RNG for particle timestep moves
+  class RanKnuth *random;     // RNG for particle timestep moves
 
   int collide_react;         // 1 if any SurfCollide or React classes defined
   int nsc,nsr;               // copy of Collide/React data in Surf class

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -34,7 +34,7 @@
 #include "output.h"
 #include "stats.h"
 #include "random_mars.h"
-#include "random_park.h"
+#include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
 #include "error.h"
@@ -2219,7 +2219,7 @@ double Variable::collapse_tree(Tree *tree)
     collapse_tree(tree->left);
     collapse_tree(tree->right);
     if (randomparticle == NULL) {
-      randomparticle = new RanPark(update->ranmaster->uniform());
+      randomparticle = new RanKnuth(update->ranmaster->uniform());
       double seed = update->ranmaster->uniform();
       randomparticle->reset(seed,me,100);
     }
@@ -2232,7 +2232,7 @@ double Variable::collapse_tree(Tree *tree)
     if (sigma < 0.0)
       error->one(FLERR,"Invalid math function in variable formula");
     if (randomparticle == NULL) {
-      randomparticle = new RanPark(update->ranmaster->uniform());
+      randomparticle = new RanKnuth(update->ranmaster->uniform());
       double seed = update->ranmaster->uniform();
       randomparticle->reset(seed,me,100);
     }
@@ -2507,7 +2507,7 @@ double Variable::eval_tree(Tree *tree, int i)
     double lower = eval_tree(tree->left,i);
     double upper = eval_tree(tree->right,i);
     if (randomparticle == NULL) {
-      randomparticle = new RanPark(update->ranmaster->uniform());
+      randomparticle = new RanKnuth(update->ranmaster->uniform());
       double seed = update->ranmaster->uniform();
       randomparticle->reset(seed,me,100);
     }
@@ -2519,7 +2519,7 @@ double Variable::eval_tree(Tree *tree, int i)
     if (sigma < 0.0)
       error->one(FLERR,"Invalid math function in variable formula");
     if (randomparticle == NULL) {
-      randomparticle = new RanPark(update->ranmaster->uniform());
+      randomparticle = new RanKnuth(update->ranmaster->uniform());
       double seed = update->ranmaster->uniform();
       randomparticle->reset(seed,me,100);
     }
@@ -2919,7 +2919,7 @@ int Variable::math_function(char *word, char *contents, Tree **tree,
     if (tree) newtree->type = RANDOM;
     else {
       if (randomequal == NULL) {
-	randomequal = new RanPark(update->ranmaster->uniform());
+	randomequal = new RanKnuth(update->ranmaster->uniform());
 	double seed = update->ranmaster->uniform();
 	randomequal->reset(seed,me,100);
       }
@@ -2933,7 +2933,7 @@ int Variable::math_function(char *word, char *contents, Tree **tree,
       if (value2 < 0.0)
 	error->all(FLERR,"Invalid math function in variable formula");
       if (randomequal == NULL) {
-	randomequal = new RanPark(update->ranmaster->uniform());
+	randomequal = new RanKnuth(update->ranmaster->uniform());
 	double seed = update->ranmaster->uniform();
 	randomequal->reset(seed,me,100);
       }

--- a/src/variable.h
+++ b/src/variable.h
@@ -61,8 +61,8 @@ class Variable : protected Pointers {
 
   int *eval_in_progress;   // flag if evaluation of variable is in progress
 
-  class RanPark *randomequal;     // RNG for equal-style vars
-  class RanPark *randomparticle;  // RNG for particle-style vars
+  class RanKnuth *randomequal;     // RNG for equal-style vars
+  class RanKnuth *randomparticle;  // RNG for particle-style vars
 
   int precedence[17];      // precedence level of math operators
                            // set length to include up to OR in enum

--- a/tools/testing/rebless.sh
+++ b/tools/testing/rebless.sh
@@ -26,20 +26,24 @@ if [ ! "$1" = "--rerun-failed" ]; then
     ################################################################################
     make -j4
     ################################################################################
-    ctest
+    #ctest
 else
     ctest --rerun-failed
 fi
 
 ################################################################################
+oldDateStr=24Aug20
 dateStr=$(date "+%d%b%y")
-for logFile in $(ls examples/**/log.archive.$dateStr.*); do
-    logFileName=$(echo $logFile | sed 's/\.archive//g')
-    mv -f $logFile ../$logFileName
+for logFileOld in $(ls examples/**/log.$oldDateStr.*); do
+    logFileNew=$(echo $logFileOld | sed "s/.${oldDateStr}//g")
+    logFileGold=$(echo $logFileNew | sed "s/.mpi/.${dateStr}.mpi/g")
+    #echo $logFileOld $logFileNew $logFileGold
+    rm ../$logFileOld
+    mv $logFileNew ../$logFileGold
 done
 ################################################################################
-cd ../
-git add examples/**/log.archive.$dateStr.*
+git add ../examples
 #git commit -m "examples: Reblessed log.archive.$dateStr"
 ################################################################################
 echo "STATUS: Log files re-blessed. Please review 'git diff --staged'"
+


### PR DESCRIPTION
## Purpose

Change pRNG in SPARTA from Park to Knuth algorithm (aka `ran3` in Numerical Recipes book). The current Park random number generator seems to have a rather small period and when the code is running on a single core it introduces a bias (see #13). This error almost disappears for parallel runs, when the period is effectively multiplied by the number of cores. Using a different RNG fixes the issue. Fixes #13.

## Author(s)

Michael Gallis (SNL), Arnaud Borner (NASA), Stan Moore (SNL)

## Backward Compatibility

Input script syntax is unchanged but this will break all the regression tests.