### PR TITLE
Fix indexing bug in Kokkos surf tally

### DIFF
--- a/src/KOKKOS/compute_surf_kokkos.cpp
+++ b/src/KOKKOS/compute_surf_kokkos.cpp
@@ -178,8 +178,8 @@ int ComputeSurfKokkos::tallyinfo(surfint *&ptr)
       ntally = istart;
       break;
     }
-    for (int k = 0; k < nsurf; k++) {
-      array_surf_tally[istart] = array_surf_tally[iend];
+    for (int k = 0; k < ntotal; k++) {
+      array_surf_tally[istart][k] = array_surf_tally[iend][k];
     }
     h_surf2tally[istart] = h_surf2tally[iend];
     h_surf2tally[iend] = -1;


### PR DESCRIPTION
## Purpose

Fix indexing bug in Kokkos surf diffuse tally, could give wrong tally for `compute surf` with Kokkos in some cases.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes