### PR TITLE
Add warning related to computing temperature and fix vibmode

### DIFF
--- a/src/compute_grid.cpp
+++ b/src/compute_grid.cpp
@@ -138,11 +138,6 @@ ComputeGrid::ComputeGrid(SPARTA *sparta, int narg, char **arg) :
       value[ivalue] = TVIB;
       set_map(ivalue,ENGVIB);
       set_map(ivalue,DOFVIB);
-
-      if (particle->find_custom((char *) "vibmode") >= 0)
-        if (comm->me == 0)
-          error->warning(FLERR,"Using compute grid tvib with "
-           "fix vibmode may give incorrect temperature");
     } else if (strcmp(arg[iarg],"pxrho") == 0) {
       value[ivalue] = PXRHO;
       set_map(ivalue,MVX);
@@ -199,6 +194,11 @@ void ComputeGrid::init()
 {
   if (ngroup != particle->mixture[imix]->ngroup)
     error->all(FLERR,"Number of groups in compute grid mixture has changed");
+
+  if (particle->find_custom((char *) "vibmode") >= 0)
+    if (comm->me == 0)
+      error->warning(FLERR,"Using compute grid tvib with "
+                            "fix vibmode may give incorrect temperature");
 
   eprefactor = 0.5*update->mvv2e;
   tprefactor = update->mvv2e / (3.0*update->boltz);

--- a/src/compute_grid.cpp
+++ b/src/compute_grid.cpp
@@ -197,8 +197,8 @@ void ComputeGrid::init()
 
   if (particle->find_custom((char *) "vibmode") >= 0)
     if (comm->me == 0)
-      error->warning(FLERR,"Using compute grid tvib with "
-                            "fix vibmode may give incorrect temperature");
+      error->warning(FLERR,"Using compute grid tvib with fix vibmode may give "
+                            "incorrect temperature, use compute tvib/grid instead");
 
   eprefactor = 0.5*update->mvv2e;
   tprefactor = update->mvv2e / (3.0*update->boltz);

--- a/src/compute_grid.cpp
+++ b/src/compute_grid.cpp
@@ -21,6 +21,7 @@
 #include "modify.h"
 #include "memory.h"
 #include "error.h"
+#include "comm.h"
 
 using namespace SPARTA_NS;
 
@@ -137,6 +138,11 @@ ComputeGrid::ComputeGrid(SPARTA *sparta, int narg, char **arg) :
       value[ivalue] = TVIB;
       set_map(ivalue,ENGVIB);
       set_map(ivalue,DOFVIB);
+
+      if (particle->find_custom((char *) "vibmode") >= 0)
+        if (comm->me == 0)
+          error->warning(FLERR,"Using compute grid tvib with "
+           "fix vibmode may give incorrect temperature");
     } else if (strcmp(arg[iarg],"pxrho") == 0) {
       value[ivalue] = PXRHO;
       set_map(ivalue,MVX);

--- a/src/compute_grid.cpp
+++ b/src/compute_grid.cpp
@@ -198,7 +198,7 @@ void ComputeGrid::init()
   if (particle->find_custom((char *) "vibmode") >= 0)
     if (comm->me == 0)
       error->warning(FLERR,"Using compute grid tvib with fix vibmode may give "
-                            "incorrect temperature, use compute tvib/grid instead");
+                     "incorrect temperature, use compute tvib/grid instead");
 
   eprefactor = 0.5*update->mvv2e;
   tprefactor = update->mvv2e / (3.0*update->boltz);

--- a/src/compute_grid.h
+++ b/src/compute_grid.h
@@ -75,6 +75,10 @@ E: Compute grid mixture ID does not exist
 
 Self-explanatory.
 
+W: Using compute grid tvib with fix vibmode may give incorrect temperature
+
+Self-explanatory.
+
 E: Number of groups in compute grid mixture has changed
 
 This mixture property cannot be changed after this compute command is

--- a/src/compute_grid.h
+++ b/src/compute_grid.h
@@ -75,7 +75,8 @@ E: Compute grid mixture ID does not exist
 
 Self-explanatory.
 
-W: Using compute grid tvib with fix vibmode may give incorrect temperature
+W: Using compute grid tvib with fix vibmode may give incorrect temperature,
+use compute tvib/grid instead
 
 Self-explanatory.
 


### PR DESCRIPTION
## Purpose

Add warning if using compute grid tvib with fix vibmode, which can give incorrect temperature.

## Author(s)

Stan Moore (SNL), reported by Arnaud Borner (NASA)

## Backward Compatibility

Yes