### PR TITLE
Add nsplit to dump_grid

### DIFF
--- a/doc/dump.html
+++ b/doc/dump.html
@@ -59,6 +59,7 @@
 </PRE>
 <PRE>      id = integer form of grid cell ID
       idstr = string form of grid cell ID
+      nsplit = integer, either 1 (unsplit cell) or negative sub cell ID
       proc = processor that owns grid cell
       xlo,ylo,zlo = coords of lower left corner of grid cell
       xhi,yhi,zhi = coords of lower left corner of grid cell

--- a/doc/dump.txt
+++ b/doc/dump.txt
@@ -48,6 +48,7 @@ args = list of arguments for a particular style :l
 
       id = integer form of grid cell ID
       idstr = string form of grid cell ID
+      nsplit = integer, either 1 (unsplit cell) or negative sub cell ID
       proc = processor that owns grid cell
       xlo,ylo,zlo = coords of lower left corner of grid cell
       xhi,yhi,zhi = coords of lower left corner of grid cell

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -384,6 +384,9 @@ int DumpGrid::parse_fields(int narg, char **arg)
     } else if (strcmp(arg[iarg],"idstr") == 0) {
       pack_choice[i] = &DumpGrid::pack_id;
       vtype[i] = STRING;
+    } else if (strcmp(arg[iarg],"nsplit") == 0) {
+      pack_choice[i] = &DumpGrid::pack_nsplit;
+      vtype[i] = INT;
     } else if (strcmp(arg[iarg],"proc") == 0) {
       pack_choice[i] = &DumpGrid::pack_proc;
       vtype[i] = INT;
@@ -717,6 +720,18 @@ void DumpGrid::pack_id(int n)
 
   for (int i = 0; i < ncpart; i++) {
     buf[n] = cells[cpart[i]].id;
+    n += size_one;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpGrid::pack_nsplit(int n)
+{
+  Grid::ChildCell *cells = grid->cells;
+
+  for (int i = 0; i < ncpart; i++) {
+    buf[n] = cells[cpart[i]].nsplit;
     n += size_one;
   }
 }

--- a/src/dump_grid.h
+++ b/src/dump_grid.h
@@ -96,6 +96,7 @@ class DumpGrid : public Dump {
   void pack_variable(int);
 
   void pack_id(int);
+  void pack_nsplit(int);
   void pack_proc(int);
 
   void pack_xlo(int);


### PR DESCRIPTION
## Purpose

Add `nsplit` to `dump_grid` command. This is useful to make dump of split cells (which have identical cell ids) unique and is easier to compare against than the volume which was the best previously available option.

## Author(s)

Tim Teichmann, KIT

## Backward Compatibility

100% compatible

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines



