### PR TITLE
Prevent RNG returning exactly zero or other bad numbers

### DIFF
--- a/src/random_knuth.cpp
+++ b/src/random_knuth.cpp
@@ -94,16 +94,19 @@ double RanKnuth::uniform()
     inext = 0;
     inextp = 31;
   }
-  if (++inext == 56) inext = 1;
-  if (++inextp == 56) inextp = 1;
-  mj = ma[inext] - ma[inextp];
-  if (mj < 0) mj += MBIG;
-  ma[inext] = mj;
-  rn = mj*FAC;
 
-  // check for bad values
+  while (1) {
+    if (++inext == 56) inext = 1;
+    if (++inextp == 56) inextp = 1;
+    mj = ma[inext] - ma[inextp];
+    if (mj < 0) mj += MBIG;
+    ma[inext] = mj;
+    rn = mj*FAC;
 
-  if (rn <= 0.0 || rn >= 1.0) return uniform();
+    // make sure the random number is valid
+
+    if (rn > 0.0 && rn < 1.0) break;
+  }
 
   return rn;
 }

--- a/src/random_knuth.cpp
+++ b/src/random_knuth.cpp
@@ -98,6 +98,7 @@ double RanKnuth::uniform()
   mj = ma[inext] - ma[inextp];
   if (mj < 0) mj += MBIG;
   ma[inext] = mj;
+  if (mj*FAC == 0.0) return uniform();
   return mj*FAC;
 }
 

--- a/src/random_knuth.cpp
+++ b/src/random_knuth.cpp
@@ -71,6 +71,7 @@ void RanKnuth::reset(double rseed, int offset, int warmup)
 double RanKnuth::uniform()
 {
   int i,ii,k,mj,mk;
+  double rn;
 
   if (not_init == 1) {
     not_init = 0;
@@ -98,8 +99,13 @@ double RanKnuth::uniform()
   mj = ma[inext] - ma[inextp];
   if (mj < 0) mj += MBIG;
   ma[inext] = mj;
-  if (mj*FAC == 0.0) return uniform();
-  return mj*FAC;
+  rn = mj*FAC;
+
+  // check for bad values
+
+  if (rn <= 0.0 || rn >= 1.0) return uniform();
+
+  return rn;
 }
 
 /* ----------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

The new Knuth RNG can return a value of exactly 0.0, which can lead to numerical issues (Infinity or NaN), for example here:  https://github.com/sparta/sparta/blob/master/src/surf_collide_diffuse.cpp#L234. This PR avoids the issue by returning a different random number if an exact 0.0 or other bad number is encountered.

## Author(s)

Stan Moore (SNL), original issue reported by Nirajan Adhikari (Purdue)

## Backward Compatibility

Yes