### PR TITLE
Fix issue with Kokkos and restart file on GPUs

### DIFF
--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -145,7 +145,7 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
   comm_classic = 0;
   atomic_reduction = 0;
   prewrap = 1;
-  auto_sync = 0;
+  auto_sync = 1;
   gpu_direct_flag = 1;
 
   need_atomics = 1;

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -203,6 +203,8 @@ void UpdateKokkos::setup()
   GridKokkos* grid_kk = (GridKokkos*) grid;
   SurfKokkos* surf_kk = (SurfKokkos*) surf;
 
+  particle_kk->sync(Device,ALL_MASK);
+
   if (sparta->kokkos->prewrap) {
 
     // particle
@@ -222,7 +224,6 @@ void UpdateKokkos::setup()
 
     sparta->kokkos->prewrap = 0;
   } else {
-    particle_kk->modify(Host,ALL_MASK);
     grid_kk->modify(Host,ALL_MASK);
     grid_kk->update_hash();
     if (surf->exist) {


### PR DESCRIPTION
## Purpose

Fix issue with Kokkos and restart file when running on GPUs. There was missing data transfer between CPU and GPU, which caused particles to be assigned to the wrong cell in some cases. This is not an issue when using UVM.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes