### PR TITLE
doc: remove leftover git strings

### DIFF
--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -560,7 +560,6 @@ twice in the same input script (active at the same time).
 
 <P><B>(Bird94)</B> G. A. Bird, Molecular Gas Dynamics and the Direct
 Simulation of Gas Flows, Clarendon Press, Oxford (1994).
-<<<<<<< HEAD
 </P>
 <A NAME = "Cercignani71"></A>
 

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -546,7 +546,6 @@ twice in the same input script (active at the same time).
 :link(Bird94)
 [(Bird94)] G. A. Bird, Molecular Gas Dynamics and the Direct
 Simulation of Gas Flows, Clarendon Press, Oxford (1994).
-<<<<<<< HEAD
 
 :link(Cercignani71)
 [(Cercignani71)] Cercignani C, Lampis M, Kinetic models for


### PR DESCRIPTION
## Purpose

Remove some leftover git merge conflict strings from a doc page

## Author(s)

Tim Teichmann

## Backward Compatibility

Compatible


