### PR TITLE
bug fix memory allocation in assign_types

### DIFF
--- a/src/read_isurf.cpp
+++ b/src/read_isurf.cpp
@@ -404,8 +404,8 @@ void ReadISurf::read_types_serial(char *typefile)
   int nxyz[3];
   FILE *fp;
 
-  uint8_t *buf = NULL ;//KAS changed int *buf --> uint8_t *buf
-  memory->create(buf,CHUNK,"readisurf:buf");//KAS
+  uint8_t *buf = NULL ;
+  memory->create(buf,CHUNK,"readisurf:buf");
 
   // proc 0 opens and reads binary file
   // error check the file grid matches input script extent
@@ -439,8 +439,8 @@ void ReadISurf::read_types_serial(char *typefile)
     if (ntypes-nread > CHUNK) nchunk = CHUNK;
     else nchunk = ntypes-nread;
 
-    if (me == 0) fread(buf,sizeof(uint8_t),nchunk,fp);//KAS
-    MPI_Bcast(buf,nchunk,MPI_CHAR,0,world);//KAS
+    if (me == 0) fread(buf,sizeof(uint8_t),nchunk,fp);
+    MPI_Bcast(buf,nchunk,MPI_CHAR,0,world);
 
     assign_types(nchunk,nread,buf);
     nread += nchunk;
@@ -461,7 +461,6 @@ void ReadISurf::read_types_serial(char *typefile)
 /* ----------------------------------------------------------------------
    store all grid surf type values
    use hash to see if I own grid cell corresponding to index (0 to N-1)
-   //KAS changed int *buf --> uint8_t *buf
 ------------------------------------------------------------------------- */
 
 void ReadISurf::assign_types(int n, bigint offset, uint8_t *buf)

--- a/src/read_isurf.h
+++ b/src/read_isurf.h
@@ -88,7 +88,7 @@ class ReadISurf : protected Pointers {
   void read_corners_serial(char *);
   void assign_corners(int, bigint, uint8_t *, double *);
   void read_types_serial(char *);
-  void assign_types(int, bigint, uint8_t *);//KAS changed from assign_types(int, bigint, uint8_t *)
+  void assign_types(int, bigint, uint8_t *);
 
   void read_corners_parallel(char *);
 


### PR DESCRIPTION
## Purpose

Fixed memory allocation bug in assign_types, called from ReadISurf::read_types_serial. Allows for read in of user-generated binary file specifying implicit surface type.

## Author(s)

Kelly Stephani, UIUC/CHESS

## Backward Compatibility

No break in backward compatibility

## Implementation Notes

**in ReadISurf::read_types_serial** 
bug found when allocating memory to int *buf used by assign_types(nchunk, nread, buf). changed to uint8_t *buf and propagated changes to fread, MPI_Bcast, assign_types and read_isurf.h.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links



