### PR TITLE
Add grid-style variable option to fix ablate

### DIFF
--- a/doc/fix_ablate.html
+++ b/doc/fix_ablate.html
@@ -29,6 +29,7 @@
 
 <PRE>  computeID = c_ID or c_ID[n] for a compute that calculates per grid cell values
   fixID = f_ID or f_ID[n] for a fix that calculates per grid cell values
+  v_name = per-grid vector calculated by a grid-style variable with name
   random = perform a random decrement 
 </PRE>
 <LI>maxrandom = maximum per grid cell decrement as an integer (only specified if source = random) 
@@ -86,14 +87,25 @@ a value of 0 is void (flow volume for particles).  Values in between
 represent partially ablated material.
 </P>
 <P>The <I>source</I> can be specified as a per grid cell quantity calculated
-by a compute, such as <A HREF = "compute_isurf_grid.html">compute isurf/grid</A>,
-e.g. the number of collisions of particles with the surfaces in each
-grid cell or the amount of energy transferred to the surface by the
-collisions.  It can also be specified a per grid cell quantity
-calculated by a fix, such as <A HREF = "fix_ave_grid.html">fix ave/grid</A>.  That
-fix could time average per-grid cell quantities from per grid cell
-computes.  In that case the <I>scale</I> factor should account for applying
-a time-averaged quantity at an interval of <I>N</I> steps.
+by a compute, fix, or variable.  For example, <A HREF = "compute_isurf_grid.html">compute
+isurf/grid</A> can tally the number of collisions
+of particles with the surfaces in each grid cell or the amount of
+energy transferred to the surface by the collisions.  Or <A HREF = "compute_isurf_grid.html">compute
+react/isurf/grid</A> can tally the number of
+reactions that remove a species from the surface.
+</P>
+<P>An example of a fix which be used as a <I>source</I> is <A HREF = "fix_ave_grid.html">fix
+ave/grid</A> which could use either of those per grid
+cell computes as input.  It could thus accumulate and time average the
+same quantities over many timesteps.  In that case the <I>scale</I> factor
+should account for applying a time-averaged quantity at an interval of
+<I>N</I> steps.  
+</P>
+<P>Finally, a grid-style variable can be be used as a <I>source</I>.  This
+could perform a calculation on other per grid cell quantities.  For
+example, it could add and subtract columns from the compute or fix
+just mentioned to tally adsorption versus desorption reactions and
+thus infer net mass removed from the surface.
 </P>
 <P>For debugging purposes, the <I>source</I> can also be specified as <I>random</I>
 with an additional integer <I>maxrandom</I> value also specified.  In this

--- a/doc/fix_ablate.txt
+++ b/doc/fix_ablate.txt
@@ -20,6 +20,7 @@ scale = scale factor to convert source to grid corner point value decrement :l
 source = computeID or fixID or random :l
   computeID = c_ID or c_ID\[n\] for a compute that calculates per grid cell values
   fixID = f_ID or f_ID\[n\] for a fix that calculates per grid cell values
+  v_name = per-grid vector calculated by a grid-style variable with name
   random = perform a random decrement :pre
 maxrandom = maximum per grid cell decrement as an integer (only specified if source = random) :l
 :ule
@@ -75,14 +76,25 @@ a value of 0 is void (flow volume for particles).  Values in between
 represent partially ablated material.
 
 The {source} can be specified as a per grid cell quantity calculated
-by a compute, such as "compute isurf/grid"_compute_isurf_grid.html,
-e.g. the number of collisions of particles with the surfaces in each
-grid cell or the amount of energy transferred to the surface by the
-collisions.  It can also be specified a per grid cell quantity
-calculated by a fix, such as "fix ave/grid"_fix_ave_grid.html.  That
-fix could time average per-grid cell quantities from per grid cell
-computes.  In that case the {scale} factor should account for applying
-a time-averaged quantity at an interval of {N} steps.
+by a compute, fix, or variable.  For example, "compute
+isurf/grid"_compute_isurf_grid.html can tally the number of collisions
+of particles with the surfaces in each grid cell or the amount of
+energy transferred to the surface by the collisions.  Or "compute
+react/isurf/grid"_compute_isurf_grid.html can tally the number of
+reactions that remove a species from the surface.
+
+An example of a fix which be used as a {source} is "fix
+ave/grid"_fix_ave_grid.html which could use either of those per grid
+cell computes as input.  It could thus accumulate and time average the
+same quantities over many timesteps.  In that case the {scale} factor
+should account for applying a time-averaged quantity at an interval of
+{N} steps.  
+
+Finally, a grid-style variable can be be used as a {source}.  This
+could perform a calculation on other per grid cell quantities.  For
+example, it could add and subtract columns from the compute or fix
+just mentioned to tally adsorption versus desorption reactions and
+thus infer net mass removed from the surface.
 
 For debugging purposes, the {source} can also be specified as {random}
 with an additional integer {maxrandom} value also specified.  In this

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -24,6 +24,8 @@
 #include "compute.h"
 #include "fix.h"
 #include "output.h"
+#include "input.h"
+#include "variable.h"
 #include "dump.h"
 #include "cut2d.h"     // remove if fix particles-inside-surfs issue
 #include "cut3d.h"
@@ -36,7 +38,7 @@
 
 using namespace SPARTA_NS;
 
-enum{COMPUTE,FIX,RANDOM};
+enum{COMPUTE,FIX,VARIABLE,RANDOM};
 enum{CVALUE,CDELTA};
 
 #define INVOKED_PER_GRID 16
@@ -105,6 +107,13 @@ FixAblate::FixAblate(SPARTA *sparta, int narg, char **arg) :
     strcpy(idsource,suffix);
     delete [] suffix;
 
+  } else if (strncmp(arg[5],"v_",2) == 0) {
+    which = VARIABLE;
+
+    int n = strlen(arg[5]);
+    char *idsource = new char[n];
+    strcpy(idsource,&arg[5][2]);
+
   } else if (strcmp(arg[5],"random") == 0) {
     if (narg != 7) error->all(FLERR,"Illegal fix ablate command");
     which = RANDOM;
@@ -151,6 +160,13 @@ FixAblate::FixAblate(SPARTA *sparta, int narg, char **arg) :
     if (nevery % modify->fix[ifix]->per_grid_freq)
       error->all(FLERR,
                  "Fix for fix ablate not computed at compatible time");
+
+  } else if (which == VARIABLE) {
+    ivariable = input->variable->find(idsource);
+    if (ivariable < 0) 
+      error->all(FLERR,"Could not find fix ablate variable name");
+    if (input->variable->grid_style(ivariable) == 0)
+      error->all(FLERR,"Fix ablate variable is not grid-style variable");
   }
 
   // this fix produces a per-grid array and a scalar
@@ -191,6 +207,9 @@ FixAblate::FixAblate(SPARTA *sparta, int narg, char **arg) :
 
   sbuf = NULL;
   maxbuf = 0;
+
+  vbuf = NULL;
+  maxvar = 0;
 
   ms = NULL;
   mc = NULL;
@@ -237,6 +256,7 @@ FixAblate::~FixAblate()
   memory->destroy(locallist);
 
   memory->destroy(sbuf);
+  memory->destroy(vbuf);
 
   delete ms;
   delete mc;
@@ -351,6 +371,10 @@ void FixAblate::init()
     ifix = modify->find_fix(idsource);
     if (ifix < 0)
       error->all(FLERR,"Fix ID for fix ablate does not exist");
+  } else if (which == VARIABLE) {
+    ivariable = input->variable->find(idsource);
+    if (ivariable < 0)
+      error->all(FLERR,"Variable ID for fix ablate does not exist");
   }
 
   // reallocate per-grid data if necessary
@@ -693,7 +717,7 @@ void FixAblate::set_delta_random()
 }
 
 /* ----------------------------------------------------------------------
-   set per-cell delta vector from compute/fix source
+   set per-cell delta vector from compute/fix/variable source
    celldelta = nevery * scale * source-value
    // NOTE: how does this work for split cells? should only do parent split?
 ------------------------------------------------------------------------- */
@@ -742,6 +766,17 @@ void FixAblate::set_delta()
       for (i = 0; i < nglocal; i++)
         celldelta[i] = prefactor * farray[i][im1];
     }
+
+  } else if (which == VARIABLE) {
+    if (nglocal > maxvar) {
+      maxvar = grid->maxlocal;
+      memory->destroy(vbuf);
+      memory->create(vbuf,maxvar,"ablate:vbuf");
+    }
+
+    input->variable->compute_grid(ivariable,vbuf,1,0);
+    for (i = 0; i < nglocal; i++)
+      celldelta[i] = prefactor * vbuf[i];
   }
 
   // NOTE: this does not get invoked on step 100,

--- a/src/fix_ablate.h
+++ b/src/fix_ablate.h
@@ -53,7 +53,7 @@ class FixAblate : public Fix {
 
  protected:
   int me;
-  int groupbit,which,argindex,icompute,ifix,maxrandom;
+  int groupbit,which,argindex,icompute,ifix,ivariable,maxrandom;
   double scale;
   char *idsource;
   int storeflag;
@@ -87,6 +87,9 @@ class FixAblate : public Fix {
 
   double *sbuf;
   int maxbuf;
+
+  double *vbuf;
+  int maxvar;
 
   class MarchingSquares *ms;
   class MarchingCubes *mc;


### PR DESCRIPTION
## Purpose

Fix ablate can take input to drive ablation of implicit surfaces from a compute or fix.  This adds an option to take input from a grid-style variable.  Useful for doing math on columns of a reaction tally array to calculate net mass loss from the surfaces in a grid cell.

## Author(s)

Steve

## Backward Compatibility

N/A b/c new feature.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


