### PR TITLE
Add nflux to compute_boundary and compute_surf commands

### DIFF
--- a/doc/compute_boundary.html
+++ b/doc/compute_boundary.html
@@ -25,10 +25,11 @@
 
 <LI>one or more values can be appended 
 
-<LI>value = <I>n</I> or <I>nwt</I> or <I>mflux</I> or <I>press</I> or <I>shx</I> or <I>shy</I> or <I>shz</I> or <I>ke</I> or <I>erot</I> or <I>evib</I> or <I>etot</I> 
+<LI>value = <I>n</I> or <I>nwt</I> or <I>nflux</I> or <I>mflux</I> or <I>press</I> or <I>shx</I> or <I>shy</I> or <I>shz</I> or <I>ke</I> or <I>erot</I> or <I>evib</I> or <I>etot</I> 
 
 <PRE>  n = count of particles hitting boundary
   nwt = weighted count of particles hitting boundary
+  nflux = flux of particles on boundary
   mflux = flux of mass on boundary
   press = magnitude of normal pressure on boundary
   shx,shy,shz = components of shear stress on boundary
@@ -117,15 +118,23 @@ boundary occurs.  The <I>nwt</I> quantity will only be different than <I>n</I>
 if particle weighting is enabled via the <A HREF = "global.html">global weight</A>
 command.
 </P>
+<P>The <I>nflux</I> value calculates the number flux imparted to the boundary by
+particles in the group.  This is computed as
+</P>
+<PRE>Nflux = N / (A * dt / fnum) 
+</PRE>
+<P>where N is the number of all contributing particles, normalized by
+A = the area of the surface element, dt = the timestep, and fnum = the
+real/simulated particle ratio set by the <A HREF = "global.html">global fnum</A>
+command.
+</P>
 <P>The <I>mflux</I> value calculates the mass flux imparted to the boundary by
 particles in the group.  This is computed as
 </P>
 <PRE>Mflux = Sum_i (mass_i) / (A * dt / fnum) 
 </PRE>
 <P>where the sum is over all contributing particle masses, normalized by
-A = the area of the surface element, dt = the timestep, and fnum = the
-real/simulated particle ratio set by the <A HREF = "global.html">global fnum</A>
-command.
+the area of the surface element, dt and fnum as defined before.
 </P>
 <P>The <I>press</I> value calculates the pressure <I>P</I> exerted on the boundary
 in the normal direction by particles in the group, such that outward

--- a/doc/compute_boundary.txt
+++ b/doc/compute_boundary.txt
@@ -17,9 +17,10 @@ ID is documented in "compute"_compute.html command :ulb,l
 boundary = style name of this compute command :l
 mix-ID = mixture ID to perform calculation on :l
 one or more values can be appended :l
-value = {n} or {nwt} or {mflux} or {press} or {shx} or {shy} or {shz} or {ke} or {erot} or {evib} or {etot} :l
+value = {n} or {nwt} or {nflux} or {mflux} or {press} or {shx} or {shy} or {shz} or {ke} or {erot} or {evib} or {etot} :l
   n = count of particles hitting boundary
   nwt = weighted count of particles hitting boundary
+  nflux = flux of particles on boundary
   mflux = flux of mass on boundary
   press = magnitude of normal pressure on boundary
   shx,shy,shz = components of shear stress on boundary
@@ -107,15 +108,23 @@ boundary occurs.  The {nwt} quantity will only be different than {n}
 if particle weighting is enabled via the "global weight"_global.html
 command.
 
+The {nflux} value calculates the number flux imparted to the boundary by
+particles in the group.  This is computed as
+
+Nflux = N / (A * dt / fnum) :pre
+
+where N is the number of all contributing particles, normalized by
+A = the area of the surface element, dt = the timestep, and fnum = the
+real/simulated particle ratio set by the "global fnum"_global.html
+command.
+
 The {mflux} value calculates the mass flux imparted to the boundary by
 particles in the group.  This is computed as
 
 Mflux = Sum_i (mass_i) / (A * dt / fnum) :pre
 
 where the sum is over all contributing particle masses, normalized by
-A = the area of the surface element, dt = the timestep, and fnum = the
-real/simulated particle ratio set by the "global fnum"_global.html
-command.
+the area of the surface element, dt and fnum as defined before.
 
 The {press} value calculates the pressure {P} exerted on the boundary
 in the normal direction by particles in the group, such that outward

--- a/doc/compute_surf.html
+++ b/doc/compute_surf.html
@@ -27,10 +27,11 @@
 
 <LI>one or more values can be appended 
 
-<LI>value = <I>n</I> or <I>nwt</I> or <I>mflux</I> or <I>fx</I> or <I>fy</I> or <I>fz</I> or <I>press</I> or <I>px</I> or <I>py</I> or <I>pz</I> or <I>shx</I> or <I>shy</I> or <I>shz</I> or <I>ke</I> 
+<LI>value = <I>n</I> or <I>nwt</I> or <I>nflux</I> or <I>mflux</I> or <I>fx</I> or <I>fy</I> or <I>fz</I> or <I>press</I> or <I>px</I> or <I>py</I> or <I>pz</I> or <I>shx</I> or <I>shy</I> or <I>shz</I> or <I>ke</I> 
 
 <PRE>  n = count of particles hitting surface element
   nwt = weighted count of particles hitting surface element
+  nflux = flux of particles on surface element
   mflux = flux of mass on surface element
   fx,fy,fz = components of force on surface element
   press = magnitude of normal pressure on surface element
@@ -142,15 +143,23 @@ occurs.  The <I>nwt</I> quantity will only be different than <I>n</I> if
 particle weighting is enabled via the <A HREF = "global.html">global weight</A>
 command.
 </P>
+<P>The <I>nflux</I> value calculates the number flux imparted to the surface
+element by particles in the group.  This is computed as
+</P>
+<PRE>Nflux = N / (A * dt / fnum) 
+</PRE>
+<P>where N is the number of all contributing particles, normalized by
+A = the area of the surface element, dt = the timestep, and fnum = the
+real/simulated particle ratio set by the <A HREF = "global.html">global fnum</A>
+command.
+</P>
 <P>The <I>mflux</I> value calculates the mass flux imparted to the surface
 element by particles in the group.  This is computed as
 </P>
 <PRE>Mflux = Sum_i (mass_i) / (A * dt / fnum) 
 </PRE>
 <P>where the sum is over all contributing particle masses, normalized by
-A = the area of the surface element, dt = the timestep, and fnum = the
-real/simulated particle ratio set by the <A HREF = "global.html">global fnum</A>
-command.
+the area of the surface element, dt and fnum as defined before.
 </P>
 <P>The <I>fx</I>, <I>fy</I>, <I>fz</I> values calculate the components of force extered
 on the surface element by particles in the group, with respect to the

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -18,9 +18,10 @@ surf = style name of this compute command :l
 group-ID = group ID for which surface elements to perform calculation on :l
 mix-ID = mixture ID for particles to perform calculation on :l
 one or more values can be appended :l
-value = {n} or {nwt} or {mflux} or {fx} or {fy} or {fz} or {press} or {px} or {py} or {pz} or {shx} or {shy} or {shz} or {ke} :l
+value = {n} or {nwt} or {nflux} or {mflux} or {fx} or {fy} or {fz} or {press} or {px} or {py} or {pz} or {shx} or {shy} or {shz} or {ke} :l
   n = count of particles hitting surface element
   nwt = weighted count of particles hitting surface element
+  nflux = flux of particles on surface element
   mflux = flux of mass on surface element
   fx,fy,fz = components of force on surface element
   press = magnitude of normal pressure on surface element
@@ -131,15 +132,23 @@ occurs.  The {nwt} quantity will only be different than {n} if
 particle weighting is enabled via the "global weight"_global.html
 command.
 
+The {nflux} value calculates the number flux imparted to the surface
+element by particles in the group.  This is computed as
+
+Nflux = N / (A * dt / fnum) :pre
+
+where N is the number of all contributing particles, normalized by
+A = the area of the surface element, dt = the timestep, and fnum = the
+real/simulated particle ratio set by the "global fnum"_global.html
+command.
+
 The {mflux} value calculates the mass flux imparted to the surface
 element by particles in the group.  This is computed as
 
 Mflux = Sum_i (mass_i) / (A * dt / fnum) :pre
 
 where the sum is over all contributing particle masses, normalized by
-A = the area of the surface element, dt = the timestep, and fnum = the
-real/simulated particle ratio set by the "global fnum"_global.html
-command.
+the area of the surface element, dt and fnum as defined before.
 
 The {fx}, {fy}, {fz} values calculate the components of force extered
 on the surface element by particles in the group, with respect to the

--- a/src/compute_boundary.cpp
+++ b/src/compute_boundary.cpp
@@ -29,7 +29,7 @@ using namespace SPARTA_NS;
 
 enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
 enum{PERIODIC,OUTFLOW,REFLECT,SURFACE,AXISYM};  // same as Domain
-enum{NUM,NUMWT,MFLUX,PRESS,XSHEAR,YSHEAR,ZSHEAR,KE,EROT,EVIB,ETOT};
+enum{NUM,NUMWT,NFLUX,MFLUX,PRESS,XSHEAR,YSHEAR,ZSHEAR,KE,EROT,EVIB,ETOT};
 
 /* ---------------------------------------------------------------------- */
 
@@ -49,6 +49,7 @@ ComputeBoundary::ComputeBoundary(SPARTA *sparta, int narg, char **arg) :
   while (iarg < narg) {
     if (strcmp(arg[iarg],"n") == 0) which[nvalue++] = NUM;
     else if (strcmp(arg[iarg],"nwt") == 0) which[nvalue++] = NUMWT;
+    else if (strcmp(arg[iarg],"nflux") == 0) which[nvalue++] = NFLUX;
     else if (strcmp(arg[iarg],"mflux") == 0) which[nvalue++] = MFLUX;
     else if (strcmp(arg[iarg],"press") == 0) which[nvalue++] = PRESS;
     else if (strcmp(arg[iarg],"shx") == 0) which[nvalue++] = XSHEAR;
@@ -214,6 +215,9 @@ void ComputeBoundary::boundary_tally(int iface, int istyle, int reaction,
       case NUMWT:
         vec[k++] += weight;
         break;
+      case NFLUX:
+        vec[k++] += weight;
+        break;
       case MFLUX:
         vec[k++] += origmass;
         break;
@@ -274,6 +278,12 @@ void ComputeBoundary::boundary_tally(int iface, int istyle, int reaction,
         break;
       case NUMWT:
         vec[k++] += weight;
+        break;
+      case NFLUX:
+        vec[k] += weight;
+        if (ip) vec[k] -= weight;
+        if (jp) vec[k] -= weight;
+        k++;
         break;
       case MFLUX:
         vec[k] += origmass;

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -27,7 +27,7 @@
 
 using namespace SPARTA_NS;
 
-enum{NUM,NUMWT,MFLUX,FX,FY,FZ,PRESS,XPRESS,YPRESS,ZPRESS,
+enum{NUM,NUMWT,NFLUX,MFLUX,FX,FY,FZ,PRESS,XPRESS,YPRESS,ZPRESS,
      XSHEAR,YSHEAR,ZSHEAR,KE,EROT,EVIB,ETOT};
 
 #define DELTA 4096
@@ -55,6 +55,7 @@ ComputeSurf::ComputeSurf(SPARTA *sparta, int narg, char **arg) :
   while (iarg < narg) {
     if (strcmp(arg[iarg],"n") == 0) which[nvalue++] = NUM;
     else if (strcmp(arg[iarg],"nwt") == 0) which[nvalue++] = NUMWT;
+    else if (strcmp(arg[iarg],"nflux") == 0) which[nvalue++] = NFLUX;
     else if (strcmp(arg[iarg],"mflux") == 0) which[nvalue++] = MFLUX;
     else if (strcmp(arg[iarg],"fx") == 0) which[nvalue++] = FX;
     else if (strcmp(arg[iarg],"fy") == 0) which[nvalue++] = FY;
@@ -296,6 +297,14 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
       break;
     case NUMWT:
       vec[k++] += weight;
+      break;
+    case NFLUX:
+      vec[k] += weight * fluxscale;
+      if (!transparent) {
+        if (ip) vec[k] -= weight * fluxscale;
+        if (jp) vec[k] -= weight * fluxscale;
+      }
+      k++;
       break;
     case MFLUX:
       vec[k] += origmass * fluxscale;


### PR DESCRIPTION
## Purpose

This adds the output option `nflux` to the `compute_boundary` and `compute_surf` commands. This is comparable with the already present `mflux` option but for number fluxes.

## Author(s)

Tim Teichmann (ITEP, KIT)

## Backward Compatibility

optional new output, therefore 100% compatible

## Implementation Notes

Should be trivial to understand.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links


