### PR TITLE
Enable reaction tallying in computes for on-surface reactions

### DIFF
--- a/src/surf_react_adsorb.h
+++ b/src/surf_react_adsorb.h
@@ -206,6 +206,12 @@ class SurfReactAdsorb : public SurfReact {
 
   class SurfCollide **cmodels;
 
+  // pointers to Compute instances which tally reactions on per-surf basis
+  // extracted from Update class
+
+  int ncompute_tally;
+  class Compute **clist_active;
+
   // GS methods
 
   void init_reactions_gs();

--- a/src/update.h
+++ b/src/update.h
@@ -81,6 +81,15 @@ class Update : protected Pointers {
 
   double rcblo[3],rcbhi[3];    // debug info from RCB for dump image
 
+  // this info accessed by SurfReactAdsorb to do on-surface reaction tallying
+
+  int nsurf_tally;         // # of Cmp tallying surf bounce info this step
+  int nboundary_tally;     // # of Cmp tallying boundary bounce info this step
+  class Compute **slist_active;   // list of active surf Computes this step
+  class Compute **blist_active;   // list of active boundary Computes this step
+
+  // public methods
+
   Update(class SPARTA *);
   ~Update();
   void set_units(const char *);
@@ -108,11 +117,6 @@ class Update : protected Pointers {
   int nblist_compute;             // # of computes that tally boundary bounces
   class Compute **slist_compute;  // list of all surf bounce Computes
   class Compute **blist_compute;  // list of all boundary bounce Computes
-
-  int nsurf_tally;         // # of Cmp tallying surf bounce info this step
-  int nboundary_tally;     // # of Cmp tallying boundary bounce info this step
-  class Compute **slist_active;   // list of active surf Computes this step
-  class Compute **blist_active;   // list of active boundary Computes this step
 
   int surf_pre_tally;       // 1 to log particle stats before surf collide
   int boundary_pre_tally;   // 1 to log particle stats before boundary collide


### PR DESCRIPTION
## Purpose

For the new surf react/adsorb model, which includes on-surface reactions in addition to gas/surface reactions, tallying of the on-surface reactions were not being done by compute surf/react.  This PR enables that.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


