### PR TITLE
Exodus output for surf2paraview

### DIFF
--- a/tools/paraview/README
+++ b/tools/paraview/README
@@ -90,6 +90,15 @@ Delaunay 2D filter from the ParaView menu.
 This will triangulate the interior of the polygon and obscure interior
 grid cells from view.
 
+The -e (or --exodus) option will output the contents of the *.pvd and
+output directory in Exodus 2 output format as a single file:
+
+% pvpython surf2paraview.py data.mir mir_surf -r ../parent/mir/tmp_surf.* --exodus
+
+This will produce an Exodus 2 file mir_surf.ex2, containing the same content
+as mir_surf.pvd and mir_surf/. The .pvd format output is not written when
+Exodus 2 output is requested.
+
 -------------------------------
 
 III. USING grid2paraview.py

--- a/tools/paraview/runIntegrationTests.sh
+++ b/tools/paraview/runIntegrationTests.sh
@@ -88,6 +88,16 @@ test_circle() {
     echo ""
     echo "$CURRENT_TEST test passed"
 
+    CURRENT_TEST="surf2paraview circle exodus"
+    echo ""
+    echo "Running surf2paraview"
+    $PARAVIEW_PVPYTHON $SURF2PARAVIEW data.circle circle_surf -r tmp_surf.* --exodus
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "circle_surf.ex2" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
     CURRENT_TEST="grid2paraview pvpython circle"
     echo ""
     echo "Checking $CURRENT_TEST output"
@@ -243,6 +253,16 @@ test_sphere() {
     check_file "sphere_surf/sphere_surf_800.vtu" 
     check_file "sphere_surf/sphere_surf_900.vtu" 
     check_file "sphere_surf/sphere_surf_1000.vtu" 
+    echo ""
+    echo "$CURRENT_TEST test passed"
+
+    CURRENT_TEST="surf2paraview sphere exodus"
+    echo ""
+    echo "Running surf2paraview"
+    $PARAVIEW_PVPYTHON $SURF2PARAVIEW data.sphere sphere_surf -r tmp_surf.* --exodus
+    echo ""
+    echo "Checking $CURRENT_TEST output"
+    check_file "sphere_surf.ex2"
     echo ""
     echo "$CURRENT_TEST test passed"
 

--- a/tools/paraview/surf2paraview.py
+++ b/tools/paraview/surf2paraview.py
@@ -17,6 +17,33 @@ import sys
 import os
 import vtk
 import glob
+from vtk.util.vtkAlgorithm import VTKPythonAlgorithmBase
+
+class UGridSource(VTKPythonAlgorithmBase):
+  def __init__(self, ug, time_steps_dict):
+    VTKPythonAlgorithmBase.__init__(self,
+      nInputPorts=0, nOutputPorts=1, outputType='vtkUnstructuredGrid')
+    self.__ug = ug
+    self.__time_steps_dict = time_steps_dict
+
+  def RequestInformation(self, request, inInfo, outInfo):
+    info = outInfo.GetInformationObject(0)
+    tsteps = sorted(self.__time_steps_dict.keys())
+    if tsteps:
+      info.Set(vtk.vtkStreamingDemandDrivenPipeline.TIME_STEPS(),
+        tsteps, len(tsteps))
+      info.Set(vtk.vtkStreamingDemandDrivenPipeline.TIME_RANGE(),
+        [tsteps[0], tsteps[-1]], 2)
+    return 1
+
+  def RequestData(self, request, inInfo, outInfo):
+    info = outInfo.GetInformationObject(0)
+    output = vtk.vtkUnstructuredGrid.GetData(outInfo)
+    tstep = info.Get(vtk.vtkStreamingDemandDrivenPipeline.UPDATE_TIME_STEP())
+    if tstep in self.__time_steps_dict:
+      read_time_step_data(self.__time_steps_dict[tstep], self.__ug)
+    output.ShallowCopy(self.__ug)
+    return 1
 
 def clean_line(line):
   line = line.partition('#')[0]
@@ -249,6 +276,8 @@ if __name__ == "__main__":
   group = parser.add_mutually_exclusive_group()
   group.add_argument('-r', '--result', help="Optional list of SPARTA dump result files", nargs='+')
   group.add_argument('-rf', '--resultfile', help="Optional filename containing path names of SPARTA dump result files")
+  parser.add_argument('-e', '--exodus', default=False, action='store_true',
+    help="Write output to Exodus II format file")
   args = parser.parse_args()
 
   try:
@@ -257,11 +286,11 @@ if __name__ == "__main__":
     print("Unable to open SPARTA surf input file: ", args.sparta_surf_file)
     sys.exit(1)
 
-  if os.path.isfile(args.paraview_output_file + '.pvd'):
+  if os.path.isfile(args.paraview_output_file + '.pvd') and not args.exodus:
     print("ParaView output file exists: ", args.paraview_output_file + '.pvd')
     sys.exit(1)
 
-  if os.path.isdir(args.paraview_output_file):
+  if os.path.isdir(args.paraview_output_file) and not args.exodus:
     print("ParaView output directory exists: ", args.paraview_output_file)
     sys.exit(1)
 
@@ -291,17 +320,21 @@ if __name__ == "__main__":
 
   read_time_steps(time_steps_file_list, time_steps_dict)
 
-  os.mkdir(args.paraview_output_file)
-
-  writer = vtk.vtkXMLUnstructuredGridWriter()
-  writer.SetInputData(ug)
-  for time in sorted(time_steps_dict.keys()):
-    print("Processing dump result file: ", time_steps_dict[time])
-    read_time_step_data(time_steps_dict[time], ug)
-    filepath = os.path.join(args.paraview_output_file, args.paraview_output_file + '_' + str(time) + '.vtu')
-    writer.SetFileName(filepath)
+  if args.exodus:
+    writer = vtk.vtkExodusIIWriter()
+    writer.WriteAllTimeStepsOn()
+    writer.SetFileName(args.paraview_output_file + ".ex2")
+    ugs = UGridSource(ug, time_steps_dict)
+    writer.SetInputConnection(ugs.GetOutputPort())
     writer.Write()
-
-  write_pvd_file(sorted(time_steps_dict.keys()), args.paraview_output_file)
-
-  print("Done.")
+  else:
+    os.mkdir(args.paraview_output_file)
+    writer = vtk.vtkXMLUnstructuredGridWriter()
+    writer.SetInputData(ug)
+    for time in sorted(time_steps_dict.keys()):
+      print("Processing dump result file: ", time_steps_dict[time])
+      read_time_step_data(time_steps_dict[time], ug)
+      filepath = os.path.join(args.paraview_output_file, args.paraview_output_file + '_' + str(time) + '.vtu')
+      writer.SetFileName(filepath)
+      writer.Write()
+    write_pvd_file(sorted(time_steps_dict.keys()), args.paraview_output_file)


### PR DESCRIPTION
Added Exodus 2 format output to the surf2paraview.py
program via the -e or --exodus command line option.

Updated README and integration tests script.

## Purpose

_Briefly describe the new feature(s), enhancement(s), or bugfix(es) included in this pull request. If this addresses an open GitHub Issue, mention the issue number, e.g. with `fixes #221` or `closes #135`, so that issue will be automatically closed when the pull request is merged_

## Author(s)

_Please state name and affiliation of the author or authors that should be credited with the changes in this pull request_

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


