### PR TITLE
Compute reduce group

### DIFF
--- a/doc/compute_reduce.html
+++ b/doc/compute_reduce.html
@@ -35,18 +35,20 @@
 </PRE>
 <LI>zero or more keyword/args pairs may be appended 
 
-<LI>keyword = <I>replace</I> 
+<LI>keyword = <I>replace</I> or <I>subset</I> 
 
 <PRE>  <I>replace</I> args = vec1 vec2
     vec1 = reduced value from this input vector will be replaced
-    vec2 = replace it with vec1[N] where N is index of max/min value from vec2 
+    vec2 = replace it with vec1[N] where N is index of max/min value from vec2
+  <I>subset</I> arg = subsetID
+    subsetID = mixture-ID or grid group-ID or surface group-ID 
 </PRE>
 
 </UL>
 <P><B>Examples:</B>
 </P>
 <PRE>compute 1 reduce sum c_grid[*]
-compute 2 reduce min f_ave v_myKE
+compute 2 reduce min f_ave v_myKE subset trace_species
 compute 3 reduce max c_mine[1] c_mine[2] c_temp replace 1 3 replace 2 3 
 </PRE>
 <P>These commands will include the average grid cell temperature, across
@@ -71,22 +73,27 @@ generate per-particle or per-grid quantities.  See the
 perform the same operations as the compute reduce command on global
 vectors.
 </P>
+<P>IMPORTANT NOTE: All inputs to a compute reduce command must be the
+same type: per-particle, per-grid, or per-surf.  You can use the
+command multiple times if you need to reduce values of different
+types.
+</P>
 <P>The reduction operation is specified by the <I>mode</I> setting.  The <I>sum</I>
 option adds the values in the vector into a global total.  The <I>min</I>
-or <I>max</I> options find the minimum or maximum value across all vector
-values.  The <I>ave</I> setting adds the vector values into a global total,
-then divides by the number of values in the vector.  The <I>sumsq</I>
-option sums the square of the values in the vector into a global
-total.  The <I>avesq</I> setting does the same as <I>sumsq</I>, then divdes the
-sum of squares by the number of values.  The last two options can be
-useful for calculating the variance of some quantity, e.g. variance =
-sumsq - ave^2.
+or <I>max</I> operations find the minimum or maximum value across all
+vector values.  The <I>ave</I> operation adds the vector values into a
+global total, then divides by the number of values in the vector.  The
+<I>sumsq</I> operation sums the square of the values in the vector into a
+global total.  The <I>avesq</I> oepration does the same as <I>sumsq</I>, then
+divdes the sum of squares by the number of values.  The last two
+operations can be useful for calculating the variance of some
+quantity, e.g. variance = sumsq - ave^2.
 </P>
-<P>Each listed input is operated on independently.
+<P>Each listed input vector is operated on independently.
 </P>
-<P>Each listed input can be a particle attribute or can be the result of
-a <A HREF = "compute.html">compute</A> or <A HREF = "fix.html">fix</A> or the evaluation of a
-<A HREF = "variable.html">variable</A>.
+<P>Each listed input vector can be a particle attribute or can be the
+result of a <A HREF = "compute.html">compute</A> or <A HREF = "fix.html">fix</A> or the evaluation
+of a <A HREF = "variable.html">variable</A>.
 </P>
 <P>Note that for values from a compute or fix, the bracketed index I can
 be specified using a wildcard asterisk with the index to effectively
@@ -180,6 +187,36 @@ the max of the ID vector, which does not yield useful information in
 this context, the <I>replace</I> keyword will extract the ID for the grid
 cell which has the maximum number of particles.  This ID and the
 cell's particle count will be printed with the statistical output.
+</P>
+<HR>
+
+<P>The <I>subset</I> keyword allows selection of a subset of each input
+vectors quantities to be used for the reduce operation.  This may
+affect all of the reduction operations.  E.g. the ave and avesq
+operations will become averages for only a subset of numerical values.
+</P>
+<P>If inputs are per-particle values, then a mixture ID should be
+specified.  Only particle species belonging to the mixture will be
+included in the calculations.  See the <A HREF = "mixture.html">mixture</A> command
+for how a set of species is included in a mixture.
+</P>
+<P>If inputs are per-grid values, then a grid group ID should be
+specified.  Only grid cells in the grid group will be included in the
+calculations.  See the <A HREF = "group.html">group grid</A> command for info on how
+grid cells can be assigned to grid groups.
+</P>
+<P>If inputs are per-surface values, then a surface group ID should be
+specified.  Only surface elements in the surface group will be
+included in the calculations.  See the <A HREF = "group.html">group surf</A> command
+for info on how surface elements can be assigned to surface groups.
+</P>
+<P>IMPORTANT NOTE: If computes or fixes are used as inputs to compute
+reduce, they may define their own subsets of particles, grid cells, or
+suface elements which contribute to their output.  E.g. grid cells not
+in the grid group used by the <A HREF = "compute_grid.html">compute grid</A> command
+have zero values as output.  You typically should use an argument for
+the <I>subset</I> keyword which is consistent with the inputs, but that is
+not required.
 </P>
 <HR>
 

--- a/doc/compute_reduce.html
+++ b/doc/compute_reduce.html
@@ -212,7 +212,7 @@ for info on how surface elements can be assigned to surface groups.
 </P>
 <P>IMPORTANT NOTE: If computes or fixes are used as inputs to compute
 reduce, they may define their own subsets of particles, grid cells, or
-suface elements which contribute to their output.  E.g. grid cells not
+surface elements which contribute to their output.  E.g. grid cells not
 in the grid group used by the <A HREF = "compute_grid.html">compute grid</A> command
 have zero values as output.  You typically should use an argument for
 the <I>subset</I> keyword which is consistent with the inputs, but that is

--- a/doc/compute_reduce.txt
+++ b/doc/compute_reduce.txt
@@ -201,7 +201,7 @@ for info on how surface elements can be assigned to surface groups.
 
 IMPORTANT NOTE: If computes or fixes are used as inputs to compute
 reduce, they may define their own subsets of particles, grid cells, or
-suface elements which contribute to their output.  E.g. grid cells not
+surface elements which contribute to their output.  E.g. grid cells not
 in the grid group used by the "compute grid"_compute_grid.html command
 have zero values as output.  You typically should use an argument for
 the {subset} keyword which is consistent with the inputs, but that is

--- a/doc/compute_reduce.txt
+++ b/doc/compute_reduce.txt
@@ -26,16 +26,18 @@ input = x, y, z, vx, vy, vz, ke, erot, evib, c_ID, c_ID\[N\], f_ID, f_ID\[N\], v
   v_name = per-particle or per-grid vector calculated by a particle-style or grid-style variable with name :pre
 
 zero or more keyword/args pairs may be appended :l
-keyword = {replace} :l
+keyword = {replace} or {subset} :l
   {replace} args = vec1 vec2
     vec1 = reduced value from this input vector will be replaced
-    vec2 = replace it with vec1\[N\] where N is index of max/min value from vec2 :pre
+    vec2 = replace it with vec1\[N\] where N is index of max/min value from vec2
+  {subset} arg = subsetID
+    subsetID = mixture-ID or grid group-ID or surface group-ID :pre
 :ule
 
 [Examples:]
 
 compute 1 reduce sum c_grid\[*\]
-compute 2 reduce min f_ave v_myKE
+compute 2 reduce min f_ave v_myKE subset trace_species
 compute 3 reduce max c_mine\[1\] c_mine\[2\] c_temp replace 1 3 replace 2 3 :pre
 
 These commands will include the average grid cell temperature, across
@@ -60,22 +62,27 @@ generate per-particle or per-grid quantities.  See the
 perform the same operations as the compute reduce command on global
 vectors.
 
+IMPORTANT NOTE: All inputs to a compute reduce command must be the
+same type: per-particle, per-grid, or per-surf.  You can use the
+command multiple times if you need to reduce values of different
+types.
+
 The reduction operation is specified by the {mode} setting.  The {sum}
 option adds the values in the vector into a global total.  The {min}
-or {max} options find the minimum or maximum value across all vector
-values.  The {ave} setting adds the vector values into a global total,
-then divides by the number of values in the vector.  The {sumsq}
-option sums the square of the values in the vector into a global
-total.  The {avesq} setting does the same as {sumsq}, then divdes the
-sum of squares by the number of values.  The last two options can be
-useful for calculating the variance of some quantity, e.g. variance =
-sumsq - ave^2.
+or {max} operations find the minimum or maximum value across all
+vector values.  The {ave} operation adds the vector values into a
+global total, then divides by the number of values in the vector.  The
+{sumsq} operation sums the square of the values in the vector into a
+global total.  The {avesq} oepration does the same as {sumsq}, then
+divdes the sum of squares by the number of values.  The last two
+operations can be useful for calculating the variance of some
+quantity, e.g. variance = sumsq - ave^2.
 
-Each listed input is operated on independently.
+Each listed input vector is operated on independently.
 
-Each listed input can be a particle attribute or can be the result of
-a "compute"_compute.html or "fix"_fix.html or the evaluation of a
-"variable"_variable.html.
+Each listed input vector can be a particle attribute or can be the
+result of a "compute"_compute.html or "fix"_fix.html or the evaluation
+of a "variable"_variable.html.
 
 Note that for values from a compute or fix, the bracketed index I can
 be specified using a wildcard asterisk with the index to effectively
@@ -169,6 +176,36 @@ the max of the ID vector, which does not yield useful information in
 this context, the {replace} keyword will extract the ID for the grid
 cell which has the maximum number of particles.  This ID and the
 cell's particle count will be printed with the statistical output.
+
+:line
+
+The {subset} keyword allows selection of a subset of each input
+vectors quantities to be used for the reduce operation.  This may
+affect all of the reduction operations.  E.g. the ave and avesq
+operations will become averages for only a subset of numerical values.
+
+If inputs are per-particle values, then a mixture ID should be
+specified.  Only particle species belonging to the mixture will be
+included in the calculations.  See the "mixture"_mixture.html command
+for how a set of species is included in a mixture.
+
+If inputs are per-grid values, then a grid group ID should be
+specified.  Only grid cells in the grid group will be included in the
+calculations.  See the "group grid"_group.html command for info on how
+grid cells can be assigned to grid groups.
+
+If inputs are per-surface values, then a surface group ID should be
+specified.  Only surface elements in the surface group will be
+included in the calculations.  See the "group surf"_group.html command
+for info on how surface elements can be assigned to surface groups.
+
+IMPORTANT NOTE: If computes or fixes are used as inputs to compute
+reduce, they may define their own subsets of particles, grid cells, or
+suface elements which contribute to their output.  E.g. grid cells not
+in the grid group used by the "compute grid"_compute_grid.html command
+have zero values as output.  You typically should use an argument for
+the {subset} keyword which is consistent with the inputs, but that is
+not required.
 
 :line
 

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -28,9 +28,6 @@
 #include "memory.h"
 #include "error.h"
 
-// DEBUG
-#include "comm.h"
-
 using namespace SPARTA_NS;
 
 enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};

--- a/src/compute_reduce.h
+++ b/src/compute_reduce.h
@@ -35,14 +35,18 @@ class ComputeReduce : public Compute {
   bigint memory_usage();
 
  protected:
-  int me;
+  int me,nprocs;
   int mode,nvalues,iregion;
   int *which,*argindex,*flavor,*value2index;
   char **ids;
   double *onevec;
   int *replace,*indices,*owner;
   int index;
-  char *idregion;
+
+  char *subsetID;
+  int isubset;
+  int *s2g;
+  int gridgroupbit,surfgroupbit;
 
   int maxparticle,maxgrid;
   double *varparticle,*vargrid;
@@ -54,7 +58,7 @@ class ComputeReduce : public Compute {
   Pair pairme,pairall;
 
   double compute_one(int, int);
-  bigint count(int);
+  bigint count_included();
   void combine(double &, double, int);
 };
 


### PR DESCRIPTION
## Purpose

Add a subset keyword option to the compute reduce command to allow the reduction operations to only be done
for a subset of particles, grid cells, or surface elements.  See Backward Compatibility note for one additional change in compute reduce.

## Author(s)

Steve

## Backward Compatibility

Behavior with no subset options should be same as before.  However the new version of compute reduce now requires
all its arguments be of the same "type", e.g. per-particle, per-grid, or per-surf quantities.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


