### PR TITLE
Allow particle species rotational DOF = 3

### DIFF
--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -177,7 +177,7 @@ void Collide::init()
     }
     if (flag) {
       char str[128];
-      sprintf(str,"%d species do not define corrent rotational "
+      sprintf(str,"%d species do not define correct rotational "
               "temps for discrete model",flag);
       error->all(FLERR,str);
     }

--- a/src/collide_vss.cpp
+++ b/src/collide_vss.cpp
@@ -786,9 +786,11 @@ double CollideVSS::rotrel(int isp, double Ec)
   // Because we are only relaxing one of the particles in each call, we only
   //  include its DoF, consistent with Bird 2013 (3.32)
 
-  double Tr = Ec /(update->boltz * (2.5-params[isp][isp].omega + particle->species[isp].rotdof/2.0));
-  double rotphi = (1.0+params[isp][isp].rotc2/sqrt(Tr) + params[isp][isp].rotc3/Tr)
-                / params[isp][isp].rotc1;
+  double Tr = Ec /(update->boltz * 
+                   (2.5-params[isp][isp].omega + 
+                    particle->species[isp].rotdof/2.0));
+  double rotphi = (1.0+params[isp][isp].rotc2/sqrt(Tr) + 
+                   params[isp][isp].rotc3/Tr) / params[isp][isp].rotc1;
   return rotphi;
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1131,12 +1131,9 @@ void Particle::read_species_file()
     else fsp->internaldof = 0;
 
     // error checks
-    // NOTE: allow rotdof = 3 when implement rotate = DISCRETE
 
-    if (fsp->rotdof != 0 && fsp->rotdof != 2)
+    if (fsp->rotdof != 0 && fsp->rotdof != 2 && fsp->rotdof != 3)
       error->all(FLERR,"Invalid rotational DOF in species file");
-    //if (fsp->rotdof != 0 && fsp->rotdof != 2 && fsp->rotdof != 3)
-    //  error->all(FLERR,"Invalid rotational DOF in species file");
 
     if (fsp->vibdof < 0 || fsp->vibdof > 8 || fsp->vibdof % 2)
       error->all(FLERR,"Invalid vibrational DOF in species file");


### PR DESCRIPTION
## Purpose

Allow continuous rotational DOFs = 3 for complex molecular species.  Previously this was flagged as an error, awaiting a discrete rotational DOF model.  But the rest of the code appears to be fine for DOF = 3 in the continuous case.

## Author(s)

Steve

## Backward Compatibility

Should now allow models with molecular species with 3 rotational DOF to run.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


