### PR TITLE
Fix Kokkos memory bug when tvib modeflag=0

### DIFF
--- a/src/KOKKOS/compute_tvib_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_tvib_grid_kokkos.cpp
@@ -45,8 +45,9 @@ ComputeTvibGridKokkos::ComputeTvibGridKokkos(SPARTA *sparta, int narg, char **ar
   kokkos_flag = 1;
 
   if (modeflag == 0) {
-    k_s2t = DAT::tdual_int_1d("compute/tvib/grid:s2t",nspecies);
     k_t2s = DAT::tdual_int_1d("compute/tvib/grid:t2s",ntally);
+    k_s2t = DAT::tdual_int_1d("compute/tvib/grid:s2t",nspecies);
+    d_tspecies = DAT::t_float_1d("d_tspecies",nspecies);
 
     for (int n = 0; n < nspecies; n++)
       k_s2t.h_view(n) = s2t[n];
@@ -65,6 +66,7 @@ ComputeTvibGridKokkos::ComputeTvibGridKokkos(SPARTA *sparta, int narg, char **ar
   } else {
     k_t2s_mode = DAT::tdual_int_1d("compute/tvib/grid:t2s_mode",ntally);
     k_s2t_mode = DAT::tdual_int_2d("compute/tvib/grids2t_mode",nspecies,maxmode);
+    d_tspecies_mode = DAT::t_float_2d_lr("d_tspecies_mode",nspecies,maxmode);
 
     for (int n = 0; n < nspecies; n++)
       for (int m = 0; m < maxmode; m++)
@@ -82,9 +84,6 @@ ComputeTvibGridKokkos::ComputeTvibGridKokkos(SPARTA *sparta, int narg, char **ar
     d_s2t_mode = k_s2t_mode.d_view;
     d_t2s_mode = k_t2s_mode.d_view;
   }
-
-  d_tspecies = DAT::t_float_1d("d_tspecies",nspecies);
-  d_tspecies_mode = DAT::t_float_2d_lr("d_tspecies_mode",nspecies,maxmode);
 
   boltz = update->boltz;
 }

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -171,7 +171,7 @@ SurfCollideDiffuseKokkos::~SurfCollideDiffuseKokkos()
 void SurfCollideDiffuseKokkos::pre_collide()
 {
   if (modify->n_update_custom)
-    error->all(FLERR,"Cannot yet use surf_collide diffuse/kk"
+    error->all(FLERR,"Cannot yet use surf_collide diffuse/kk "
                "with fix vibmode or fix ambipolar");
 
   if (random == NULL) {


### PR DESCRIPTION
## Purpose

Fix Kokkos memory bug when `compute tvib` `modeflag=0`. The `maxmode` variable is uninitialized when `modeflag=0`, leading to the code using a bogus value here: https://github.com/sparta/sparta/blob/master/src/KOKKOS/compute_tvib_grid_kokkos.cpp#L87. This PR fixes the issue with an `if` test.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes