### PR TITLE
More vibmodes

### DIFF
--- a/doc/species.html
+++ b/doc/species.html
@@ -115,6 +115,13 @@ species with a vibdof = 4,6,8.  Note that the <A HREF = "fix_vibmode.html">fix
 vibmode</A> command must also be used to allocate
 per-particle storage for these additional modes.
 </P>
+<P>NOTE: By default the maximum allowed number of vibrational modes is 4
+(dof = 8). If you have a model with species which need more, you can
+change the settings at the top of src/particle.h in the enum command
+for MAXVIBMODE=4 to a larger value and re-compile the code.  The
+format of the <I>vibfile</I>, as described next, is then enhanced
+accordingly.
+</P>
 <HR>
 
 <P>The optional <I>vibfile</I> keyword can be used to specify additional

--- a/doc/species.txt
+++ b/doc/species.txt
@@ -106,6 +106,13 @@ species with a vibdof = 4,6,8.  Note that the "fix
 vibmode"_fix_vibmode.html command must also be used to allocate
 per-particle storage for these additional modes.
 
+NOTE: By default the maximum allowed number of vibrational modes is 4
+(dof = 8). If you have a model with species which need more, you can
+change the settings at the top of src/particle.h in the enum command
+for MAXVIBMODE=4 to a larger value and re-compile the code.  The
+format of the {vibfile}, as described next, is then enhanced
+accordingly.
+
 :line
 
 The optional {vibfile} keyword can be used to specify additional

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -178,7 +178,7 @@ void Particle::init()
   }
 
   // if vibstyle = DISCRETE,
-  // all species with vibdof = 4,6,8 must have info read from a species.vib file
+  // all species with vibdof > 2 must have info read from a species.vib file
 
   if (collide && collide->vibstyle == DISCRETE) {
     for (int isp = 0; isp < nspecies; isp++) {
@@ -1135,10 +1135,8 @@ void Particle::read_species_file()
 
     if (fsp->rotdof != 0 && fsp->rotdof != 2)
       error->all(FLERR,"Invalid rotational DOF in species file");
-    //if (fsp->rotdof != 0 && fsp->rotdof != 2 && fsp->rotdof != 3)
-    //  error->all(FLERR,"Invalid rotational DOF in species file");
 
-    if (fsp->vibdof < 0 || fsp->vibdof > 8 || fsp->vibdof % 2)
+    if (fsp->vibdof < 0 || fsp->vibdof > 2*MAXVIBMODE || fsp->vibdof % 2)
       error->all(FLERR,"Invalid vibrational DOF in species file");
 
     // initialize additional rotation/vibration fields
@@ -1148,10 +1146,13 @@ void Particle::read_species_file()
     fsp->nvibmode = fsp->vibdof / 2;
 
     fsp->rottemp[0] = fsp->rottemp[1] = fsp->rottemp[2] = 0.0;
-    fsp->vibtemp[1] = fsp->vibtemp[2] = fsp->vibtemp[3] = 0.0;
-    fsp->vibrel[1] = fsp->vibrel[2] = fsp->vibrel[3] = 0.0;
-    fsp->vibdegen[0] = fsp->vibdegen[1] =
-      fsp->vibdegen[2] = fsp->vibdegen[3] = 0;
+
+    fsp->vibdegen[0] = 0;
+    for (int m = 1; m < MAXVIBMODE; m++) {
+      fsp->vibtemp[m] = 0.0;
+      fsp->vibrel[m] = 0.0;
+      fsp->vibdegen[m] = 0;
+    }
 
     fsp->vibdiscrete_read = 0;
 
@@ -1233,7 +1234,7 @@ void Particle::read_vibration_file()
   // skip blank lines or comment lines starting with '#'
   // all other lines can have up to NWORDS
 
-  int NWORDS = 14;
+  int NWORDS = 2 + 3*MAXVIBMODE;
   char **words = new char*[NWORDS];
   char line[MAXLINE],copy[MAXLINE];
 
@@ -1262,7 +1263,7 @@ void Particle::read_vibration_file()
     strcpy(vsp->id,words[0]);
 
     vsp->nmode = atoi(words[1]);
-    if (vsp->nmode < 2 || vsp->nmode > 4)
+    if (vsp->nmode < 2 || vsp->nmode > MAXVIBMODE)
       error->one(FLERR,"Invalid N count in vibration file");
     if (nwords != 2 + 3*vsp->nmode)
       error->one(FLERR,"Incorrect line format in vibration file");
@@ -1290,12 +1291,12 @@ void Particle::read_vibration_file()
 int Particle::wordcount(char *line, char **words)
 {
   int nwords = 0;
-  char *word = strtok(line," \t");
+  char *word = strtok(line," \t\n");
 
   while (word) {
     if (words) words[nwords] = word;
     nwords++;
-    word = strtok(NULL," \t");
+    word = strtok(NULL," \t\n");
   }
 
   return nwords;

--- a/src/particle.h
+++ b/src/particle.h
@@ -25,6 +25,8 @@ class Particle : protected Pointers {
   int exist;                // 1 if particles exist
   int sorted;               // 1 if particles are sorted by grid cell
 
+  enum{MAXVIBMODE=6};       // increase value if species need more vib modes
+
   struct Species {          // info on each particle species, read from file
     char id[16];            // species ID
     double molwt;           // molecular weight
@@ -33,9 +35,9 @@ class Particle : protected Pointers {
     double charge;          // multiple of electron charge
     double rotrel;          // inverse rotational relaxation number
     double rottemp[3];      // rotational temperature(s)
-    double vibtemp[4];      // vibrational temperature(s)
-    double vibrel[4];       // inverse vibrational relaxation number(s)
-    int vibdegen[4];        // vibrational mode degeneracies
+    double vibtemp[MAXVIBMODE];   // vibrational temperature(s)
+    double vibrel[MAXVIBMODE];    // inverse vibrational relaxation number(s)
+    int vibdegen[MAXVIBMODE];     // vibrational mode degeneracies
     int rotdof,vibdof;      // rotational/vibrational DOF
     int nrottemp,nvibmode;  // # of rotational/vibrational temps/modes defined
     int internaldof;        // 1 if either rotdof or vibdof != 0
@@ -50,9 +52,9 @@ class Particle : protected Pointers {
 
   struct VibFile {          // extra vibration info read from vibfile
     char id[16];
-    double vibrel[4];
-    double vibtemp[4];
-    int vibdegen[4];
+    double vibrel[MAXVIBMODE];
+    double vibtemp[MAXVIBMODE];
+    int vibdegen[MAXVIBMODE];
     int nmode;
   };
 

--- a/src/particle.h
+++ b/src/particle.h
@@ -25,7 +25,7 @@ class Particle : protected Pointers {
   int exist;                // 1 if particles exist
   int sorted;               // 1 if particles are sorted by grid cell
 
-  enum{MAXVIBMODE=6};       // increase value if species need more vib modes
+  enum{MAXVIBMODE=4};       // increase value if species need more vib modes
 
   struct Species {          // info on each particle species, read from file
     char id[16];            // species ID


### PR DESCRIPTION
## Purpose

Allow the maximum number or discrete vibrational modes (4 by default) to be extended by setting an enum value in particle.h and re-compiling the code.  At some point this could be made a global setting.  But it's a rare need, so this should be sufficient for now.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

Michael did some testing.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


