### PR TITLE
Tweaks to Kokkos atomics

### DIFF
--- a/lib/kokkos/Makefile.kokkos
+++ b/lib/kokkos/Makefile.kokkos
@@ -32,8 +32,8 @@ KOKKOS_DEBUG ?= "no"
 KOKKOS_USE_TPLS ?= ""
 # Options: c++14,c++1y,c++17,c++1z,c++2a
 KOKKOS_CXX_STANDARD ?= "c++14"
-# Options: aggressive_vectorization,disable_profiling,enable_large_mem_tests,disable_complex_align,disable_deprecated_code,enable_deprecation_warnings
-KOKKOS_OPTIONS ?= ""
+# Options: aggressive_vectorization,disable_profiling,enable_large_mem_tests,disable_complex_align,disable_deprecated_code,enable_deprecation_warnings,enable_desul_atomics
+KOKKOS_OPTIONS ?= "enable_desul_atomics"
 KOKKOS_CMAKE ?= "no"
 KOKKOS_TRIBITS ?= "no"
 KOKKOS_STANDALONE_CMAKE ?= "no"

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -621,7 +621,7 @@ void CollideVSSKokkos::operator()(TagCollideCollisionsOne< NEARCP, ATOMIC_REDUCT
     return;
   }
   if (ATOMIC_REDUCTION == 1)
-    Kokkos::atomic_fetch_add(&d_nattempt_one(),nattempt);
+    Kokkos::atomic_add(&d_nattempt_one(),nattempt);
   else if (ATOMIC_REDUCTION == 0)
     d_nattempt_one() += nattempt;
   else
@@ -691,7 +691,7 @@ void CollideVSSKokkos::operator()(TagCollideCollisionsOne< NEARCP, ATOMIC_REDUCT
                                                    recomb_part3,recomb_species,recomb_density,nlocal);
 
     if (ATOMIC_REDUCTION == 1)
-      Kokkos::atomic_fetch_add(&d_ncollide_one(),1);
+      Kokkos::atomic_increment(&d_ncollide_one());
     else if (ATOMIC_REDUCTION == 0)
       d_ncollide_one()++;
     else
@@ -699,7 +699,7 @@ void CollideVSSKokkos::operator()(TagCollideCollisionsOne< NEARCP, ATOMIC_REDUCT
 
     if (reactflag) {
       if (ATOMIC_REDUCTION == 1)
-        Kokkos::atomic_fetch_add(&d_nreact_one(),1);
+        Kokkos::atomic_increment(&d_nreact_one());
       else if (ATOMIC_REDUCTION == 0)
         d_nreact_one()++;
       else

--- a/src/KOKKOS/fix_ave_histo_kokkos.h
+++ b/src/KOKKOS/fix_ave_histo_kokkos.h
@@ -172,25 +172,25 @@ protected:
     if (value > mm_v.max_val) mm_v.max_val = value;
     if (value < lo) {
       if (beyond == 0 /*IGNORE*/) {
-        Kokkos::atomic_fetch_add(&d_stats(1), weight);
+        Kokkos::atomic_add(&d_stats(1), weight);
         return;
       } else {
-        Kokkos::atomic_fetch_add(&d_bin(0), weight);
+        Kokkos::atomic_add(&d_bin(0), weight);
       }
     } else if (value > hi) {
       if (beyond == 0 /*IGNORE*/) {
-        Kokkos::atomic_fetch_add(&d_stats(1), weight);
+        Kokkos::atomic_add(&d_stats(1), weight);
         return;
       } else {
-        Kokkos::atomic_fetch_add(&d_bin(nbins-1), weight);
+        Kokkos::atomic_add(&d_bin(nbins-1), weight);
       }
     } else {
       int ibin = static_cast<int>((value - lo) * bininv);
       ibin = MIN(ibin, nbins-1);
       if (beyond == 2 /*EXTRA*/) ibin++;
-      Kokkos::atomic_fetch_add(&d_bin(ibin), weight);
+      Kokkos::atomic_add(&d_bin(ibin), weight);
     }
-    Kokkos::atomic_fetch_add(&d_stats(0), weight);
+    Kokkos::atomic_add(&d_stats(0), weight);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/react_tce_kokkos.h
+++ b/src/KOKKOS/react_tce_kokkos.h
@@ -135,7 +135,7 @@ int attempt_kk(Particle::OnePart *ip, Particle::OnePart *jp,
     //      nothing that is I-specific or J-specific
 
     if (react_prob > random_prob) {
-      Kokkos::atomic_fetch_add(&d_tally_reactions[d_list[i]],1);
+      Kokkos::atomic_increment(&d_tally_reactions[d_list[i]]);
       ip->ispecies = r->d_products[0];
 
       // Previous statment did not destroy the 2nd species (B) if

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -82,7 +82,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &, int, int &) const
   {
-    Kokkos::atomic_fetch_add(&d_nsingle(),1);
+    Kokkos::atomic_increment(&d_nsingle());
 
     // if surface chemistry defined, attempt reaction
     // reaction > 0 if reaction took place

--- a/src/KOKKOS/surf_collide_piston_kokkos.h
+++ b/src/KOKKOS/surf_collide_piston_kokkos.h
@@ -49,7 +49,7 @@ class SurfCollidePistonKokkos : public SurfCollidePiston {
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &dtremain, int, int &) const
   {
-    Kokkos::atomic_fetch_add(&d_nsingle(),1);
+    Kokkos::atomic_increment(&d_nsingle());
 
     // if surface chemistry defined, attempt reaction
     // reaction > 0 if reaction took place

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -48,7 +48,7 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, const double *norm, double &, int, int &) const
   {
-    Kokkos::atomic_fetch_add(&d_nsingle(),1);
+    Kokkos::atomic_increment(&d_nsingle());
 
     // if surface chemistry defined, attempt reaction
     // reaction > 0 if reaction took place

--- a/src/KOKKOS/surf_collide_transparent_kokkos.h
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.h
@@ -49,7 +49,7 @@ class SurfCollideTransparentKokkos : public SurfCollideTransparent {
   Particle::OnePart*
   collide_kokkos(Particle::OnePart *&ip, const double *, double &, int, int&) const
   {
-    Kokkos::atomic_fetch_add(&d_nsingle(),1);
+    Kokkos::atomic_increment(&d_nsingle());
 
     return NULL;
   }

--- a/src/KOKKOS/surf_collide_vanish_kokkos.h
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.h
@@ -49,7 +49,7 @@ class SurfCollideVanishKokkos : public SurfCollideVanish {
   Particle::OnePart*
   collide_kokkos(Particle::OnePart *&ip, const double *, double &, int, int&) const
   {
-    Kokkos::atomic_fetch_add(&d_nsingle(),1);
+    Kokkos::atomic_increment(&d_nsingle());
 
     ip = NULL;
     return NULL;

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -720,7 +720,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
   int nmask = d_cells[icell].nmask;
   stuck_iterate = 0;
   if (ATOMIC_REDUCTION == 1)
-    Kokkos::atomic_fetch_add(&d_ntouch_one(),1);
+    Kokkos::atomic_increment(&d_ntouch_one());
   else if (ATOMIC_REDUCTION == 0)
     d_ntouch_one()++;
   else
@@ -886,7 +886,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
       }
 
       if (ATOMIC_REDUCTION == 1)
-        Kokkos::atomic_fetch_add(&d_nscheck_one(),nsurf);
+        Kokkos::atomic_add(&d_nscheck_one(),nsurf);
       else if (ATOMIC_REDUCTION == 0)
         d_nscheck_one() += nsurf;
       else
@@ -1162,7 +1162,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
 
           exclude = minsurf;
           if (ATOMIC_REDUCTION == 1)
-            Kokkos::atomic_fetch_add(&d_nscollide_one(),1);
+            Kokkos::atomic_increment(&d_nscollide_one());
           else if (ATOMIC_REDUCTION == 0)
             d_nscollide_one()++;
           else
@@ -1209,7 +1209,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
           else {
             particle_i.flag = PDISCARD;
             if (ATOMIC_REDUCTION == 1)
-              Kokkos::atomic_fetch_add(&d_nstuck(),1);
+              Kokkos::atomic_increment(&d_nstuck());
             else if (ATOMIC_REDUCTION == 0)
               d_nstuck()++;
             else
@@ -1255,7 +1255,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
         if (x[1] < lo[1] || x[1] > hi[1]) {
           particle_i.flag = PDISCARD;
           if (ATOMIC_REDUCTION == 1)
-            Kokkos::atomic_fetch_add(&d_naxibad(),1);
+            Kokkos::atomic_increment(&d_naxibad());
           else if (ATOMIC_REDUCTION == 0)
             d_naxibad()++;
           else
@@ -1412,7 +1412,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
       if (bflag == OUTFLOW) {
         particle_i.flag = PDISCARD;
         if (ATOMIC_REDUCTION == 1)
-          Kokkos::atomic_fetch_add(&d_nexit_one(),1);
+          Kokkos::atomic_increment(&d_nexit_one());
         else if (ATOMIC_REDUCTION == 0)
           d_nexit_one()++;
         else
@@ -1458,12 +1458,12 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
           //jpart->weight = particle_i.weight;
           //pstop++;
         }
-        Kokkos::atomic_fetch_add(&d_nboundary_one(),1);
-        Kokkos::atomic_fetch_add(&d_ntouch_one(),-1);    // decrement here since will increment below
+        Kokkos::atomic_increment(&d_nboundary_one());
+        Kokkos::atomic_decrement(&d_ntouch_one());    // decrement here since will increment below
       } else {
         if (ATOMIC_REDUCTION == 1) {
-          Kokkos::atomic_fetch_add(&d_nboundary_one(),1);
-          Kokkos::atomic_fetch_add(&d_ntouch_one(),-1);    // decrement here since will increment below
+          Kokkos::atomic_increment(&d_nboundary_one());
+          Kokkos::atomic_decrement(&d_ntouch_one());    // decrement here since will increment below
         } else if (ATOMIC_REDUCTION == 0) {
           d_nboundary_one()++;
           d_ntouch_one()--;    // decrement here since will increment below
@@ -1503,7 +1503,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
     neigh = d_cells[icell].neigh;
     nmask = d_cells[icell].nmask;
     if (ATOMIC_REDUCTION == 1)
-      Kokkos::atomic_fetch_add(&d_ntouch_one(),1);
+      Kokkos::atomic_increment(&d_ntouch_one());
     else if (ATOMIC_REDUCTION == 0)
       d_ntouch_one()++;
     else
@@ -1543,7 +1543,7 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
         return;
       }
       if (ATOMIC_REDUCTION == 1)
-        Kokkos::atomic_fetch_add(&d_ncomm_one(),1);
+        Kokkos::atomic_increment(&d_ncomm_one());
       else if (ATOMIC_REDUCTION == 0)
         d_ncomm_one()++;
       else


### PR DESCRIPTION
## Purpose

- Enable Kokkos Desul atomics in Makefile to match CMake settings. This was an oversight in Kokkos, should be fixed in upstream Kokkos in a future update.
- Change `Kokkos::atomic_fetch_add` to more specific functions.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes