### PR TITLE
Allow Kokkos surf_collide_diffuse to use fixes with custom data

### DIFF
--- a/src/KOKKOS/fix_ambipolar_kokkos.cpp
+++ b/src/KOKKOS/fix_ambipolar_kokkos.cpp
@@ -59,7 +59,7 @@ FixAmbipolarKokkos::FixAmbipolarKokkos(SPARTA *sparta, int narg, char **arg) :
 
 FixAmbipolarKokkos::FixAmbipolarKokkos(SPARTA *sparta) :
   FixAmbipolar(sparta),
-  rand_pool(12345 + comm->me
+  rand_pool(12345 // seed doesn't matter since it will just be copied over
 #ifdef SPARTA_KOKKOS_EXACT
             , sparta
 #endif
@@ -67,13 +67,15 @@ FixAmbipolarKokkos::FixAmbipolarKokkos(SPARTA *sparta) :
 {
   ions = NULL;
   random = NULL;
+  id = NULL;
+  style = NULL;
 }
 
 /* ---------------------------------------------------------------------- */
 
 FixAmbipolarKokkos::~FixAmbipolarKokkos()
 {
-  if (copymode || copy) return;
+  if (copy) return;
 
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.destroy();

--- a/src/KOKKOS/fix_ambipolar_kokkos.cpp
+++ b/src/KOKKOS/fix_ambipolar_kokkos.cpp
@@ -41,6 +41,8 @@ FixAmbipolarKokkos::FixAmbipolarKokkos(SPARTA *sparta, int narg, char **arg) :
 #endif
             )
 {
+  kokkos_flag = 1;
+
   // random = RNG for electron velocity creation
 
 #ifdef SPARTA_KOKKOS_EXACT
@@ -55,13 +57,44 @@ FixAmbipolarKokkos::FixAmbipolarKokkos(SPARTA *sparta, int narg, char **arg) :
 
 /* ---------------------------------------------------------------------- */
 
+FixAmbipolarKokkos::FixAmbipolarKokkos(SPARTA *sparta) :
+  FixAmbipolar(sparta),
+  rand_pool(12345 + comm->me
+#ifdef SPARTA_KOKKOS_EXACT
+            , sparta
+#endif
+            )
+{
+  ions = NULL;
+  random = NULL;
+}
+
+/* ---------------------------------------------------------------------- */
+
 FixAmbipolarKokkos::~FixAmbipolarKokkos()
 {
-  if (copymode) return;
+  if (copymode || copy) return;
 
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.destroy();
 #endif
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixAmbipolarKokkos::pre_update_custom_kokkos()
+{
+  boltz = update->boltz;
+
+  ParticleKokkos* particle_kk = (ParticleKokkos*) particle;
+  particle_kk->sync(Device,PARTICLE_MASK|SPECIES_MASK|CUSTOM_MASK);
+  d_particles = particle_kk->k_particles.d_view;
+  d_species = particle_kk->k_species.d_view;
+  auto h_ewhich = particle_kk->k_ewhich.h_view;
+  auto k_eivec = particle_kk->k_eivec;
+  auto k_edarray = particle_kk->k_edarray;
+  d_ionambi = k_eivec.h_view[h_ewhich[ionindex]].k_view.d_view;
+  d_velambi = k_edarray.h_view[h_ewhich[velindex]].k_view.d_view;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/fix_ambipolar_kokkos.h
+++ b/src/KOKKOS/fix_ambipolar_kokkos.h
@@ -44,7 +44,7 @@ class FixAmbipolarKokkos : public FixAmbipolar {
 
  private:
 
-  int boltz;
+  double boltz;
 
   t_particle_1d d_particles;
   t_species_1d d_species;

--- a/src/KOKKOS/fix_ambipolar_kokkos.h
+++ b/src/KOKKOS/fix_ambipolar_kokkos.h
@@ -33,12 +33,14 @@ class FixAmbipolarKokkos : public FixAmbipolar {
   DAT::t_int_1d d_ions;                  // 1 if a particle species is an ionx
 
   FixAmbipolarKokkos(class SPARTA *, int, char **);
+  FixAmbipolarKokkos(class SPARTA *);
   ~FixAmbipolarKokkos();
+  void pre_update_custom_kokkos();
   void update_custom(int, double, double, double, double *);
   void surf_react(Particle::OnePart *, int &, int &);
 
   KOKKOS_INLINE_FUNCTION
-  void update_custom_kokkos(int, double, double, double, double *);
+  void update_custom_kokkos(int, double, double, double, const double *) const;
 
  private:
 
@@ -47,9 +49,8 @@ class FixAmbipolarKokkos : public FixAmbipolar {
   t_particle_1d d_particles;
   t_species_1d d_species;
 
-  DAT::t_int_1d d_ewhich;
-  ParticleKokkos::tdual_struct_tdual_int_1d_1d k_eivec;
-  ParticleKokkos::tdual_struct_tdual_float_2d_1d k_edarray;
+  DAT::t_int_1d d_ionambi;
+  DAT::t_float_2d d_velambi;
 
 #ifndef SPARTA_KOKKOS_EXACT
   Kokkos::Random_XorShift64_Pool<DeviceType> rand_pool;
@@ -72,12 +73,9 @@ class FixAmbipolarKokkos : public FixAmbipolar {
 
 KOKKOS_INLINE_FUNCTION
 void FixAmbipolarKokkos::update_custom_kokkos(int index, double temp_thermal,
-                                             double, double,
-                         double *vstream)
+                                              double, double,
+                                              const double *vstream) const
 {
-  auto &d_ionambi = k_eivec.d_view[d_ewhich[ionindex]].k_view.d_view;
-  auto &d_velambi = k_edarray.d_view[d_ewhich[velindex]].k_view.d_view;
-
   // if species is not ambipolar ion, set ionambi off and return
 
   int ispecies = d_particles[index].ispecies;

--- a/src/KOKKOS/fix_vibmode_kokkos.cpp
+++ b/src/KOKKOS/fix_vibmode_kokkos.cpp
@@ -51,19 +51,23 @@ FixVibmodeKokkos::FixVibmodeKokkos(SPARTA *sparta, int narg, char **arg) :
 
 FixVibmodeKokkos::FixVibmodeKokkos(SPARTA *sparta) :
   FixVibmode(sparta),
-  rand_pool(12345 + comm->me
+  rand_pool(12345 // seed doesn't matter since it will just be copied over
 #ifdef SPARTA_KOKKOS_EXACT
             , sparta
 #endif
             )
 {
   random = NULL;
+  id = NULL;
+  style = NULL;
 }
 
 /* ---------------------------------------------------------------------- */
 
 FixVibmodeKokkos::~FixVibmodeKokkos()
 {
+  if (copy) return;
+
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.destroy();
 #endif

--- a/src/KOKKOS/fix_vibmode_kokkos.h
+++ b/src/KOKKOS/fix_vibmode_kokkos.h
@@ -32,12 +32,13 @@ namespace SPARTA_NS {
 class FixVibmodeKokkos : public FixVibmode {
  public:
   FixVibmodeKokkos(class SPARTA *, int, char **);
+  FixVibmodeKokkos(class SPARTA *);
   ~FixVibmodeKokkos();
-  //void init();
+  void pre_update_custom_kokkos();
   void update_custom(int, double, double, double, double *);
 
   KOKKOS_INLINE_FUNCTION
-  void update_custom_kokkos(int, double, double, double, double *);
+  void update_custom_kokkos(int, double, double, double, const double *) const;
 
  private:
   int boltz;
@@ -56,8 +57,7 @@ class FixVibmodeKokkos : public FixVibmode {
   t_particle_1d d_particles;
   t_species_1d d_species;
 
-  DAT::t_int_1d d_ewhich;
-  ParticleKokkos::tdual_struct_tdual_int_2d_1d k_eiarray;
+  DAT::t_int_2d d_vibmode;
 };
 
 /* ----------------------------------------------------------------------
@@ -69,10 +69,8 @@ class FixVibmodeKokkos : public FixVibmode {
 KOKKOS_INLINE_FUNCTION
 void FixVibmodeKokkos::update_custom_kokkos(int index, double temp_thermal,
                                             double temp_rot, double temp_vib,
-                                            double *)
+                                            const double *) const
 {
-  auto &d_vibmode = k_eiarray.d_view[d_ewhich[vibmodeindex]].k_view.d_view;
-
   int isp = d_particles[index].ispecies;
   int nmode = d_species[isp].nvibmode;
 
@@ -105,9 +103,9 @@ void FixVibmodeKokkos::update_custom_kokkos(int index, double temp_thermal,
     evib += ivib * boltz * d_species[isp].vibtemp[imode];
   }
 
-  rand_pool.free_state(rand_gen);
-
   d_particles[index].evib = evib;
+
+  rand_pool.free_state(rand_gen);
 }
 
 }

--- a/src/KOKKOS/kokkos_copy.h
+++ b/src/KOKKOS/kokkos_copy.h
@@ -44,7 +44,7 @@ class KKCopy {
     obj.copy = 1;
   }
 
-  void uncopy(int copy = 1) {
+  void uncopy(int copy = 0) {
     if (ptr_temp != NULL) {
       memcpy(&obj, ptr_temp, sizeof(ClassStyle));
       free(ptr_temp);

--- a/src/KOKKOS/kokkos_copy.h
+++ b/src/KOKKOS/kokkos_copy.h
@@ -44,13 +44,13 @@ class KKCopy {
     obj.copy = 1;
   }
 
-  void uncopy() {
+  void uncopy(int copy = 1) {
     if (ptr_temp != NULL) {
       memcpy(&obj, ptr_temp, sizeof(ClassStyle));
       free(ptr_temp);
       ptr_temp = NULL;
     }
-    obj.copy = 0;
+    obj.copy = copy;
     obj.copymode = 0;
   }
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -80,8 +80,8 @@ SurfCollideDiffuseKokkos::~SurfCollideDiffuseKokkos()
 {
   if (copy) return;
 
-  fix_ambi_kk_copy.uncopy();
-  fix_vibmode_kk_copy.uncopy();
+  fix_ambi_kk_copy.uncopy(1);
+  fix_vibmode_kk_copy.uncopy(1);
 
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.destroy();

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -101,7 +101,7 @@ void SurfCollideDiffuseKokkos::init()
         if (!afix->kokkos_flag)
           error->all(FLERR,"Must use fix ambipolar/kk when Kokkos is enabled");
         afix_kk = (FixAmbipolarKokkos*)afix;
-      } else if (strcmp(modify->fix[ifix]->style,"ambipolar") == 0) {
+      } else if (strcmp(modify->fix[ifix]->style,"vibmode") == 0) {
         vibmode_flag = 1;
         FixVibmode *vfix = (FixVibmode *) modify->fix[ifix];
         if (!vfix->kokkos_flag)

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -149,3 +149,11 @@ void SurfCollideDiffuseKokkos::pre_collide()
   vibstyle = NONE;
   if (Pointers::collide) vibstyle = Pointers::collide->vibstyle;
 }
+
+/* ---------------------------------------------------------------------- */
+
+void SurfCollideDiffuseKokkos::post_collide()
+{
+  ParticleKokkos* particle_kk = (ParticleKokkos*) particle;
+  if (ambi_flag || vibmode_flag) particle_kk->modify(Device,CUSTOM_MASK);
+}

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -44,6 +44,9 @@ SurfCollideStyle(diffuse/kk,SurfCollideDiffuseKokkos)
 #include "error.h"
 #include "Kokkos_Random.hpp"
 #include "rand_pool_wrap.h"
+#include "kokkos_copy.h"
+#include "fix_ambipolar_kokkos.h"
+#include "fix_vibmode_kokkos.h"
 
 namespace SPARTA_NS {
 
@@ -55,7 +58,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
   SurfCollideDiffuseKokkos(class SPARTA *, int, char **);
   SurfCollideDiffuseKokkos(class SPARTA *);
   ~SurfCollideDiffuseKokkos();
-
+  void init();
   void pre_collide();
 
 #ifndef SPARTA_KOKKOS_EXACT
@@ -106,10 +109,11 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
 
     if (ip) {
       diffuse(ip,norm);
-      //if (modify->n_update_custom) {
-      //  int i = ip - particle->particles;
-      //  modify->update_custom(i,twall,twall,twall,vstream);
-      //}
+      int i = ip - d_particles.data();
+      if (ambi_flag)
+        fix_ambi_kk_copy.obj.update_custom_kokkos(i,twall,twall,twall,vstream);
+      if (vibmode_flag)
+        fix_vibmode_kk_copy.obj.update_custom_kokkos(i,twall,twall,twall,vstream);
     }
     //if (jp) {
     //  diffuse(jp,norm);
@@ -144,8 +148,15 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
 
  private:
   double boltz;
+  t_particle_1d d_particles;
   t_species_1d d_species;
   int rotstyle, vibstyle;
+
+  int ambi_flag,vibmode_flag;
+  FixAmbipolarKokkos* afix_kk;
+  FixVibmodeKokkos* vfix_kk;
+  KKCopy<FixAmbipolarKokkos> fix_ambi_kk_copy;
+  KKCopy<FixVibmodeKokkos> fix_vibmode_kk_copy;
 
   KOKKOS_INLINE_FUNCTION
   void diffuse(Particle::OnePart *p, const double *norm) const

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -60,6 +60,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
   ~SurfCollideDiffuseKokkos();
   void init();
   void pre_collide();
+  void post_collide();
 
 #ifndef SPARTA_KOKKOS_EXACT
   Kokkos::Random_XorShift64_Pool<DeviceType> rand_pool;

--- a/src/KOKKOS/surf_collide_piston_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_piston_kokkos.cpp
@@ -38,37 +38,8 @@ SurfCollidePistonKokkos::SurfCollidePistonKokkos(SPARTA *sparta, int narg, char 
 SurfCollidePistonKokkos::SurfCollidePistonKokkos(SPARTA *sparta) :
   SurfCollidePiston(sparta)
 {
-  // ID and style
-  // ID must be all alphanumeric chars or underscores
-
-  int narg = 2;
-  const char* arg[] = {"sc_kk_piston_copy","piston"};
-
-  int n = strlen(arg[0]) + 1;
-  id = new char[n];
-  strcpy(id,arg[0]);
-
-  for (int i = 0; i < n-1; i++)
-    if (!isalnum(id[i]) && id[i] != '_')
-      error->all(FLERR,"Surf_collide ID must be alphanumeric or "
-                 "underscore characters");
-
-  n = strlen(arg[1]) + 1;
-  style = new char[n];
-  strcpy(style,arg[1]);
-
-  vector_flag = 1;
-  size_vector = 2;
-  nsingle = ntotal = 0;
-  copy = 0;
-
-  if (narg != 2) error->all(FLERR,"Illegal surf_collide piston command");
-
-  allowreact = 1;
-
-  k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.d_view;
-  h_nsingle = k_nsingle.h_view;
+  id = NULL;
+  style = NULL;  
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/surf_collide_specular_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_specular_kokkos.cpp
@@ -37,37 +37,6 @@ SurfCollideSpecularKokkos::SurfCollideSpecularKokkos(SPARTA *sparta, int narg, c
 SurfCollideSpecularKokkos::SurfCollideSpecularKokkos(SPARTA *sparta) :
   SurfCollideSpecular(sparta)
 {
-  // ID and style
-  // ID must be all alphanumeric chars or underscores
-
-  int narg = 2;
-  const char* arg[] = {"sc_kk_specular_copy","specular"};
-
-  int n = strlen(arg[0]) + 1;
-  id = new char[n];
-  strcpy(id,arg[0]);
-
-  for (int i = 0; i < n-1; i++)
-    if (!isalnum(id[i]) && id[i] != '_')
-      error->all(FLERR,"Surf_collide ID must be alphanumeric or "
-                 "underscore characters");
-
-  n = strlen(arg[1]) + 1;
-  style = new char[n];
-  strcpy(style,arg[1]);
-
-  vector_flag = 1;
-  size_vector = 2;
-
-  nsingle = ntotal = 0;
-
-  copy = 0;
-
-  if (narg != 2) error->all(FLERR,"Illegal surf_collide specular command");
-
-  allowreact = 1;
-
-  k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.d_view;
-  h_nsingle = k_nsingle.h_view;
+  id = NULL;
+  style = NULL;
 }

--- a/src/KOKKOS/surf_collide_transparent_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.cpp
@@ -33,37 +33,6 @@ SurfCollideTransparentKokkos::SurfCollideTransparentKokkos(SPARTA *sparta, int n
 SurfCollideTransparentKokkos::SurfCollideTransparentKokkos(SPARTA *sparta) :
   SurfCollideTransparent(sparta)
 {
-  // ID and style
-  // ID must be all alphanumeric chars or underscores
-
-  int narg = 2;
-  const char* arg[] = {"sc_kk_transparent_copy","transparent"};
-
-  int n = strlen(arg[0]) + 1;
-  id = new char[n];
-  strcpy(id,arg[0]);
-
-  for (int i = 0; i < n-1; i++)
-    if (!isalnum(id[i]) && id[i] != '_')
-      error->all(FLERR,"Surf_collide ID must be alphanumeric or "
-                 "underscore characters");
-
-  n = strlen(arg[1]) + 1;
-  style = new char[n];
-  strcpy(style,arg[1]);
-
-  vector_flag = 1;
-  size_vector = 2;
-
-  nsingle = ntotal = 0;
-
-  copy = 0;
-
-  if (narg != 2) error->all(FLERR,"Illegal surf_collide transparent command");
-
-  transparent = 1;
-
-  k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.d_view;
-  h_nsingle = k_nsingle.h_view;
+  id = NULL;
+  style = NULL;
 }

--- a/src/KOKKOS/surf_collide_vanish_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.cpp
@@ -33,35 +33,6 @@ SurfCollideVanishKokkos::SurfCollideVanishKokkos(SPARTA *sparta, int narg, char 
 SurfCollideVanishKokkos::SurfCollideVanishKokkos(SPARTA *sparta) :
   SurfCollideVanish(sparta)
 {
-  // ID and style
-  // ID must be all alphanumeric chars or underscores
-
-  int narg = 2;
-  const char* arg[] = {"sc_kk_vanish_copy","vanish"};
-
-  int n = strlen(arg[0]) + 1;
-  id = new char[n];
-  strcpy(id,arg[0]);
-
-  for (int i = 0; i < n-1; i++)
-    if (!isalnum(id[i]) && id[i] != '_')
-      error->all(FLERR,"Surf_collide ID must be alphanumeric or "
-                 "underscore characters");
-
-  n = strlen(arg[1]) + 1;
-  style = new char[n];
-  strcpy(style,arg[1]);
-
-  vector_flag = 1;
-  size_vector = 2;
-
-  nsingle = ntotal = 0;
-
-  copy = 0;
-
-  if (narg != 2) error->all(FLERR,"Illegal surf_collide vanish command");
-
-  k_nsingle = DAT::tdual_int_scalar("SurfCollide:nsingle");
-  d_nsingle = k_nsingle.d_view;
-  h_nsingle = k_nsingle.h_view;
+  id = NULL;
+  style = NULL;
 }

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -551,6 +551,16 @@ template < int DIM, int SURF > void UpdateKokkos::move()
       error->one(FLERR,str);
     }
 
+    if (surf->nsc > 0) {
+      int ndiff = 0;
+      for (int n = 0; n < surf->nsc; n++) {
+        if (strcmp(surf->sc[n]->style,"diffuse") == 0) {
+          sc_kk_diffuse_copy[ndiff].obj.post_collide();
+          ndiff++;
+        }
+      }
+    }
+
     // if gridcut >= 0.0, check if another iteration of move is required
     // only the case if some particle flag = PENTRY/PEXIT
     //   in which case perform particle migration

--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -60,8 +60,7 @@ Compute::Compute(SPARTA *sparta, int narg, char **arg) : Pointers(sparta)
   invoked_per_particle = invoked_per_grid = invoked_per_surf = -1;
 
   kokkos_flag = 0;
-  copymode = 0;
-  copy = 0;
+  copy = copymode = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -57,7 +57,7 @@ Fix::Fix(SPARTA *sparta, int, char **arg) : Pointers(sparta)
   END_OF_STEP = 2;
 
   kokkos_flag = 0;
-  copymode = 0;
+  copy = copymode = 0;
 
   execution_space = Host;
   datamask_read = ALL_MASK;
@@ -68,7 +68,7 @@ Fix::Fix(SPARTA *sparta, int, char **arg) : Pointers(sparta)
 
 Fix::~Fix()
 {
-  if (copymode) return;
+  if (copy || copymode) return;
 
   delete [] id;
   delete [] style;

--- a/src/fix.h
+++ b/src/fix.h
@@ -61,12 +61,13 @@ class Fix : protected Pointers {
   int START_OF_STEP,END_OF_STEP;    // mask settings
 
   int kokkos_flag;              // 0/1 if Kokkos fix
-  int copymode;                 // 1 if copy of class (prevents deallocation of
+  int copy,copymode;            // 1 if copy of class (prevents deallocation of
                                 //  base class when child copy is destroyed)
   ExecutionSpace execution_space;
   unsigned int datamask_read,datamask_modify;
 
   Fix(class SPARTA *, int, char **);
+  Fix(class SPARTA *sparta) : Pointers(sparta) {} // needed for Kokkos
   virtual ~Fix();
 
   virtual int setmask() = 0;

--- a/src/fix_ambipolar.cpp
+++ b/src/fix_ambipolar.cpp
@@ -76,7 +76,7 @@ FixAmbipolar::FixAmbipolar(SPARTA *sparta, int narg, char **arg) :
 
 FixAmbipolar::~FixAmbipolar()
 {
-  if (copymode) return;
+  if (copy || copymode) return;
 
   memory->destroy(ions);
   delete random;

--- a/src/fix_ambipolar.h
+++ b/src/fix_ambipolar.h
@@ -32,6 +32,7 @@ class FixAmbipolar : public Fix {
   int *ions;                  // 1 if a particle species is an ionx
 
   FixAmbipolar(class SPARTA *, int, char **);
+  FixAmbipolar(class SPARTA *sparta) : Fix(sparta) {} // needed for Kokkos
   virtual ~FixAmbipolar();
   int setmask();
   void init();

--- a/src/fix_vibmode.cpp
+++ b/src/fix_vibmode.cpp
@@ -46,6 +46,10 @@ FixVibmode::FixVibmode(SPARTA *sparta, int narg, char **arg) :
 
   // create per-particle array
 
+  if (!collide)
+    error->all(FLERR,"Cannot use fix vibmode without "
+               "collide style defined");
+
   if (collide->vibstyle != DISCRETE)
     error->all(FLERR,"Cannot use fix vibmode without "
                "collide_modify vibrate discrete");

--- a/src/fix_vibmode.cpp
+++ b/src/fix_vibmode.cpp
@@ -66,7 +66,7 @@ FixVibmode::FixVibmode(SPARTA *sparta, int narg, char **arg) :
 
 FixVibmode::~FixVibmode()
 {
-  if (copymode) return;
+  if (copy) return;
 
   delete random;
   particle->remove_custom(vibmodeindex);

--- a/src/fix_vibmode.h
+++ b/src/fix_vibmode.h
@@ -29,6 +29,7 @@ namespace SPARTA_NS {
 class FixVibmode : public Fix {
  public:
   FixVibmode(class SPARTA *, int, char **);
+  FixVibmode(class SPARTA *sparta) : Fix(sparta) {} // needed for Kokkos
   virtual ~FixVibmode();
   int setmask();
   void init();

--- a/src/surf_collide_diffuse.h
+++ b/src/surf_collide_diffuse.h
@@ -30,7 +30,7 @@ class SurfCollideDiffuse : public SurfCollide {
   SurfCollideDiffuse(class SPARTA *, int, char **);
   SurfCollideDiffuse(class SPARTA *sparta) : SurfCollide(sparta) {}
   ~SurfCollideDiffuse();
-  void init();
+  virtual void init();
   Particle::OnePart *collide(Particle::OnePart *&, double &,
                              int, double *, int, int &);
   void wrapper(Particle::OnePart *, double *, int *, double*);


### PR DESCRIPTION
## Purpose

Allow Kokkos surf_collide_diffuse to use fixes with custom data (i.e. `fix ambipolar` or `fix vibmode`), which previously errored out.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes