### PR TITLE
Generalize surf collide rotation check to axisymmetric

### DIFF
--- a/src/surf_collide_cll.cpp
+++ b/src/surf_collide_cll.cpp
@@ -107,10 +107,17 @@ SurfCollideCLL::SurfCollideCLL(SPARTA *sparta, int narg, char **arg) :
       wx = atof(arg[iarg+4]);
       wy = atof(arg[iarg+5]);
       wz = atof(arg[iarg+6]);
-      if (domain->dimension == 2 && pz != 0.0)
-        error->all(FLERR,"Surf_collide cll rotation invalid for 2d");
-      if (domain->dimension == 2 && (wx != 0.0 || wy != 0.0))
-        error->all(FLERR,"Surf_collide cll rotation invalid for 2d");
+
+      if (domain->dimension == 2) {
+        if (pz != 0.0)
+          error->all(FLERR,"Surf_collide diffuse rotation invalid for 2d");
+        if (!domain->axisymmetric && (wx != 0.0 || wy != 0.0))
+          error->all(FLERR,"Surf_collide diffuse rotation invalid for 2d");
+        if (domain->axisymmetric && (wy != 0.0 || wz != 0.0))
+          error->all(FLERR,
+                     "Surf_collide diffuse rotation invalid for 2d axisymmetric");
+      }
+
       iarg += 7;
     } else error->all(FLERR,"Illegal surf_collide cll command");
   }

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -81,10 +81,17 @@ SurfCollideDiffuse::SurfCollideDiffuse(SPARTA *sparta, int narg, char **arg) :
       wx = atof(arg[iarg+4]);
       wy = atof(arg[iarg+5]);
       wz = atof(arg[iarg+6]);
-      if (domain->dimension == 2 && pz != 0.0)
-        error->all(FLERR,"Surf_collide diffuse rotation invalid for 2d");
-      if (domain->dimension == 2 && (wx != 0.0 || wy != 0.0))
-        error->all(FLERR,"Surf_collide diffuse rotation invalid for 2d");
+
+      if (domain->dimension == 2) {
+        if (pz != 0.0)
+          error->all(FLERR,"Surf_collide diffuse rotation invalid for 2d");
+        if (!domain->axisymmetric && (wx != 0.0 || wy != 0.0))
+          error->all(FLERR,"Surf_collide diffuse rotation invalid for 2d");
+        if (domain->axisymmetric && (wy != 0.0 || wz != 0.0))
+          error->all(FLERR,
+                     "Surf_collide diffuse rotation invalid for 2d axisymmetric");
+      }
+
       iarg += 7;
     } else error->all(FLERR,"Illegal surf_collide diffuse command");
   }


### PR DESCRIPTION
## Purpose

The error checks on the angular velocity vector for a rotating surf were good for 2d, but not 2d axisymmetric.  This generalizes the checks.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


