### PR TITLE
Rename gpu/direct to gpu/aware in Kokkos package

### DIFF
--- a/doc/package.txt
+++ b/doc/package.txt
@@ -28,16 +28,16 @@ args = arguments specific to the style :l
       {collide/retry} = {yes} or {no}
         yes = retry collision algorithm until successful
         no = do not retry collision algorithm (default)
-      {gpu/direct} = {yes} or {no}
-        yes = use GPU-direct, i.e. CUDA-aware MPI (default)
-        no = do not use GPU-direct :pre
+      {gpu/aware} = {yes} or {no}
+        yes = use GPU-aware MPI (default)
+        no = do not use GPU-aware MPI :pre
 :ule
 
 [Examples:]
 
 package kokkos comm classic
 package kokkos comm threaded reduction atomic
-package kokkos gpu/direct no :pre
+package kokkos gpu/aware no :pre
 
 [Description:]
 
@@ -120,10 +120,10 @@ without being moved between the host and GPU.  This requires that your
 MPI is able to access GPU memory directly.  Currently that is true for
 OpenMPI 1.8 (or later versions), Mvapich2 1.9 (or later), and CrayMPI.
 
-The {gpu/direct} keyword chooses whether GPU-direct will be used. When 
+The {gpu/aware} keyword chooses whether GPU-aware MPI will be used. When 
 this keyword is set to {on}, buffers in GPU memory are passed directly 
 through MPI send/receive calls. This can reduce overhead of first 
-copying the data to the host CPU. However GPU-direct is not supported on 
+copying the data to the host CPU. However GPU-aware MPI is not supported on 
 all systems, which can lead to segmentation faults and would require 
 using a value of {off}. 
 
@@ -147,7 +147,7 @@ setting"_Section_start.html#start_6
 
 For the KOKKOS package, the option defaults are comm = threaded, 
 reduction = parallel/reduce, collide/extra = 1.1, and collide/retry = 
-no, gpu/direct yes. These settings are made automatically by the 
+no, gpu/aware yes. These settings are made automatically by the 
 required "-k on" "command-line switch"_Section_start.html#start_6. You 
 can change them by using the package kokkos command in your input script 
 or via the "-pk kokkos" "command-line switch"_Section_start.html#start_6. 

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -195,7 +195,7 @@ int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d d_plis
   particle_kk->sync(Device,PARTICLE_MASK);
   d_particles = particle_kk->k_particles.d_view;
 
-  if (sparta->kokkos->gpu_direct_flag && !ncustom) {
+  if (sparta->kokkos->gpu_aware_flag && !ncustom) {
     iparticle_kk->
       exchange_uniform(d_sbuf,nbytes_total,
                        (char *) (d_particles.data()+particle->nlocal),d_rbuf);

--- a/src/KOKKOS/compute_boundary_kokkos.cpp
+++ b/src/KOKKOS/compute_boundary_kokkos.cpp
@@ -85,7 +85,7 @@ void ComputeBoundaryKokkos::compute_array()
 
   // sum tallies across processors
 
-  if (sparta->kokkos->gpu_direct_flag) {
+  if (sparta->kokkos->gpu_aware_flag) {
     MPI_Allreduce(d_myarray.data(),d_array.data(),nrow*ntotal,
                   MPI_DOUBLE,MPI_SUM,world);
     k_array.modify_device();

--- a/src/KOKKOS/irregular_kokkos.cpp
+++ b/src/KOKKOS/irregular_kokkos.cpp
@@ -349,7 +349,7 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
   d_recvbuf_ptr = d_recvbuf_ptr_in;
   d_recvbuf = d_recvbuf_in;
 
-  if (!sparta->kokkos->gpu_direct_flag &&
+  if (!sparta->kokkos->gpu_aware_flag &&
       h_recvbuf.extent(0) != d_recvbuf.extent(0)) {
     h_recvbuf = HAT::t_char_1d(Kokkos::view_alloc("irregular:d_recvbuf:mirror",Kokkos::WithoutInitializing),d_recvbuf.extent(0));
   }
@@ -358,7 +358,7 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
 
   offset = num_self*nbytes;
   for (int irecv = 0; irecv < nrecv; irecv++) {
-    if (sparta->kokkos->gpu_direct_flag) {
+    if (sparta->kokkos->gpu_aware_flag) {
       MPI_Irecv(&d_recvbuf_ptr[offset],num_recv[irecv]*nbytes,MPI_CHAR,
                 proc_recv[irecv],0,world,&request[irecv]);
     } else {
@@ -395,7 +395,7 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
   for (int isend = 0; isend < nsend; isend++) {
     count = num_send[isend];
 
-    if (!sparta->kokkos->gpu_direct_flag) {
+    if (!sparta->kokkos->gpu_aware_flag) {
 
       // allocate exact buffer size to reduce GPU <--> CPU memory transfer
 
@@ -412,7 +412,7 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
     //pack_buffer_serial(0,count);
     copymode = 0;
 
-    if (sparta->kokkos->gpu_direct_flag)
+    if (sparta->kokkos->gpu_aware_flag)
       MPI_Send(d_buf.data(),count*nbytes,MPI_CHAR,proc_send[isend],0,world);
     else {
       Kokkos::deep_copy(h_buf,d_buf);
@@ -432,7 +432,7 @@ void IrregularKokkos::exchange_uniform(DAT::t_char_1d d_sendbuf_in, int nbytes_i
   if (nrecv) {
     MPI_Waitall(nrecv,request,status);
 
-    if (!sparta->kokkos->gpu_direct_flag)
+    if (!sparta->kokkos->gpu_aware_flag)
       Kokkos::deep_copy(d_recvbuf,h_recvbuf);
   }
 }

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -146,7 +146,7 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
   atomic_reduction = 0;
   prewrap = 1;
   auto_sync = 1;
-  gpu_direct_flag = 1;
+  gpu_aware_flag = 1;
 
   need_atomics = 1;
   if (nthreads == 1 && ngpus == 0)
@@ -208,12 +208,13 @@ void KokkosSPARTA::accelerator(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
       collide_extra = atof(arg[iarg+1]);
       iarg += 2;
-    } else if (strcmp(arg[iarg],"gpu/direct") == 0) {
+    } else if ((strcmp(arg[iarg],"gpu/aware") == 0)
+               || (strcmp(arg[iarg],"gpu/direct") == 0)) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
       if (strcmp(arg[iarg+1],"yes") == 0) {
-        gpu_direct_flag = 1;
+        gpu_aware_flag = 1;
       } else if (strcmp(arg[iarg+1],"no") == 0) {
-        gpu_direct_flag = 0;
+        gpu_aware_flag = 0;
       } else error->all(FLERR,"Illegal package kokkos command");
       iarg += 2;
     } else error->all(FLERR,"Illegal package kokkos command");

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -30,7 +30,7 @@ class KokkosSPARTA : protected Pointers {
   int nthreads,ngpus;
   int numa;
   int need_atomics;
-  int gpu_direct_flag;
+  int gpu_aware_flag;
   int collide_retry_flag;
   double collide_extra;
 

--- a/src/KOKKOS/react_bird_kokkos.cpp
+++ b/src/KOKKOS/react_bird_kokkos.cpp
@@ -161,7 +161,7 @@ double ReactBirdKokkos::extract_tally(int m)
   if (!tally_flag) {
     tally_flag = 1;
 
-    if (sparta->kokkos->gpu_direct_flag) {
+    if (sparta->kokkos->gpu_aware_flag) {
       MPI_Allreduce(d_tally_reactions.data(),k_tally_reactions_all.d_view.data(),nlist,
                     MPI_SPARTA_BIGINT,MPI_SUM,world);
       k_tally_reactions_all.modify_device();


### PR DESCRIPTION
## Purpose

Rename `gpu/direct` to `gpu/aware` in Kokkos package.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes, the old option is still supported, but will be deprecated. 
