### PR TITLE
Fix surface reaction reference in variable

### DIFF
--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -1569,7 +1569,7 @@ double Variable::evaluate(char *str, Tree **tree)
 	char *id = new char[n];
 	strcpy(id,&word[2]);
 
-	int isr = surf->find_collide(id);
+	int isr = surf->find_react(id);
 	if (isr < 0)
           error->all(FLERR,"Invalid surf reaction ID in variable formula");
 	SurfReact *sr = surf->sr[isr];


### PR DESCRIPTION
## Purpose

Fixes a bug in variable. Currently the lookup for the surface reaction model falsely uses the function for the collision model. Thus, the lookup either fails or returns a wrong reference.

## Author(s)

Tim Teichmann, KIT

## Backward Compatibility

Functionality was broken before.

## Implementation Notes

Trivial: use correct lookup function


