### PR TITLE
Add no slip option to surf_collide_specular

### DIFF
--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -15,8 +15,8 @@ surf_collide ID style args keyword values ... :pre
 ID = user-assigned name for the surface collision model :ulb,l
 style = {specular} or {diffuse} or {cll} or {impulsive} or {td} or {piston} or {transparent} or {vanish} or {specular/kk} or {diffuse/kk} or {piston/kk} or {vanish/kk} :l
 args = arguments for specific style :l
-  {specular} or {specular/kk} args = adiabatic (optional)
-    adiabatic = reflect all velocity components off surface (not just normal component)
+  {specular} or {specular/kk} args = noslip (optional)
+    noslip = reflect all velocity components off surface (not just normal component)
   {diffuse} or {diffuse/kk} args = Tsurf acc
     Tsurf = temperature of surface (temperature units)
             Tsurf can be a variable (see below)
@@ -116,10 +116,14 @@ The {specular} style computes a simple specular reflection model.  It
 requires no arguments.  Specular reflection means that a particle
 reflects off a surface element with its incident velocity vector
 reversed with respect to the outward normal of the surface element.
-The particle's speed is unchanged. If the optional {adiabatic} keyword
-is set, all velocity components are reflected off the surface
-(instead of just the normal component), which creates a no-slip
-condition on the surface.
+The particle's speed is unchanged.
+
+Specular reflection means that a particle bounce off a surface element
+reverses only the component of its velocity normal to the surface. If
+the optional {noslip} keyword is used, the particle bounce flips the sign
+of all 3 xyz components of the particle's incident velocity, so that it
+now moves in the opposite direction, creating a no slip boundary condition.
+In either case, the particle's speed is unchanged.
 
 :line
 

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -15,8 +15,8 @@ surf_collide ID style args keyword values ... :pre
 ID = user-assigned name for the surface collision model :ulb,l
 style = {specular} or {diffuse} or {cll} or {impulsive} or {td} or {piston} or {transparent} or {vanish} or {specular/kk} or {diffuse/kk} or {piston/kk} or {vanish/kk} :l
 args = arguments for specific style :l
-  {specular} or {specular/kk} args = adiabatic
-    adiabatic = {yes} or {no}
+  {specular} or {specular/kk} args = adiabatic (optional)
+    adiabatic = reflect all velocity components off surface (not just normal component)
   {diffuse} or {diffuse/kk} args = Tsurf acc
     Tsurf = temperature of surface (temperature units)
             Tsurf can be a variable (see below)
@@ -117,9 +117,9 @@ requires no arguments.  Specular reflection means that a particle
 reflects off a surface element with its incident velocity vector
 reversed with respect to the outward normal of the surface element.
 The particle's speed is unchanged. If the optional {adiabatic} keyword
-is set to {yes}, all velocity components are reflected off the surface
+is set, all velocity components are reflected off the surface
 (instead of just the normal component), which creates a no-slip
-condition on the surface (default value is {no}).
+condition on the surface.
 
 :line
 

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -77,7 +77,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
      ip = particle with current x = collision pt, current v = incident v
      norm = surface normal unit vector
      isr = index of reaction model if >= 0, -1 for no chemistry
-     ip = set to NULL if destroyed by chemsitry
+     ip = set to NULL if destroyed by chemistry
      return jp = new particle if created by chemistry
      return reaction = index of reaction (1 to N) that took place, 0 = no reaction
      resets particle(s) to post-collision outward velocity

--- a/src/KOKKOS/surf_collide_piston_kokkos.h
+++ b/src/KOKKOS/surf_collide_piston_kokkos.h
@@ -41,7 +41,7 @@ class SurfCollidePistonKokkos : public SurfCollidePiston {
      ip = particle with current x = collision pt, current v = incident v
      norm = surface normal unit vector
      isr = index of reaction model if >= 0, -1 for no chemistry
-     ip = set to NULL if destroyed by chemsitry
+     ip = set to NULL if destroyed by chemistry
      return jp = new particle if created by chemistry
      return reaction = index of reaction (1 to N) that took place, 0 = no reaction
      resets particle(s) to post-collision outward velocity

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -65,7 +65,7 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
     //  if (reaction) surf->nreact_one++;
     //}
 
-    // specular or adiabatic reflection for each particle
+    // specular or noslip reflection for each particle
     // only if SurfReact did not already reset velocities
     // also both partiticles need to trigger any fixes
     //   to update per-particle properties which depend on
@@ -75,9 +75,9 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
 
     if (ip) {
       if (!velreset) {
-        if (adiabatic_flag) {
+        if (noslip_flag) {
 
-          // adiabatic reflection
+          // noslip reflection
           // reflect incident v, all three components.
 
           MathExtraKokkos::negate3(ip->v);
@@ -97,9 +97,9 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
 
     //if (jp) {
     //  if (!velreset) {
-    //    if (adiabatic_flag) {
+    //    if (noslip_flag) {
 
-          // adiabatic reflection
+          // noslip reflection
           // reflect incident v, all three components.
 
     //      MathExtra::negate3(jp->v);

--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -1043,7 +1043,7 @@ void Collide::collisions_one_ambipolar()
             memory->grow(plist,npmax,"collide:plist");
           }
           plist[np++] = particle->nlocal-1;
-        
+
         } else {
           if (nelectron == maxelectron) {
             maxelectron += DELTAELECTRON;

--- a/src/collide.h
+++ b/src/collide.h
@@ -83,7 +83,7 @@ class Collide : protected Pointers {
   int *nn_last_partner_igroup;   // ditto for two groups of particles
   int *nn_last_partner_jgroup;
 
-  int ndelete,maxdelete;      // # of particles removed by chemsitry
+  int ndelete,maxdelete;      // # of particles removed by chemistry
   int *dellist;               // list of particle indices to delete
 
   char *mixID;               // ID of mixture to use for groups

--- a/src/surf_collide_cll.cpp
+++ b/src/surf_collide_cll.cpp
@@ -166,7 +166,7 @@ void SurfCollideCLL::init()
    isurf = index of surface element
    norm = surface normal unit vector
    isr = index of reaction model if >= 0, -1 for no chemistry
-   ip = reset to NULL if destroyed by chemsitry
+   ip = reset to NULL if destroyed by chemistry
    return jp = new particle if created by chemistry
    return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -142,7 +142,7 @@ void SurfCollideDiffuse::init()
    isurf = index of surface element
    norm = surface normal unit vector
    isr = index of reaction model if >= 0, -1 for no chemistry
-   ip = reset to NULL if destroyed by chemsitry
+   ip = reset to NULL if destroyed by chemistry
    return jp = new particle if created by chemistry
    return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -170,7 +170,7 @@ void SurfCollideImpulsive::init()
    isurf = index of surface element
    norm = surface normal unit vector
    isr = index of reaction model if >= 0, -1 for no chemistry
-   ip = reset to NULL if destroyed by chemsitry
+   ip = reset to NULL if destroyed by chemistry
    return jp = new particle if created by chemistry
    return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity

--- a/src/surf_collide_piston.cpp
+++ b/src/surf_collide_piston.cpp
@@ -86,7 +86,7 @@ void SurfCollidePiston::init()
    isurf = index of surface element
    norm = surface normal unit vector
    isr = index of reaction model if >= 0, -1 for no chemistry
-   ip = reset to NULL if destroyed by chemsitry
+   ip = reset to NULL if destroyed by chemistry
    return jp = new particle if created by chemistry
    return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity

--- a/src/surf_collide_specular.cpp
+++ b/src/surf_collide_specular.cpp
@@ -41,7 +41,7 @@ SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
       adiabatic_flag = 0;
       if (strcmp(arg[iarg+1],"yes") == 0) adiabatic_flag = 1;
       else if (strcmp(arg[iarg+1],"no") == 0) adiabatic_flag = 0;
-      else error->all(FLERR,"Illegal surf_collide specular command"); 
+      else error->all(FLERR,"Illegal surf_collide specular command");
       iarg += 2;
     }
   }
@@ -89,11 +89,11 @@ collide(Particle::OnePart *&ip, double &,
   //   since temperature does not change, would need to add a twall arg
 
   if (ip) {
-    if (!velreset) {  
+    if (!velreset) {
       if (adiabatic_flag) {
 
         // adiabatic reflection
-        // reflect incident v, all three components.
+        // reflect incident v, all three components
 
         MathExtra::negate3(ip->v);
       } else {

--- a/src/surf_collide_specular.cpp
+++ b/src/surf_collide_specular.cpp
@@ -31,6 +31,8 @@ SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
 
   // optional args
 
+  adiabatic_flag = 0;
+
   int iarg = 2;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"adiabatic") == 0) {

--- a/src/surf_collide_specular.cpp
+++ b/src/surf_collide_specular.cpp
@@ -27,7 +27,7 @@ using namespace SPARTA_NS;
 SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
   SurfCollide(sparta, narg, arg)
 {
-  if (narg < 2) error->all(FLERR,"Illegal surf_collide specular command");
+  if (narg < 2 || narg > 3) error->all(FLERR,"Illegal surf_collide specular command");
 
   // optional args
 
@@ -36,13 +36,8 @@ SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
   int iarg = 2;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"adiabatic") == 0) {
-      if (iarg+2 > narg)
-        error->all(FLERR,"Illegal surf_collide specular command");
-      adiabatic_flag = 0;
-      if (strcmp(arg[iarg+1],"yes") == 0) adiabatic_flag = 1;
-      else if (strcmp(arg[iarg+1],"no") == 0) adiabatic_flag = 0;
-      else error->all(FLERR,"Illegal surf_collide specular command");
-      iarg += 2;
+      adiabatic_flag = 1;
+      iarg += 1;
     }
   }
 }

--- a/src/surf_collide_specular.cpp
+++ b/src/surf_collide_specular.cpp
@@ -31,14 +31,15 @@ SurfCollideSpecular::SurfCollideSpecular(SPARTA *sparta, int narg, char **arg) :
 
   // optional args
 
-  adiabatic_flag = 0;
+  noslip_flag = 0;
 
   int iarg = 2;
   while (iarg < narg) {
-    if (strcmp(arg[iarg],"adiabatic") == 0) {
-      adiabatic_flag = 1;
+    if (strcmp(arg[iarg],"noslip") == 0) {
+      noslip_flag = 1;
       iarg += 1;
-    }
+    } else
+      error->all(FLERR,"Illegal surf_collide specular command");
   }
 }
 
@@ -75,7 +76,7 @@ collide(Particle::OnePart *&ip, double &,
     if (reaction) surf->nreact_one++;
   }
 
-  // specular or adiabatic reflection for each particle
+  // specular or noslip reflection for each particle
   // only if SurfReact did not already reset velocities
   // also both partiticles need to trigger any fixes
   //   to update per-particle properties which depend on
@@ -85,9 +86,9 @@ collide(Particle::OnePart *&ip, double &,
 
   if (ip) {
     if (!velreset) {
-      if (adiabatic_flag) {
+      if (noslip_flag) {
 
-        // adiabatic reflection
+        // noslip reflection
         // reflect incident v, all three components
 
         MathExtra::negate3(ip->v);
@@ -107,9 +108,9 @@ collide(Particle::OnePart *&ip, double &,
 
   if (jp) {
     if (!velreset) {
-      if (adiabatic_flag) {
+      if (noslip_flag) {
 
-        // adiabatic reflection
+        // noslip reflection
         // reflect incident v, all three components.
 
         MathExtra::negate3(jp->v);

--- a/src/surf_collide_specular.h
+++ b/src/surf_collide_specular.h
@@ -35,6 +35,8 @@ class SurfCollideSpecular : public SurfCollide {
                              int, double *, int, int &);
   void wrapper(Particle::OnePart *, double *, int *, double*);
   void flags_and_coeffs(int *, double *) {}
+ private:
+  int adiabatic_flag;
 };
 
 }

--- a/src/surf_collide_specular.h
+++ b/src/surf_collide_specular.h
@@ -37,7 +37,7 @@ class SurfCollideSpecular : public SurfCollide {
   void flags_and_coeffs(int *, double *) {}
 
  protected:
-  int adiabatic_flag;
+  int noslip_flag;
 };
 
 }

--- a/src/surf_collide_td.cpp
+++ b/src/surf_collide_td.cpp
@@ -130,7 +130,7 @@ void SurfCollideTD::init()
    isurf = index of surface element
    norm = surface normal unit vector
    isr = index of reaction model if >= 0, -1 for no chemistry
-   ip = reset to NULL if destroyed by chemsitry
+   ip = reset to NULL if destroyed by chemistry
    return jp = new particle if created by chemistry
    return reaction = index of reaction (1 to N) that took place, 0 = no reaction
    resets particle(s) to post-collision outward velocity


### PR DESCRIPTION
## Purpose

Add `noslip` option to `surf_collide_specular`.  In this, all velocity components are reflected off the surface (instead of just the normal component), which creates a no-slip condition on the surface.

## Author(s)

Michael Gallis (SNL), Stan Moore (SNL)

## Backward Compatibility

Yes