### PR TITLE
Add error checks to code

### DIFF
--- a/src/read_restart.h
+++ b/src/read_restart.h
@@ -86,6 +86,10 @@ E: Cannot read_restart after simulation box is defined
 The read_restart command cannot be used after a read_data,
 read_restart, or create_box command.
 
+E: Cannot (yet) use global mem/limit without parallel restart file ('%' character in filename)
+
+This feature is not yet implemented.
+
 E: Cannot open restart file %s
 
 The specified file cannot be opened.  Check that the path and name are

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3416,6 +3416,9 @@ void Variable::particle_vector(char *word, Tree **tree,
     newtree->nstride = sizeof(Particle::Species);
     newtree->carray = (char *) &species[0].magmoment;
   }
+
+  if (particle->nlocal*newtree->nstride > MAXSMALLINT)
+    error->all(FLERR,"Too many particles per processor for particle-style variable");
 }
 
 /* ----------------------------------------------------------------------
@@ -3470,6 +3473,9 @@ void Variable::grid_vector(char *word, Tree **tree,
     newtree->carray = (char *) &cells[0].lo[2];
   else if (strcmp(word,"czhi") == 0)
     newtree->carray = (char *) &cells[0].hi[2];
+
+  if (grid->nlocal*newtree->nstride > MAXSMALLINT)
+    error->all(FLERR,"Too many grid cells per processor for grid-style variable");
 }
 
 /* ----------------------------------------------------------------------

--- a/src/variable.h
+++ b/src/variable.h
@@ -274,6 +274,16 @@ E: Invalid math/special function in variable formula
 
 Self-explanatory.
 
+E: Too many particles per processor for particle-style variable
+
+The number of particles per MPI rank is too large, increase the
+number of MPI ranks.
+
+E: Too many grid cells per processor for grid-style variable
+
+The number of grid cells per MPI rank is too large, increase the
+number of MPI ranks.
+
 E: Invalid stats keyword in variable formula
 
 The keyword is not recognized.


### PR DESCRIPTION
## Purpose

- Add error check for too many particles per processor for variables
- Add error check if using `global mem/limit` without `%` in dump file output

## Author(s)

Stan Moore (SNL), issues reported by Michael Gallis (SNL) and Cosimo Livi (ASML)

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


