### PR TITLE
Tweak to read_restart with mem/limit

### DIFF
--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -87,8 +87,8 @@ void ReadRestart::command(int narg, char **arg)
   else multiproc = 0;
 
   if (mem_limit_flag && !multiproc)
-    error->all(FLERR,"Cannot (yet) use global mem/limit without parallel "
-                      "restart file ('%' character in filename)");
+    error->all(FLERR,"Cannot (yet) use global mem/limit without "
+               "% in restart file name");
 
   // open single restart file or base file for multiproc case
 

--- a/src/read_restart.h
+++ b/src/read_restart.h
@@ -86,7 +86,7 @@ E: Cannot read_restart after simulation box is defined
 The read_restart command cannot be used after a read_data,
 read_restart, or create_box command.
 
-E: Cannot (yet) use global mem/limit without parallel restart file ('%' character in filename)
+E: Cannot (yet) use global mem/limit without % in restart file name
 
 This feature is not yet implemented.
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -83,6 +83,10 @@ void WriteRestart::command(int narg, char **arg)
   if (strchr(arg[0],'%')) multiproc = nprocs;
   else multiproc = 0;
 
+  if (mem_limit_flag && !multiproc)
+    error->all(FLERR,"Cannot (yet) use global mem/limit without "
+               "% in restart file name");
+
   // setup output style and process optional args
   // also called by Output class for periodic restart files
 
@@ -370,7 +374,8 @@ void WriteRestart::write_less_memory(char *file)
   int nbytes_custom = particle->sizeof_custom();
   int nbytes = nbytes_particle + nbytes_custom;
 
-  int max_size = MAX(grid_send_size,update->global_mem_limit);
+  int max_size = MIN(particle_send_size,update->global_mem_limit);
+  max_size = MAX(max_size,grid_send_size);
   max_size = MAX(max_size,nbytes);
   max_size += 128; // extra for size and ROUNDUP(ptr)
 

--- a/src/write_restart.h
+++ b/src/write_restart.h
@@ -84,6 +84,10 @@ Self-explanatory.  Check the input script syntax and compare to the
 documentation for the command.  You can use -echo screen as a
 command-line option when running SPARTA to see the offending line.
 
+E: Cannot (yet) use global mem/limit without % in restart file name
+
+This feature is not yet implemented.
+
 E: Cannot use write_restart fileper without % in restart file name
 
 Self-explanatory.


### PR DESCRIPTION
## Purpose

Reduce size of `global mem/limit` buffer if it is bigger than the total size needed to send all particles. This can improve performance and reduce memory if `mem/limit` is set to a large value with a small number of particles. Also tweak error messages.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes