### PR TITLE
Add surf_collide adiabatic model with isotropic scattering

### DIFF
--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -17,7 +17,7 @@
 </PRE>
 <UL><LI>ID = user-assigned name for the surface collision model 
 
-<LI>style = <I>specular</I> or <I>diffuse</I> or <I>cll</I> or <I>impulsive</I> or <I>td</I> or <I>piston</I> or <I>transparent</I> or <I>vanish</I> or <I>specular/kk</I> or <I>diffuse/kk</I> or <I>piston/kk</I> or <I>vanish/kk</I> 
+<LI>style = <I>specular</I> or <I>diffuse</I> or <I>cll</I> or <I>adiabatic</I> or <I>impulsive</I> or <I>td</I> or <I>piston</I> or <I>transparent</I> or <I>vanish</I> or <I>specular/kk</I> or <I>diffuse/kk</I> or <I>piston/kk</I> or <I>vanish/kk</I> 
 
 <LI>args = arguments for specific style 
 
@@ -33,6 +33,7 @@
     acc_t = accommodation coefficient in the surface tangential direction
     acc_rot = accommodation coefficient for the rotational modes
     acc_vib = accommodation coefficient for the vibrational modes
+  <I>adiabatic</I> args = none
   <I>impulsive</I> args = Tsurf <I>model</I> param1 param2 var theta_peak pol_pow azi_pow
     Tsurf = temperature of surface (temperature units)
             Tsurf can be a variable (see below)
@@ -96,6 +97,7 @@ surf_collide 1 transparent
 surf_collide 1 diffuse 273.15 0.9
 surf_collide 1 cll 273.15 0.8 0.8 0.5 0.1
 surf_collide 1 cll 273.15 1.0 1.0 0.1 0.1 partial 0.5
+surf_collide 1 adiabatic
 surf_collide 1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75
 surf_collide 1 impulsive 1000.0 tempvar 3 500 2000 60 5 75
 surf_collide 1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75 double 10
@@ -201,6 +203,16 @@ determine the current surface temperature.
 functions and include <A HREF = "status_style.html">stats_style</A> command keywords
 for the simulation box parameters and timestep and elapsed time.
 Thus, it is easy to specify a time-dependent temperature.
+</P>
+<HR>
+
+<P>The <I>adiabatic</I> style computes the adiabatic surface collision model
+proposed by Mohammadzadeh, Rana, and Struchtrup
+<A HREF = "#Mohammadzadeh16">(Mohammadzadeh16)</A>. This style requires no arguments.
+The adiabatic surface is modelled by scattering particles isotropically
+whilst conserving their velocity magnitude. Therefore, no energy is
+transferred between the wall and the particles. Note, that this is only
+valid for particle collisions not for potential surface reactions.
 </P>
 <HR>
 
@@ -630,6 +642,12 @@ Experiments and simulations, The Journal of Chemical Physics, (1990).
 
 <P><B>(Goodman74)</B> F. O. Goodman, Determination of characteristic surface
 vibration temperatures by molecular beam scattering: Application to
-specular scattering in the H-LiF (001) system, Surface Science, (1974)
+specular scattering in the H-LiF (001) system, Surface Science, (1974).
+</P>
+<A NAME = "Mohammadzadeh16"></A>
+
+<P><B>(Mohammadzadeh16)</B> A. Mohammadzadeh, A. Rana, and H. Struchtrup,
+DSMC and R13 modeling of the adiabatic surface, International Journal
+of Thermal Sciences, vol. 101, pp. 9–23, March (2016).
 </P>
 </HTML>

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -13,7 +13,7 @@ surf_collide command :h3
 surf_collide ID style args keyword values ... :pre
 
 ID = user-assigned name for the surface collision model :ulb,l
-style = {specular} or {diffuse} or {cll} or {impulsive} or {td} or {piston} or {transparent} or {vanish} or {specular/kk} or {diffuse/kk} or {piston/kk} or {vanish/kk} :l
+style = {specular} or {diffuse} or {cll} or {adiabatic} or {impulsive} or {td} or {piston} or {transparent} or {vanish} or {specular/kk} or {diffuse/kk} or {piston/kk} or {vanish/kk} :l
 args = arguments for specific style :l
   {specular} or {specular/kk} args = none
   {diffuse} or {diffuse/kk} args = Tsurf acc
@@ -27,6 +27,7 @@ args = arguments for specific style :l
     acc_t = accommodation coefficient in the surface tangential direction
     acc_rot = accommodation coefficient for the rotational modes
     acc_vib = accommodation coefficient for the vibrational modes
+  {adiabatic} args = none
   {impulsive} args = Tsurf {model} param1 param2 var theta_peak pol_pow azi_pow
     Tsurf = temperature of surface (temperature units)
             Tsurf can be a variable (see below)
@@ -84,6 +85,7 @@ surf_collide 1 transparent
 surf_collide 1 diffuse 273.15 0.9
 surf_collide 1 cll 273.15 0.8 0.8 0.5 0.1
 surf_collide 1 cll 273.15 1.0 1.0 0.1 0.1 partial 0.5
+surf_collide 1 adiabatic
 surf_collide 1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75
 surf_collide 1 impulsive 1000.0 tempvar 3 500 2000 60 5 75
 surf_collide 1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75 double 10
@@ -189,6 +191,16 @@ Equal-style variables can specify formulas with various mathematical
 functions and include "stats_style"_status_style.html command keywords
 for the simulation box parameters and timestep and elapsed time.
 Thus, it is easy to specify a time-dependent temperature.
+
+:line
+
+The {adiabatic} style computes the adiabatic surface collision model
+proposed by Mohammadzadeh, Rana, and Struchtrup
+"(Mohammadzadeh16)"_#Mohammadzadeh16. This style requires no arguments.
+The adiabatic surface is modelled by scattering particles isotropically
+whilst conserving their velocity magnitude. Therefore, no energy is
+transferred between the wall and the particles. Note, that this is only
+valid for particle collisions not for potential surface reactions.
 
 :line
 
@@ -604,4 +616,9 @@ Experiments and simulations, The Journal of Chemical Physics, (1990).
 :link(Goodman74)
 [(Goodman74)] F. O. Goodman, Determination of characteristic surface
 vibration temperatures by molecular beam scattering: Application to
-specular scattering in the H-LiF (001) system, Surface Science, (1974)
+specular scattering in the H-LiF (001) system, Surface Science, (1974).
+
+:link(Mohammadzadeh16)
+[(Mohammadzadeh16)] A. Mohammadzadeh, A. Rana, and H. Struchtrup,
+DSMC and R13 modeling of the adiabatic surface, International Journal
+of Thermal Sciences, vol. 101, pp. 9–23, March (2016).

--- a/doc/surf_react_adsorb.txt
+++ b/doc/surf_react_adsorb.txt
@@ -307,12 +307,12 @@ assigned to the surface element using the
 scattering model is desired, specify a {NULL} value.
 
 Any of the following surface collision models can be used: {specular},
-{diffuse}, {cll}, {impulsive}, {td}.  The scattering model style and
-its corresponding arguments are specified in the line following the
-reaction-style.  If there are two gas-phase products, two lines (for
-the first and second particle) can be specified.  The arguments for
-the different surface scattering models are the same as specified in
-the "surf_collide"_surf_collide.html command.
+{diffuse}, {adiabatic}, {cll}, {impulsive}, {td}.  The scattering
+model style and its corresponding arguments are specified in the line
+following the reaction-style.  If there are two gas-phase products,
+two lines (for the first and second particle) can be specified.  The
+arguments for the different surface scattering models are the same as
+specified in the "surf_collide"_surf_collide.html command.
 
 :line
 

--- a/examples/surf_collide/in.beam.adiabatic
+++ b/examples/surf_collide/in.beam.adiabatic
@@ -1,0 +1,42 @@
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+create_grid 	    5 5 5
+balance_grid        rcb cell
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2 
+
+surf_collide        1 adiabatic
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+

--- a/examples/surf_collide/in.circle.adiabatic
+++ b/examples/surf_collide/in.circle.adiabatic
@@ -1,0 +1,43 @@
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    20 20 1 
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0 
+
+read_surf           data.circle
+surf_collide	    1 adiabatic
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 &
+#                    surf proc 0.01 size 512 512 zoom 1.75 &
+#                    gline yes 0.005 
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+

--- a/examples/surf_collide/log.01Mar22.mpi_1.beam.adiabatic
+++ b/examples/surf_collide/log.01Mar22.mpi_1.beam.adiabatic
@@ -1,0 +1,116 @@
+SPARTA (7 Jan 2022)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+Created 125 child grid cells
+  CPU time = 0.00111079 secs
+  create/ghost percent = 74.6083 25.3917
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000306129 secs
+  reassign/sort/migrate/ghost percent = 37.4611 1.16822 18.6916 42.6791
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 adiabatic
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.018664837     3118        0        0        0        0 
+     200  0.038883209     6225        0        0        0        0 
+     300  0.073545694     6933        0        0        0        0 
+     400   0.10846663     6968        0        0        0        0 
+     500   0.14355516     7007        0        0        0        0 
+     600   0.17871594     6951        0        0        0        0 
+     700   0.21373487     6983        0        0        0        0 
+     800   0.24877405     7037        0        0        0        0 
+     900   0.28419948     7068        0        0        0        0 
+    1000   0.31984496     7083        0        0        0        0 
+Loop time of 0.319856 on 1 procs for 1000 steps with 7083 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.27209    | 0.27209    | 0.27209    |   0.0 | 85.07
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.0013118  | 0.0013118  | 0.0013118  |   0.0 |  0.41
+Modify  | 0.045358   | 0.045358   | 0.045358   |   0.0 | 14.18
+Output  | 0.00014472 | 0.00014472 | 0.00014472 |   0.0 |  0.05
+Other   |            | 0.0009532  |            |       |  0.30
+
+Particle moves    = 5094446 (5.09M)
+Cells touched     = 5404464 (5.4M)
+Particle comms    = 0 (0K)
+Boundary collides = 28030 (28K)
+Boundary exits    = 24087 (24.1K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.59273e+07
+Particle-moves/step: 5094.45
+Cell-touches/particle/step: 1.06085
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00550207
+Particle fraction exiting boundary: 0.00472809
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 7083 ave 7083 max 7083 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      125 ave 125 max 125 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.01Mar22.mpi_1.circle.adiabatic
+++ b/examples/surf_collide/log.01Mar22.mpi_1.circle.adiabatic
@@ -1,0 +1,133 @@
+SPARTA (7 Jan 2022)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+Created 400 child grid cells
+  CPU time = 0.00146198 secs
+  create/ghost percent = 58.6758 41.3242
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 0.000580788 secs
+  reassign/sort/migrate/ghost percent = 26.4778 1.06732 13.5468 58.908
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.0017252 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 12.1752 8.70647 3.33057 53.6899 22.0978 6.6335 0.0138198
+  surf2grid time = 0.000926256 secs
+  map/comm1/comm2/comm3/comm4/split percent = 40.4118 5.63707 12.3037 4.16988 8.36551 23.8095
+surf_collide	    1 adiabatic
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100   0.11665273    19735        0        0      111     4384 
+     200   0.38131523    31071        0        0      163     6394 
+     300   0.72111607    36581        0        0      181     7595 
+     400     1.099318    39478        0        0      185     7970 
+     500    1.4918654    41155        0        0      177     8366 
+     600    1.8989697    42114        0        0      173     8591 
+     700    2.3131812    42929        0        0      185     8266 
+     800    2.7277949    43266        0        0      197     8735 
+     900     3.151932    43555        0        0      204     8452 
+    1000    3.5719559    43791        0        0      179     8276 
+Loop time of 3.57198 on 1 procs for 1000 steps with 43791 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 2.647      | 2.647      | 2.647      |   0.0 | 74.10
+Coll    | 0.31426    | 0.31426    | 0.31426    |   0.0 |  8.80
+Sort    | 0.4003     | 0.4003     | 0.4003     |   0.0 | 11.21
+Comm    | 0.0083504  | 0.0083504  | 0.0083504  |   0.0 |  0.23
+Modify  | 0.19887    | 0.19887    | 0.19887    |   0.0 |  5.57
+Output  | 0.00029635 | 0.00029635 | 0.00029635 |   0.0 |  0.01
+Other   |            | 0.002937   |            |       |  0.08
+
+Particle moves    = 36554861 (36.6M)
+Cells touched     = 41335330 (41.3M)
+Particle comms    = 0 (0K)
+Boundary collides = 166738 (0.167M)
+Boundary exits    = 166932 (0.167M)
+SurfColl checks   = 7288341 (7.29M)
+SurfColl occurs   = 171043 (0.171M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.02338e+07
+Particle-moves/step: 36554.9
+Cell-touches/particle/step: 1.13078
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00456131
+Particle fraction exiting boundary: 0.00456662
+Surface-checks/particle/step: 0.199381
+Surface-collisions/particle/step: 0.00467908
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 43791 ave 43791 max 43791 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      400 ave 400 max 400 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.01Mar22.mpi_4.beam.adiabatic
+++ b/examples/surf_collide/log.01Mar22.mpi_4.beam.adiabatic
@@ -1,0 +1,117 @@
+SPARTA (7 Jan 2022)
+################################################################################
+# beam of particles striking the surface at an inclined angle - free molecular flow (no collisions)
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    123456
+dimension   	    3
+global              gridcut 0.0 comm/sort yes
+
+boundary	    oo oo so
+
+create_box          -11 11 -11 11 0 10
+Created orthogonal box = (-11 -11 0) to (11 11 10)
+create_grid 	    5 5 5
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 125 child grid cells
+  CPU time = 0.00112009 secs
+  create/ghost percent = 83.6313 16.3687
+balance_grid        rcb cell
+Balance grid migrated 105 cells
+  CPU time = 0.00102067 secs
+  reassign/sort/migrate/ghost percent = 59.8692 0.537258 13.4314 26.1621
+
+global		    nrho 1e10 fnum 1e6
+
+species		    air.species N O
+mixture		    air N O vstream 0 1000 -1000
+
+mixture             air N frac 0.8
+mixture             air O frac 0.2
+
+surf_collide        1 adiabatic
+bound_modify        zlo collide 1
+
+region              circle cylinder z 0 -10 1 -INF INF
+fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
+
+#dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005
+#dump_modify	    2 pad 4
+
+timestep            0.0001
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0 0 0
+  total     (ave,min,max) = 1.51379 1.51379 1.51379
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100 0.0051748753     3118        0        0        0        0 
+     200  0.029842615     6225        0        0        0        0 
+     300   0.05863452     6949        0        0        0        0 
+     400  0.085777283     6938        0        0        0        0 
+     500   0.11331511     7006        0        0        0        0 
+     600   0.14417362     6974        0        0        0        0 
+     700   0.17132998     7006        0        0        0        0 
+     800   0.19864821     6966        0        0        0        0 
+     900   0.22629285     7058        0        0        0        0 
+    1000   0.25420427     7069        0        0        0        0 
+Loop time of 0.254273 on 4 procs for 1000 steps with 7069 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.026099   | 0.073303   | 0.11547    |  11.8 | 28.83
+Coll    | 0          | 0          | 0          |   0.0 |  0.00
+Sort    | 0          | 0          | 0          |   0.0 |  0.00
+Comm    | 0.030602   | 0.033366   | 0.035157   |   1.0 | 13.12
+Modify  | 0.00025845 | 0.0083197  | 0.032431   |  15.3 |  3.27
+Output  | 0.00018835 | 0.0003196  | 0.00071001 |   0.0 |  0.13
+Other   |            | 0.139      |            |       | 54.65
+
+Particle moves    = 5094853 (5.09M)
+Cells touched     = 5405012 (5.41M)
+Particle comms    = 193584 (0.194M)
+Boundary collides = 28030 (28K)
+Boundary exits    = 24101 (24.1K)
+SurfColl checks   = 0 (0K)
+SurfColl occurs   = 0 (0K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 5.00923e+06
+Particle-moves/step: 5094.85
+Cell-touches/particle/step: 1.06088
+Particle comm iterations/step: 1.756
+Particle fraction communicated: 0.037996
+Particle fraction colliding with boundary: 0.00550163
+Particle fraction exiting boundary: 0.00473046
+Surface-checks/particle/step: 0
+Surface-collisions/particle/step: 0
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 1767.25 ave 3379 max 177 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      31.25 ave 32 max 31 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+GhostCell: 48.75 ave 49 max 48 min
+Histogram: 1 0 0 0 0 0 0 0 0 3
+EmptyCell: 35 ave 35 max 35 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/examples/surf_collide/log.01Mar22.mpi_4.circle.adiabatic
+++ b/examples/surf_collide/log.01Mar22.mpi_4.circle.adiabatic
@@ -1,0 +1,134 @@
+SPARTA (7 Jan 2022)
+################################################################################
+# 2d flow around a circle
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    20 20 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (/ascldap/users/stamoor/sparta_stanmoore1/src/grid.cpp:410)
+Created 400 child grid cells
+  CPU time = 0.00112271 secs
+  create/ghost percent = 83.5422 16.4578
+balance_grid        rcb cell
+Balance grid migrated 280 cells
+  CPU time = 0.00109196 secs
+  reassign/sort/migrate/ghost percent = 58.9956 0.69869 14.869 25.4367
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 100.0 0 0
+
+read_surf           data.circle
+  50 points
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  48 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  264 88 48 = cells outside/inside/overlapping surfs
+  48 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00138855 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.2479 16.8613 1.49382 46.3942 16.0027 15.1442 0.223214
+  surf2grid time = 0.000644207 secs
+  map/comm1/comm2/comm3/comm4/split percent = 37.5278 7.62398 9.17839 4.92228 10.2147 20.0592
+surf_collide	    1 adiabatic
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+fix		    in emit/face air xlo twopass # subsonic 0.1 NULL
+
+timestep 	    0.0001
+
+#dump                2 image all 50 image.*.ppm type type pdiam 0.1 #                    surf proc 0.01 size 512 512 zoom 1.75 #                    gline yes 0.005
+#dump_modify	    2 pad 4
+
+stats		    100
+stats_style	    step cpu np nattempt ncoll nscoll nscheck
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np Natt Ncoll Nscoll Nscheck 
+       0            0        0        0        0        0        0 
+     100  0.065354824    19751        0        0      113     4269 
+     200    0.2309823    31127        0        0      155     6600 
+     300   0.38565373    36623        0        0      182     7358 
+     400   0.55121255    39504        0        0      179     7981 
+     500   0.72713184    41177        0        0      212     8334 
+     600   0.90315223    42219        0        0      151     8197 
+     700    1.0822983    43053        0        0      195     8623 
+     800    1.3004394    43354        0        0      209     8601 
+     900    1.4834599    43613        0        0      172     8308 
+    1000    1.6658607    43867        0        0      178     8760 
+Loop time of 1.666 on 4 procs for 1000 steps with 43867 particles
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.24086    | 0.69263    | 1.1441     |  54.0 | 41.57
+Coll    | 0.025491   | 0.070599   | 0.11601    |  16.9 |  4.24
+Sort    | 0.040407   | 0.1072     | 0.17864    |  20.4 |  6.43
+Comm    | 0.027841   | 0.080176   | 0.099884   |  10.7 |  4.81
+Modify  | 0.00088573 | 0.054259   | 0.10822    |  22.9 |  3.26
+Output  | 0.00029111 | 0.0016148  | 0.0026791  |   2.7 |  0.10
+Other   |            | 0.6595     |            |       | 39.59
+
+Particle moves    = 36565348 (36.6M)
+Cells touched     = 41354828 (41.4M)
+Particle comms    = 140746 (0.141M)
+Boundary collides = 167590 (0.168M)
+Boundary exits    = 166967 (0.167M)
+SurfColl checks   = 7267819 (7.27M)
+SurfColl occurs   = 170728 (0.171M)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 5.48699e+06
+Particle-moves/step: 36565.3
+Cell-touches/particle/step: 1.13098
+Particle comm iterations/step: 2.096
+Particle fraction communicated: 0.00384916
+Particle fraction colliding with boundary: 0.0045833
+Particle fraction exiting boundary: 0.00456626
+Surface-checks/particle/step: 0.198762
+Surface-collisions/particle/step: 0.00466912
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 10966.8 ave 17521 max 4474 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      100 ave 100 max 100 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 21 ave 21 max 21 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+

--- a/src/surf_collide_adiabatic.cpp
+++ b/src/surf_collide_adiabatic.cpp
@@ -1,0 +1,197 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "math.h"
+#include "surf_collide_adiabatic.h"
+#include "surf.h"
+#include "surf_react.h"
+#include "update.h"
+#include "particle.h"
+#include "modify.h"
+#include "comm.h"
+#include "math_const.h"
+#include "math_extra.h"
+#include "error.h"
+#include "random_mars.h"
+#include "random_knuth.h"
+
+using namespace SPARTA_NS;
+using namespace MathConst;
+
+/* ---------------------------------------------------------------------- */
+
+SurfCollideAdiabatic::SurfCollideAdiabatic(SPARTA *sparta, int narg, char **arg) :
+  SurfCollide(sparta, narg, arg)
+{
+  if (narg != 2) error->all(FLERR,"Illegal surf_collide adiabatic command");
+
+  // initialize RNG for isotropic reflection
+
+  random = new RanKnuth(update->ranmaster->uniform());
+  double seed = update->ranmaster->uniform();
+  random->reset(seed,comm->me,100);
+}
+
+/* ---------------------------------------------------------------------- */
+
+SurfCollideAdiabatic::~SurfCollideAdiabatic()
+{
+  if (copy) return;
+
+  delete random;
+}
+
+/* ----------------------------------------------------------------------
+   particle collision with surface with optional chemistry
+   ip = particle with current x = collision pt, current v = incident v
+   isurf = index of surface element
+   norm = surface normal unit vector
+   isr = index of reaction model if >= 0, -1 for no chemistry
+   ip = reset to NULL if destroyed by chemsitry
+   return jp = new particle if created by chemistry
+   return reaction = index of reaction (1 to N) that took place, 0 = no reaction
+   resets particle(s) to post-collision outward velocity
+------------------------------------------------------------------------- */
+
+Particle::OnePart *SurfCollideAdiabatic::
+collide(Particle::OnePart *&ip, double &,
+        int isurf, double *norm, int isr, int &reaction)
+{
+  nsingle++;
+
+  // if surface chemistry defined, attempt reaction
+  // reaction = 1 to N for which reaction took place, 0 for none
+  // velreset = 1 if reaction reset post-collision velocity, else 0
+
+  Particle::OnePart iorig;
+  Particle::OnePart *jp = NULL;
+  reaction = 0;
+  int velreset = 0;
+
+  // note that adiabatic condition (i.e. not energy transfer of flow to surf)
+  // does only apply to particle collisions. Chemistry (e.g. particle
+  // adsorptions) can lead to energy transfer in both directions.
+  if (isr >= 0) {
+    if (modify->n_surf_react) memcpy(&iorig,ip,sizeof(Particle::OnePart));
+    reaction = surf->sr[isr]->react(ip,isurf,norm,jp,velreset);
+    if (reaction) surf->nreact_one++;
+  }
+
+  // isotropic scattering conserving velocity magnitude (i.e. kinetic energy)
+  //   of each particle
+  // only if SurfReact did not already reset velocities
+  // cannot trigger fixes that require temperature of particle here
+  //   because temperature of wall is not known
+
+  if (ip) {
+    if (!velreset) scatter_isotropic(ip,norm);
+  }
+  if (jp) {
+    if (!velreset) scatter_isotropic(jp,norm);
+  }
+
+  // call any fixes with a surf_react() method
+  // they may reset j to -1, e.g. fix ambipolar
+  //   in which case newly created j is deleted
+
+  if (reaction && modify->n_surf_react) {
+    int i = -1;
+    if (ip) i = ip - particle->particles;
+    int j = -1;
+    if (jp) j = jp - particle->particles;
+    modify->surf_react(&iorig,i,j);
+    if (jp && j < 0) {
+      jp = NULL;
+      particle->nlocal--;
+    }
+  }
+
+  return jp;
+}
+
+/* ----------------------------------------------------------------------
+   particle collision with adiabatic surface
+   p = particle with current x = collision pt, current v = incident v
+   norm = surface normal unit vector
+   resets particle(s) to post-collision outward velocity so that particle
+   is scattered isotropically whilst conserving its velocity magnitude
+   (i.e. no energy transfer to surf), this is an efficient way to model
+   an adiabatic surface in DSMC as it does not require an iterative
+   procedure to determine the surface temp, for more details and references
+   see documentation
+------------------------------------------------------------------------- */
+
+void SurfCollideAdiabatic::scatter_isotropic(Particle::OnePart *p, double *norm)
+{
+  double *v = p->v;
+  double dot = MathExtra::dot3(v,norm);
+
+  // tangent1/2 = surface tangential unit vectors
+
+  double tangent1[3], tangent2[3];
+  tangent1[0] = v[0] - dot*norm[0];
+  tangent1[1] = v[1] - dot*norm[1];
+  tangent1[2] = v[2] - dot*norm[2];
+
+  // if mag(tangent1) == 0 mean normal collision, in that case choose
+  // a random tangential vector
+  if (MathExtra::lensq3(tangent1) == 0.0) {
+    tangent2[0] = random->uniform();
+    tangent2[1] = random->uniform();
+    tangent2[2] = random->uniform();
+    MathExtra::cross3(norm,tangent2,tangent1);
+  }
+
+  // normalize tangent1
+  MathExtra::norm3(tangent1);
+  // compute tangent2 as norm x tangent1, so that tangent1 and tangent2 are
+  // orthogonal
+  MathExtra::cross3(norm,tangent1,tangent2);
+
+  // isotropic scattering
+  // vmag = magnitude of incidient particle velocity vector
+  // vperp = velocity component perpendicular to surface along norm (cy)
+  // vtan1/2 = 2 remaining velocity components tangential to surface
+
+  double vmag = MathExtra::len3(v);
+
+  double theta = MY_2PI*random->uniform();
+  double f_phi = random->uniform();
+  double sqrt_f_phi = sqrt(f_phi);
+
+  double vperp = vmag * sqrt(1.0 - f_phi);
+  double vtan1 = vmag * sqrt_f_phi * sin(theta);
+  double vtan2 = vmag * sqrt_f_phi * cos(theta);
+
+  // update particle velocity
+  v[0] = vperp*norm[0] + vtan1*tangent1[0] + vtan2*tangent2[0];
+  v[1] = vperp*norm[1] + vtan1*tangent1[1] + vtan2*tangent2[1];
+  v[2] = vperp*norm[2] + vtan1*tangent1[2] + vtan2*tangent2[2];
+
+  // p->erot and p->evib stay identical
+}
+
+/* ----------------------------------------------------------------------
+   wrapper on scatter_isotropic() method to perform collision for a
+   single particle
+   pass in 0 coefficients to match command-line args for style adiabatic
+   flags, coeffs can be NULL
+   called by SurfReactAdsorb
+------------------------------------------------------------------------- */
+
+void SurfCollideAdiabatic::wrapper(Particle::OnePart *p, double *norm,
+                                  int *flags, double *coeffs)
+{
+  scatter_isotropic(p,norm);
+}

--- a/src/surf_collide_adiabatic.h
+++ b/src/surf_collide_adiabatic.h
@@ -1,0 +1,57 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef SURF_COLLIDE_CLASS
+
+SurfCollideStyle(adiabatic,SurfCollideAdiabatic)
+
+#else
+
+#ifndef SPARTA_SURF_COLLIDE_ADIABATIC_H
+#define SPARTA_SURF_COLLIDE_ADIABATIC_H
+
+#include "surf_collide.h"
+
+namespace SPARTA_NS {
+
+class SurfCollideAdiabatic : public SurfCollide {
+ public:
+  SurfCollideAdiabatic(class SPARTA *, int, char **);
+  SurfCollideAdiabatic(class SPARTA *sparta) : SurfCollide(sparta) {}
+  ~SurfCollideAdiabatic();
+  Particle::OnePart *collide(Particle::OnePart *&, double &,
+                             int, double *, int, int &);
+  void wrapper(Particle::OnePart *, double *, int *, double*);
+  void flags_and_coeffs(int *, double *) {}
+
+ protected:
+  class RanKnuth *random; // RNG for particle reflection
+
+  void scatter_isotropic(Particle::OnePart *, double *);
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running SPARTA to see the offending line.
+
+*/


### PR DESCRIPTION
## Purpose

This adds a new surface collision model to model adiabatic surfaces. This model was proposed by Mohammadzadeh, Rana, and Struchtrup  [1]. Basically, particles that hit the surface are isotropcially scattered (similar to a diffuse reflection) but their velocity magnitude is conserved. This means that the kinetic energy of the particle remains unchanged and no energy is transferred from or to the surface (adiabatic). Because this is done per particle no iterative procedure is necessary to determine the surface temperature. Note, that due to the isotropic scattering momentum is not conserved, thus still leading to a non-slip condition on the wall.

## Author(s)

Tim Teichmann (ITEP, KIT)

## Backward Compatibility

Optional feature

## Implementation Notes

As discussed by mail this is the first version upon which we can iterate.

Since I have no exp with KOKKOS I have not included a dedicated KOKKOS version for now. I have added two examples in the surf_collide dir, especially the beam example illustrates the isotropic scattering when compared with the specular case.

If you like I can add another example, best would be something like a box filled with particles and adiabatic walls that demonstrates that energy is conserved.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

[1] A. Mohammadzadeh, A. Rana, and H. Struchtrup, "DSMC and R13 modeling of the adiabatic surface", International Journal of Thermal Sciences, vol. 101, pp. 9–23, March (2016), doi: 10.1016/j.ijthermalsci.2015.10.007.

