### PR TITLE
Remove superfluous include in variable.cpp

### DIFF
--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -27,7 +27,6 @@
 #include "modify.h"
 #include "compute.h"
 #include "fix.h"
-#include "grid.h"
 #include "surf.h"
 #include "surf_collide.h"
 #include "surf_react.h"


### PR DESCRIPTION
## Purpose

I think one include is enough ;-)

## Author(s)

Tim Teichmann (ITEP,KIT)

## Backward Compatibility

Yes, compiler fixed this for us anyways.

## Implementation Notes

Trivial


