### PR TITLE
Fix issue with read_restart and surfs

### DIFF
--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -3951,6 +3951,7 @@ void Surf::read_restart(FILE *fp)
     lines = (Line *) memory->smalloc(nsurf*sizeof(Line),"surf:lines");
     // NOTE: need different logic for different surf styles
     nlocal = nsurf;
+    nmax = nlocal;
 
     if (me == 0) {
       for (int i = 0; i < nsurf; i++) {
@@ -3975,6 +3976,7 @@ void Surf::read_restart(FILE *fp)
     tris = (Tri *) memory->smalloc(nsurf*sizeof(Tri),"surf:tris");
     // NOTE: need different logic for different surf styles
     nlocal = nsurf;
+    nmax = nlocal;
 
     if (me == 0) {
       for (int i = 0; i < nsurf; i++) {


### PR DESCRIPTION
## Purpose

Fix issue with read_restart and surfs. The `nmax` variable was not set when a restart file with surfaces was read, which is needed to grow the surfs data structure if more surfaces are added later. It was manifest with a segmentation fault when running with Kokkos.

## Author(s)

Stan Moore (SNL), reproducer from Michael Gallis (SNL)

## Backward Compatibility

Yes