### PR TITLE
Prevent large buffer with global mem/limit option

### DIFF
--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -265,7 +265,7 @@ void ParticleKokkos::sort_kokkos()
       d_sorted = t_particle_1d("particle:sorted",d_particles.extent(0));
     }
     else if (reorder_scheme == FIXEDMEMORY && d_pswap1.size() == 0){
-      nParticlesWksp = (double)update->global_mem_limit/sizeof(Particle::OnePart);
+      nParticlesWksp = MIN(nlocal,(double)update->global_mem_limit/sizeof(Particle::OnePart));
       d_pswap1 = t_particle_1d(Kokkos::view_alloc("particle:swap1",Kokkos::WithoutInitializing),nParticlesWksp);
       d_pswap2 = t_particle_1d(Kokkos::view_alloc("particle:swap2",Kokkos::WithoutInitializing),nParticlesWksp);
     }

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -387,8 +387,9 @@ void ReadRestart::command(int narg, char **arg)
         int nbytes_custom = particle->sizeof_custom();
         int nbytes = nbytes_particle + nbytes_custom;
 
-        int maxbuf_new = MAX(grid_read_size,update->global_mem_limit);
-        maxbuf_new = MAX(maxbuf_new,sizeof(nbytes));
+        int maxbuf_new = MIN(particle_read_size,update->global_mem_limit);
+        maxbuf_new = MAX(maxbuf_new,grid_read_size);
+        maxbuf_new = MAX(maxbuf_new,nbytes);
         maxbuf_new += 128; // extra for size and ROUNDUP(ptr)
         if (maxbuf_new > maxbuf) {
           maxbuf = maxbuf_new;
@@ -398,7 +399,7 @@ void ReadRestart::command(int narg, char **arg)
 
         // number of particles per pass
 
-        step_size = update->global_mem_limit/nbytes;
+        step_size = MIN(particle_nlocal,update->global_mem_limit/nbytes);
 
         // extra pass for grid
 
@@ -527,7 +528,8 @@ void ReadRestart::command(int narg, char **arg)
         int nbytes_custom = particle->sizeof_custom();
         int nbytes = nbytes_particle + nbytes_custom;
 
-        int maxbuf_new = MAX(grid_read_size,update->global_mem_limit);
+        int maxbuf_new = MIN(particle_read_size,update->global_mem_limit);
+        maxbuf_new = MAX(maxbuf_new,grid_read_size);
         maxbuf_new = MAX(maxbuf_new,nbytes);
         maxbuf_new += 128; // extra for size and ROUNDUP(ptr)
         if (maxbuf_new > maxbuf) {
@@ -538,7 +540,7 @@ void ReadRestart::command(int narg, char **arg)
 
         // number of particles per pass
 
-        step_size = update->global_mem_limit/nbytes;
+        step_size = MIN(particle_nlocal,update->global_mem_limit/nbytes);
 
         // extra pass for grid
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -425,7 +425,7 @@ void WriteRestart::write_less_memory(char *file)
 
   // number of particles per pass
 
-  int step_size = update->global_mem_limit/nbytes;
+  int step_size = MIN(particle->nlocal,update->global_mem_limit/nbytes);
 
   // extra pass for grid
 


### PR DESCRIPTION
## Purpose

Limit size of buffer with `global mem/limit` option if chosen value is larger than needed.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes