### PR TITLE
Fix bug in restart when using `global mem/limit` and a proc has no particles

### DIFF
--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -403,8 +403,8 @@ void ReadRestart::command(int narg, char **arg)
 
         // extra pass for grid
 
-        npasses = ceil((double)particle_nlocal/step_size)+1;
         if (particle_nlocal == 0) npasses = 2;
+        else npasses = ceil((double)particle_nlocal/step_size)+1;
 
         int nlocal_restart = 0;
         bigint total_read_part = 0;
@@ -544,8 +544,8 @@ void ReadRestart::command(int narg, char **arg)
 
         // extra pass for grid
 
-        npasses = ceil((double)particle_nlocal/step_size)+1;
         if (particle_nlocal == 0) npasses = 2;
+        else npasses = ceil((double)particle_nlocal/step_size)+1;
 
         if (i % nclusterprocs) {
           iproc = me + (i % nclusterprocs);

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -404,7 +404,7 @@ void ReadRestart::command(int narg, char **arg)
         // extra pass for grid
 
         npasses = ceil((double)particle_nlocal/step_size)+1;
-        if (particle_nlocal == 0) npasses++;
+        if (particle_nlocal == 0) npasses = 2;
 
         int nlocal_restart = 0;
         bigint total_read_part = 0;
@@ -545,7 +545,7 @@ void ReadRestart::command(int narg, char **arg)
         // extra pass for grid
 
         npasses = ceil((double)particle_nlocal/step_size)+1;
-        if (particle_nlocal == 0) npasses++;
+        if (particle_nlocal == 0) npasses = 2;
 
         if (i % nclusterprocs) {
           iproc = me + (i % nclusterprocs);

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -429,8 +429,9 @@ void WriteRestart::write_less_memory(char *file)
 
   // extra pass for grid
 
-  int my_npasses = ceil((double)particle->nlocal/step_size)+1;
+  int my_passes;
   if (particle->nlocal == 0) my_npasses = 2;
+  else my_npasses = ceil((double)particle->nlocal/step_size)+1;
 
   // output of one or more native files
   // filewriter = 1 = this proc writes to file

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -429,7 +429,7 @@ void WriteRestart::write_less_memory(char *file)
 
   // extra pass for grid
 
-  int my_passes;
+  int my_npasses;
   if (particle->nlocal == 0) my_npasses = 2;
   else my_npasses = ceil((double)particle->nlocal/step_size)+1;
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -430,7 +430,7 @@ void WriteRestart::write_less_memory(char *file)
   // extra pass for grid
 
   int my_npasses = ceil((double)particle->nlocal/step_size)+1;
-  if (particle->nlocal == 0) my_npasses++;
+  if (particle->nlocal == 0) my_npasses = 2;
 
   // output of one or more native files
   // filewriter = 1 = this proc writes to file


### PR DESCRIPTION
## Purpose

Fix bug in restart when using `global mem/limit` and a proc has no particles--led to an error when reading the restart file. This bug was introduced by PR #333, which caused a division by `0` when a proc had no particles.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes

## Implementation Notes

