### PR TITLE
Allow global mem/limit command to overwrite value in restart file

### DIFF
--- a/doc/read_restart.txt
+++ b/doc/read_restart.txt
@@ -160,7 +160,10 @@ assuming the continued simulation needs the information.
 Also note that many commands can be used after a restart file is read,
 to override a setting that was stored in the restart file.  For
 example, the "global"_global.html command can be used to reset the
-values of its specified keywords.
+values of its specified keywords. If a global command is used in the
+input file before the restart file is read, then it will be overriden
+by values in the restart file. The only exception is the *mem/limit*
+command, since it affects how the restart file is processed.
 
 In particular, take note of the following issues:
 

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -62,8 +62,8 @@ void ReadRestart::command(int narg, char **arg)
   if (domain->box_exist)
     error->all(FLERR,"Cannot read_restart after simulation box is defined");
 
-  int mem_limit_flag = update->global_mem_limit > 0 ||
-           (update->mem_limit_grid_flag && !grid->nlocal);
+  mem_limit_flag = update->global_mem_limit > 0 ||
+       (update->mem_limit_grid_flag && !grid->nlocal);
 
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
@@ -1049,10 +1049,15 @@ void ReadRestart::header(int incompatible)
     } else if (flag == PARTICLE_REORDER) {
       update->reorder_period = read_int();
     } else if (flag == MEMLIMIT_GRID) {
-      update->mem_limit_grid_flag = read_int();
-    } else if (flag == MEMLIMIT) {
-      update->global_mem_limit = read_int();
+      // ignore value if already set
 
+      if (mem_limit_flag) read_int();
+      else update->mem_limit_grid_flag = read_int();
+    } else if (flag == MEMLIMIT) {
+      // ignore value if already set
+
+      if (mem_limit_flag) read_int();
+      else update->global_mem_limit = read_int();
     } else if (flag == NPARTICLE) {
       nparticle_file = read_bigint();
     } else if (flag == NUNSPLIT) {

--- a/src/read_restart.h
+++ b/src/read_restart.h
@@ -32,7 +32,7 @@ class ReadRestart : protected Pointers {
   void command(int, char **);
 
  private:
-  int me,nprocs,nprocs_file,multiproc_file;
+  int me,nprocs,nprocs_file,multiproc_file,mem_limit_flag;
   FILE *fp;
   int nfix_restart_global,nfix_restart_peratom;
 


### PR DESCRIPTION
## Purpose

If `global mem/limit` is used to read but not write restart file, it can mess up flags and lead to a crash in the code. This PR allows the `global mem/limit` command to overwrite a value in restart file if it is set in the input to avoid this issue.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes