### PR TITLE
Global flow volume tally from surf projections should not include transparent surfs

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -2028,6 +2028,7 @@ void Grid::flow_stats()
 /* ----------------------------------------------------------------------
    compute flow volume for entire box, using list of surfs
    volume for one surf is projection to lower z face (3d) or y face (2d)
+   skip transparent surfs
    NOTE: this does not work if any surfs are clipped to zlo or zhi faces in 3d
          this does not work if any surfs are clipped to ylo or yhi faces in 3d
          need to add contribution due to closing surfs on those faces
@@ -2068,6 +2069,7 @@ double Grid::flow_volume()
 
   if (domain->dimension == 3) {
     for (int i = 0; i < n; i++) {
+      if (tris[i].transparent) continue;
       p1 = tris[i].p1;
       p2 = tris[i].p2;
       p3 = tris[i].p3;
@@ -2088,6 +2090,7 @@ double Grid::flow_volume()
 
   } else if (domain->axisymmetric) {
     for (int i = 0; i < n; i++) {
+      if (lines[i].transparent) continue;
       p1 = lines[i].p1;
       p2 = lines[i].p2;
       volume -=
@@ -2103,6 +2106,7 @@ double Grid::flow_volume()
 
   } else {
     for (int i = 0; i < n; i++) {
+      if (lines[i].transparent) continue;
       p1 = lines[i].p1;
       p2 = lines[i].p2;
       volume -= (0.5*(p1[1]+p2[1]) - boxlo[1]) * (p2[0]-p1[0]);


### PR DESCRIPTION
## Purpose

The diagnostic output of global flow volume is calculated by looping over the projection of all surf elements in the system.
Transparent surfaces should not contribute.  But they were.  This PR removes them from the calculation.

## Author(s)

Steve

## Backward Compatibility

N/A, since I believe it is just a diagnostic output.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


