### PR TITLE
New compute surf options

### DIFF
--- a/doc/compute_reduce.html
+++ b/doc/compute_reduce.html
@@ -19,7 +19,7 @@
 
 <LI>reduce = style name of this compute command 
 
-<LI>mode = <I>sum</I> or <I>min</I> or <I>max</I> or <I>ave</I>  or <I>sumsq</I> or <I>avesq</I> 
+<LI>mode = <I>sum</I> or <I>min</I> or <I>max</I> or <I>ave</I> or <I>sumsq</I> or <I>avesq</I> or (sum-area) or <I>ave-area</I> 
 
 <LI>one or more inputs can be listed 
 
@@ -85,10 +85,22 @@ vector values.  The <I>ave</I> operation adds the vector values into a
 global total, then divides by the number of values in the vector.  The
 <I>sumsq</I> operation sums the square of the values in the vector into a
 global total.  The <I>avesq</I> oepration does the same as <I>sumsq</I>, then
-divdes the sum of squares by the number of values.  The last two
+divdes the sum of squares by the number of values.  These two
 operations can be useful for calculating the variance of some
 quantity, e.g. variance = sumsq - ave^2.
 </P>
+<P>The <I>sum-area</I> or <I>ave-area</I> options can only be used for per-surf
+inputs.  Both options multiply each per-surf value by the area of the
+surface element (triangle in 3d, line segment in 2d) and sum the
+resulting values over all surface elements.  That is the output for
+the <I>sum-area</I> option.  For the <I>ave-area</I> option the summed value is
+divided by the summed area of all elements.  Note that both of these
+options are designed to work with flux values (e.g. mass per area per
+time) produced by the <A HREF = "compute_surf.html">compute surf</A> command with
+its default <I>norm</I> = yes option.
+</P>
+<HR>
+
 <P>Each listed input vector is operated on independently.
 </P>
 <P>Each listed input vector can be a particle attribute or can be the
@@ -187,6 +199,9 @@ the max of the ID vector, which does not yield useful information in
 this context, the <I>replace</I> keyword will extract the ID for the grid
 cell which has the maximum number of particles.  This ID and the
 cell's particle count will be printed with the statistical output.
+</P>
+<P>Note that the <I>replace</I> keyword can be used multiple times with
+different pairs of indices.
 </P>
 <HR>
 

--- a/doc/compute_reduce.txt
+++ b/doc/compute_reduce.txt
@@ -14,7 +14,7 @@ compute ID reduce mode input1 input2 ... keyword args ... :pre
 
 ID is documented in "compute"_compute.html command :ulb,l
 reduce = style name of this compute command :l
-mode = {sum} or {min} or {max} or {ave}  or {sumsq} or {avesq} :l
+mode = {sum} or {min} or {max} or {ave} or {sumsq} or {avesq} or (sum-area) or {ave-area} :l
 one or more inputs can be listed :l
 input = x, y, z, vx, vy, vz, ke, erot, evib, c_ID, c_ID\[N\], f_ID, f_ID\[N\], v_name :l
   x,y,z,vx,vy,vz = particle position or velocity component
@@ -74,9 +74,21 @@ vector values.  The {ave} operation adds the vector values into a
 global total, then divides by the number of values in the vector.  The
 {sumsq} operation sums the square of the values in the vector into a
 global total.  The {avesq} oepration does the same as {sumsq}, then
-divdes the sum of squares by the number of values.  The last two
+divdes the sum of squares by the number of values.  These two
 operations can be useful for calculating the variance of some
 quantity, e.g. variance = sumsq - ave^2.
+
+The {sum-area} or {ave-area} options can only be used for per-surf
+inputs.  Both options multiply each per-surf value by the area of the
+surface element (triangle in 3d, line segment in 2d) and then sum the
+resulting values over all surface elements.  That is the output for
+the {sum-area} option.  For the {ave-area} option the summed value is
+divided by the summed area of all elements.  Note that both of these
+options are designed to work with flux values (e.g. mass per area per
+time) produced by the "compute surf"_compute_surf.html command
+produced with its default {norm} = yes option.
+
+:line
 
 Each listed input vector is operated on independently.
 

--- a/doc/compute_reduce.txt
+++ b/doc/compute_reduce.txt
@@ -80,13 +80,13 @@ quantity, e.g. variance = sumsq - ave^2.
 
 The {sum-area} or {ave-area} options can only be used for per-surf
 inputs.  Both options multiply each per-surf value by the area of the
-surface element (triangle in 3d, line segment in 2d) and then sum the
+surface element (triangle in 3d, line segment in 2d) and sum the
 resulting values over all surface elements.  That is the output for
 the {sum-area} option.  For the {ave-area} option the summed value is
 divided by the summed area of all elements.  Note that both of these
 options are designed to work with flux values (e.g. mass per area per
-time) produced by the "compute surf"_compute_surf.html command
-produced with its default {norm} = yes option.
+time) produced by the "compute surf"_compute_surf.html command with
+its default {norm} = yes option.
 
 :line
 
@@ -188,6 +188,9 @@ the max of the ID vector, which does not yield useful information in
 this context, the {replace} keyword will extract the ID for the grid
 cell which has the maximum number of particles.  This ID and the
 cell's particle count will be printed with the statistical output.
+
+Note that the {replace} keyword can be used multiple times with
+different pairs of indices.
 
 :line
 

--- a/doc/compute_surf.html
+++ b/doc/compute_surf.html
@@ -15,7 +15,7 @@
 </H3>
 <P><B>Syntax:</B>
 </P>
-<PRE>compute ID surf group-ID mix-ID value1 value2 ... 
+<PRE>compute ID surf group-ID mix-ID value1 value2 ... keyword setting ... 
 </PRE>
 <UL><LI>ID is documented in <A HREF = "compute.html">compute</A> command 
 
@@ -42,12 +42,19 @@
   evib = flux of particle vibrational energy on surface element
   etot = flux of particle total energy on surface element 
 </PRE>
+<LI>zero or more keyword/setting pairs can be appended 
+
+<LI>keyword = <I>norm</I> 
+
+<PRE>  norm arg = <I>flux</I> or <I>flow</I> for dividing flux quantities by area or not 
+</PRE>
 
 </UL>
 <P><B>Examples:</B>
 </P>
 <PRE>compute 1 surf all all n press eng
-compute mine surf sphere species press shx shy shz 
+compute mine surf sphere species press shx shy shz
+compute 2 surf all all mflux ke erot norm flow 
 </PRE>
 <P>These commands will dump time averages for each species and each
 surface element to a dump file every 1000 steps:
@@ -98,10 +105,12 @@ contributions from 0, 1, or 2 outgoing particles.  The exception is
 the <I>n</I> and <I>nwt</I> values which simply tally counts of particles
 colliding with the surface element.
 </P>
-<P>If the surface element is transparent, the particle will pass through
-the surface unaltered.  The flux of particle count, mass, or energy to
-the surface can still be tallied by this compute.  See details on
-transparent surface elements below.
+<P>If the explicit surface element is transparent, the particle will pass
+through the surface unaltered.  See the transparent keyword for the
+<A HREF = "read_surf.html">read_surf</A> command.  The count of particles going
+through the surfacce as well as their mass or energy fluxes can still
+be tallied by this compute.  See details on transparent surface
+elements below.
 </P>
 <P>Also note that all values for a collision are tallied based on the
 species group of the incident particle.  Quantities associated with
@@ -153,6 +162,11 @@ A = the area of the surface element, dt = the timestep, and fnum = the
 real/simulated particle ratio set by the <A HREF = "global.html">global fnum</A>
 command.
 </P>
+<P>If the optional <I>norm</I> key is set to <I>flow</I>, then the area A is not
+included in the Nflux formula.  The Nflux quantity becomes effectively
+a particle flow rate (count per time).  See discussion of the <I>norm</I>
+keyword below.
+</P>
 <P>The <I>mflux</I> value calculates the mass flux imparted to the surface
 element by particles in the group.  This is computed as
 </P>
@@ -160,6 +174,11 @@ element by particles in the group.  This is computed as
 </PRE>
 <P>where the sum is over all contributing particle masses, normalized by
 the area of the surface element, dt and fnum as defined before.
+</P>
+<P>If the optional <I>norm</I> key is set to <I>flow</I>, then the area A is not
+included in the Nflux formula.  Then Mflux quantity becomes
+effectively a mass flow rate (mass per time).  See discussion of the
+<I>norm</I> keyword below.
 </P>
 <P>The <I>fx</I>, <I>fy</I>, <I>fz</I> values calculate the components of force extered
 on the surface element by particles in the group, with respect to the
@@ -233,6 +252,11 @@ over all contributing e_delta, normalized by A = the area of the
 surface element and dt = the timestep and fnum = the real/simulated
 particle ratio set by the <A HREF = "global.html">global fnum</A> command.
 </P>
+<P>If the optional <I>norm</I> key is set to <I>flow</I>, then the area A is not
+included in the Eflux formula.  Then Eflux quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the <I>norm</I> keyword below.
+</P>
 <P>The <I>erot</I> value calculates the rotational energy flux <I>Eflux</I>
 imparted to the surface element by particles in the group, such that
 energy lost by a particle is a positive flux.  This is computed as
@@ -244,6 +268,11 @@ Eflux = - Sum_i (e_delta) / (A * dt / fnum)
 internal rotational energy changes from Erot_pre to Erot_post when
 colliding with the surface element.  The flux equation is the same as
 for the <I>ke</I> value.
+</P>
+<P>If the optional <I>norm</I> key is set to <I>flow</I>, then the area A is not
+included in the Eflux formula.  Then Eflux quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the <I>norm</I> keyword below.
 </P>
 <P>The <I>evib</I> value calculates the vibrational energy flux <I>Eflux</I>
 imparted to the surface element by particles in the group, such that
@@ -257,11 +286,21 @@ internal vibrational energy changes from Evib_pre to Evib_post when
 colliding with the surface element.  The flux equation is the same as
 for the <I>ke</I> value.
 </P>
+<P>If the optional <I>norm</I> key is set to <I>flow</I>, then the area A is not
+included in the Eflux formula.  Then Eflux quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the <I>norm</I> keyword below.
+</P>
 <P>The <I>etot</I> value calculates the total energy flux imparted to the
 surface element by particles in the group, such that energy lost by a
 particle is a positive flux.  This is simply the sum of kinetic,
 rotational, and vibrational energies.  Thus the total energy flux is
 the sum of what is computed by the <I>ke</I>, <I>erot</I>, and <I>evib</I> values.
+</P>
+<P>If the optional <I>norm</I> key is set to <I>flow</I>, then the area A is not
+included in the <I>etot</I> formula.  Then <I>etot</I> quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the <I>norm</I> keyword below.
 </P>
 <HR>
 
@@ -273,21 +312,58 @@ transparent surface elements.  The <A HREF = "Section_howto.html#howto_15">Secti
 transparent surfaces and how to create them.
 </P>
 <P>The <I>n</I> and <I>nwt</I> value are calculated the same for transparent
-surfaces.  I.e. they are the count and weighted count of particles
-passing through the surface.
+surfaces as for non-transparent.  I.e. they are the count and weighted
+count of particles passing through the surface.
 </P>
-<P>The <I>mflux</I>, <I>ke</I>, <I>erot</I>. <I>evib</I>, and <I>etot</I> values are fluxes.  For
-transparent surfaces, they are calculated for the incident particle as
-if they had struck the surface.  The outgoing particle is ignored.
-This means the tally quantity is the flux of particles onto the
-outward face of the surface.  No tallying is done for particles
-hitting the inward face of the surface.  See <A HREF = "Section_howto.html#howto_15">Section
-6.15</A> for how to do tallying in both
-directions.
+<P>The <I>nflux</I>, <I>mflux</I>, <I>ke</I>, <I>erot</I>. <I>evib</I>, and <I>etot</I> values are
+fluxes.  For transparent surfaces, they are calculated only for the
+incident particle as if it had struck the surface.  The outgoing
+particle is ignored.  This means the tally quantity is the flux of
+particles onto the outward face of the surface.  No tallying is done
+for particles hitting the inward face of the transparent surface.  See
+<A HREF = "Section_howto.html#howto_15">Section 6.15</A> for how to do tallying in
+both directions.
 </P>
 <P>All the other values are calculated as described above.  This means
-they will be zero, since the incident particle and outgoing particle
-have the same mass and velocity.
+they will be zero, since the incident and outgoing particle have the
+same mass and velocity.
+</P>
+<P>IMPORTANT NOTE:
+</P>
+<P>Transparent surface elements can intersect standard non-transparent
+surface elements.  For example, to model flow around a spherical
+object, the sphere would be defined by the usual non-transparent
+triangles which interact with flow particles.  A plane of transparent
+surface elements normal to the flow direction could be defined which
+cut through the sphere.  In this case some or all of the transparent
+triangles will be partially or wholly inside the sphere.  SPARTA does
+not attempt to calculate the portion of a tranparent triangle (or line
+segment in 2d) which is inside the flow volume.  The "area" specified
+in all the formulas above will be the area of the entire transparent
+triangle (or line segment in 2d), which may or may not be what you
+want.
+</P>
+<P>See the optional norm keyword (below) to calculate flux values
+un-normalized by the surface element area.  Also see the "sum-area"
+and "ave-area" modes of the <A HREF = "compute_reduce.html">compute reduce</A>
+command for additional ways to sum or average either normalized or
+un-normalized flux values produced by this compute.
+</P>
+<HR>
+
+<P><B>Optional norm keyword:</B>
+</P>
+<P>If the <I>norm</I> keyword is used with a setting of <I>flow</I>, then the
+formulas above for all flux values will not use the surface element
+area A in the denominator.  Specifically these values are nflux,
+mflux, ke, erot, evib, etot.
+</P>
+<P>The formulas thus compute the aggregate mass or energy flow to the
+surface (e.g. mass per time), not the flux (e.g. mass per area per
+time).
+</P>
+<P>If the setting is <I>flux</I> (the default), then the flux formulas will be
+calculated as shown with the area A in the denominator.
 </P>
 <HR>
 
@@ -346,6 +422,8 @@ effectively.
 <P><A HREF = "fix_ave_surf.html">fix ave/surf</A>, <A HREF = "dump.html">dump surf</A>, <A HREF = "compute_isurf_grid.html">compute
 isurf/grid</A>
 </P>
-<P><B>Default:</B> none
+<P><B>Default:</B>
+</P>
+<P>The default for the norm keyword is flux.
 </P>
 </HTML>

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -11,7 +11,7 @@ compute surf/kk command :h3
 
 [Syntax:]
 
-compute ID surf group-ID mix-ID value1 value2 ... :pre
+compute ID surf group-ID mix-ID value1 value2 ... keyword setting ... :pre
 
 ID is documented in "compute"_compute.html command :ulb,l
 surf = style name of this compute command :l
@@ -31,12 +31,16 @@ value = {n} or {nwt} or {nflux} or {mflux} or {fx} or {fy} or {fz} or {press} or
   erot = flux of particle rotational energy on surface element
   evib = flux of particle vibrational energy on surface element
   etot = flux of particle total energy on surface element :pre
+zero or more keyword/setting pairs can be appended :l
+keyword = {norm} :l
+  norm arg = {yes} or {no} for dividing fluxes by area :pre
 :ule
 
 [Examples:]
 
 compute 1 surf all all n press eng
-compute mine surf sphere species press shx shy shz :pre
+compute mine surf sphere species press shx shy shz
+compute 2 surf all all mflux ke erot norm no :pre
 
 These commands will dump time averages for each species and each
 surface element to a dump file every 1000 steps:
@@ -87,10 +91,12 @@ contributions from 0, 1, or 2 outgoing particles.  The exception is
 the {n} and {nwt} values which simply tally counts of particles
 colliding with the surface element.
 
-If the surface element is transparent, the particle will pass through
-the surface unaltered.  The flux of particle count, mass, or energy to
-the surface can still be tallied by this compute.  See details on
-transparent surface elements below.
+If the explicit surface element is transparent, the particle will pass
+through the surface unaltered.  See the transparent keyword for the
+"read_surf"_read_surf.html command.  The count of particles going
+through the surfacce as well as their mass or energy fluxes can still
+be tallied by this compute.  See details on transparent surface
+elements below.
 
 Also note that all values for a collision are tallied based on the
 species group of the incident particle.  Quantities associated with
@@ -142,6 +148,11 @@ A = the area of the surface element, dt = the timestep, and fnum = the
 real/simulated particle ratio set by the "global fnum"_global.html
 command.
 
+If the optional {norm} key is set to {no}, then the area A is not
+included in the Nflux formula.  Then Nflux becomes effectively a
+particle flow rate (count per time).  See discussion of the {norm}
+keyword below.
+
 The {mflux} value calculates the mass flux imparted to the surface
 element by particles in the group.  This is computed as
 
@@ -149,6 +160,11 @@ Mflux = Sum_i (mass_i) / (A * dt / fnum) :pre
 
 where the sum is over all contributing particle masses, normalized by
 the area of the surface element, dt and fnum as defined before.
+
+If the optional {norm} key is set to {no}, then the area A is not
+included in the Nflux formula.  Then Mflux becomes effectively a
+mass flow rate (mass per time).  See discussion of the {norm}
+keyword below.
 
 The {fx}, {fy}, {fz} values calculate the components of force extered
 on the surface element by particles in the group, with respect to the
@@ -222,6 +238,11 @@ over all contributing e_delta, normalized by A = the area of the
 surface element and dt = the timestep and fnum = the real/simulated
 particle ratio set by the "global fnum"_global.html command.
 
+If the optional {norm} key is set to {no}, then the area A is not
+included in the Eflux formula.  Then Eflux becomes effectively an
+energy flow rate (energy per time).  See discussion of the {norm}
+keyword below.
+
 The {erot} value calculates the rotational energy flux {Eflux}
 imparted to the surface element by particles in the group, such that
 energy lost by a particle is a positive flux.  This is computed as
@@ -233,6 +254,11 @@ where e_delta is the rotational energy change in a particle, whose
 internal rotational energy changes from Erot_pre to Erot_post when
 colliding with the surface element.  The flux equation is the same as
 for the {ke} value.
+
+If the optional {norm} key is set to {no}, then the area A is not
+included in the Eflux formula.  Then Eflux becomes effectively an
+energy flow rate (energy per time).  See discussion of the {norm}
+keyword below.
 
 The {evib} value calculates the vibrational energy flux {Eflux}
 imparted to the surface element by particles in the group, such that
@@ -246,11 +272,21 @@ internal vibrational energy changes from Evib_pre to Evib_post when
 colliding with the surface element.  The flux equation is the same as
 for the {ke} value.
 
+If the optional {norm} key is set to {no}, then the area A is not
+included in the Eflux formula.  Then Eflux becomes effectively an
+energy flow rate (energy per time).  See discussion of the {norm}
+keyword below.
+
 The {etot} value calculates the total energy flux imparted to the
 surface element by particles in the group, such that energy lost by a
 particle is a positive flux.  This is simply the sum of kinetic,
 rotational, and vibrational energies.  Thus the total energy flux is
 the sum of what is computed by the {ke}, {erot}, and {evib} values.
+
+If the optional {norm} key is set to {no}, then the area A is not
+included in the {etot} formula.  Then {etot} becomes effectively an
+energy flow rate (energy per time).  See discussion of the {norm}
+keyword below.
 
 :line
 
@@ -262,21 +298,58 @@ transparent surface elements.  The "Section
 transparent surfaces and how to create them.
 
 The {n} and {nwt} value are calculated the same for transparent
-surfaces.  I.e. they are the count and weighted count of particles
-passing through the surface.
+surfaces as for non-transparent.  I.e. they are the count and weighted
+count of particles passing through the surface.
 
-The {mflux}, {ke}, {erot}. {evib}, and {etot} values are fluxes.  For
-transparent surfaces, they are calculated for the incident particle as
-if they had struck the surface.  The outgoing particle is ignored.
-This means the tally quantity is the flux of particles onto the
-outward face of the surface.  No tallying is done for particles
-hitting the inward face of the surface.  See "Section
-6.15"_Section_howto.html#howto_15 for how to do tallying in both
-directions.
+The {nflux}, {mflux}, {ke}, {erot}. {evib}, and {etot} values are
+fluxes.  For transparent surfaces, they are calculated only for the
+incident particle as if it had struck the surface.  The outgoing
+particle is ignored.  This means the tally quantity is the flux of
+particles onto the outward face of the surface.  No tallying is done
+for particles hitting the inward face of the transparent surface.  See
+"Section 6.15"_Section_howto.html#howto_15 for how to do tallying in
+both directions.
 
 All the other values are calculated as described above.  This means
-they will be zero, since the incident particle and outgoing particle
-have the same mass and velocity.
+they will be zero, since the incident and outgoing particle have the
+same mass and velocity.
+
+IMPORTANT NOTE:
+
+Transparent surface elements can intersect standard non-transparent
+surface elements.  For example, to model flow around a spherical
+object, the sphere would be defined by the usual non-transparent
+triangles which interact with flow particles.  A plane of transparent
+surface elements normal to the flow direction could be defined which
+cut through the sphere.  In this case some or all of the transparent
+triangles will be partially or wholly inside the sphere.  SPARTA does
+not attempt to calculate the portion of a tranparent triangle (or line
+segment in 2d) which is inside the flow volume.  The "area" specified
+in all the formulas above will be the area of the entire transparent
+triangle (or line segment in 2d), which may or may not be what you
+want.
+
+See the optional norm keyword (below) to calculate flux values
+un-normalized by the surface element area.  Also see the "sum-area"
+and "ave-area" modes of the "compute reduce"_compute_reduce.html
+command for additional ways to sum or average either normalized or
+un-normalized flux values produced by this compute.
+
+:line
+
+[Optional norm keyword:]
+
+If the {norm} keyword is used with a setting of {no}, then the
+formulas above for all flux values will not use the surface element
+area A in the denominator.  Specifically these values are nflux,
+mflux, ke, erot, evib, etot.
+
+The formulas thus compute the aggregate mass or energy flow to the
+surface (e.g. mass per time), not the flux (e.g. mass per area per
+time).
+
+If the setting is {yes}, then the flux formulas will be calculated as
+shown with the area A in the denominator.
 
 :line
 
@@ -335,4 +408,6 @@ effectively.
 "fix ave/surf"_fix_ave_surf.html, "dump surf"_dump.html, "compute
 isurf/grid"_compute_isurf_grid.html
 
-[Default:] none
+[Default:]
+
+The default for keyword flux is yes.

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -33,14 +33,14 @@ value = {n} or {nwt} or {nflux} or {mflux} or {fx} or {fy} or {fz} or {press} or
   etot = flux of particle total energy on surface element :pre
 zero or more keyword/setting pairs can be appended :l
 keyword = {norm} :l
-  norm arg = {yes} or {no} for dividing fluxes by area :pre
+  norm arg = {flux} or {flow} for dividing flux quantities by area or not :pre
 :ule
 
 [Examples:]
 
 compute 1 surf all all n press eng
 compute mine surf sphere species press shx shy shz
-compute 2 surf all all mflux ke erot norm no :pre
+compute 2 surf all all mflux ke erot norm flow :pre
 
 These commands will dump time averages for each species and each
 surface element to a dump file every 1000 steps:
@@ -148,9 +148,9 @@ A = the area of the surface element, dt = the timestep, and fnum = the
 real/simulated particle ratio set by the "global fnum"_global.html
 command.
 
-If the optional {norm} key is set to {no}, then the area A is not
-included in the Nflux formula.  Then Nflux becomes effectively a
-particle flow rate (count per time).  See discussion of the {norm}
+If the optional {norm} key is set to {flow}, then the area A is not
+included in the Nflux formula.  The Nflux quantity becomes effectively
+a particle flow rate (count per time).  See discussion of the {norm}
 keyword below.
 
 The {mflux} value calculates the mass flux imparted to the surface
@@ -161,10 +161,10 @@ Mflux = Sum_i (mass_i) / (A * dt / fnum) :pre
 where the sum is over all contributing particle masses, normalized by
 the area of the surface element, dt and fnum as defined before.
 
-If the optional {norm} key is set to {no}, then the area A is not
-included in the Nflux formula.  Then Mflux becomes effectively a
-mass flow rate (mass per time).  See discussion of the {norm}
-keyword below.
+If the optional {norm} key is set to {flow}, then the area A is not
+included in the Nflux formula.  Then Mflux quantity becomes
+effectively a mass flow rate (mass per time).  See discussion of the
+{norm} keyword below.
 
 The {fx}, {fy}, {fz} values calculate the components of force extered
 on the surface element by particles in the group, with respect to the
@@ -238,10 +238,10 @@ over all contributing e_delta, normalized by A = the area of the
 surface element and dt = the timestep and fnum = the real/simulated
 particle ratio set by the "global fnum"_global.html command.
 
-If the optional {norm} key is set to {no}, then the area A is not
-included in the Eflux formula.  Then Eflux becomes effectively an
-energy flow rate (energy per time).  See discussion of the {norm}
-keyword below.
+If the optional {norm} key is set to {flow}, then the area A is not
+included in the Eflux formula.  Then Eflux quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the {norm} keyword below.
 
 The {erot} value calculates the rotational energy flux {Eflux}
 imparted to the surface element by particles in the group, such that
@@ -255,10 +255,10 @@ internal rotational energy changes from Erot_pre to Erot_post when
 colliding with the surface element.  The flux equation is the same as
 for the {ke} value.
 
-If the optional {norm} key is set to {no}, then the area A is not
-included in the Eflux formula.  Then Eflux becomes effectively an
-energy flow rate (energy per time).  See discussion of the {norm}
-keyword below.
+If the optional {norm} key is set to {flow}, then the area A is not
+included in the Eflux formula.  Then Eflux quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the {norm} keyword below.
 
 The {evib} value calculates the vibrational energy flux {Eflux}
 imparted to the surface element by particles in the group, such that
@@ -272,10 +272,10 @@ internal vibrational energy changes from Evib_pre to Evib_post when
 colliding with the surface element.  The flux equation is the same as
 for the {ke} value.
 
-If the optional {norm} key is set to {no}, then the area A is not
-included in the Eflux formula.  Then Eflux becomes effectively an
-energy flow rate (energy per time).  See discussion of the {norm}
-keyword below.
+If the optional {norm} key is set to {flow}, then the area A is not
+included in the Eflux formula.  Then Eflux quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the {norm} keyword below.
 
 The {etot} value calculates the total energy flux imparted to the
 surface element by particles in the group, such that energy lost by a
@@ -283,10 +283,10 @@ particle is a positive flux.  This is simply the sum of kinetic,
 rotational, and vibrational energies.  Thus the total energy flux is
 the sum of what is computed by the {ke}, {erot}, and {evib} values.
 
-If the optional {norm} key is set to {no}, then the area A is not
-included in the {etot} formula.  Then {etot} becomes effectively an
-energy flow rate (energy per time).  See discussion of the {norm}
-keyword below.
+If the optional {norm} key is set to {flow}, then the area A is not
+included in the {etot} formula.  Then {etot} quantity becomes
+effectively an energy flow rate (energy per time).  See discussion of
+the {norm} keyword below.
 
 :line
 
@@ -339,7 +339,7 @@ un-normalized flux values produced by this compute.
 
 [Optional norm keyword:]
 
-If the {norm} keyword is used with a setting of {no}, then the
+If the {norm} keyword is used with a setting of {flow}, then the
 formulas above for all flux values will not use the surface element
 area A in the denominator.  Specifically these values are nflux,
 mflux, ke, erot, evib, etot.
@@ -348,8 +348,8 @@ The formulas thus compute the aggregate mass or energy flow to the
 surface (e.g. mass per time), not the flux (e.g. mass per area per
 time).
 
-If the setting is {yes}, then the flux formulas will be calculated as
-shown with the area A in the denominator.
+If the setting is {flux} (the default), then the flux formulas will be
+calculated as shown with the area A in the denominator.
 
 :line
 
@@ -410,4 +410,4 @@ isurf/grid"_compute_isurf_grid.html
 
 [Default:]
 
-The default for keyword flux is yes.
+The default for the norm keyword is flux.

--- a/doc/mixture.html
+++ b/doc/mixture.html
@@ -124,22 +124,24 @@ the streaming velocity.  Particles created using the mixture will use
 the specified <I>Vx,Vy,Vz</I> values.
 </P>
 <P>The <I>temp</I> keyword sets a global attribute of the mixture, namely the
-thermal temperature of its particles.  When particles are created,
-this value is used to sample a Gaussian velocity distribution, which
-is superposed on the streaming velocity, when each particle's velocity
-is initialized.
+thermal temperature of its particles.  It must be a value >= zero.
+When particles are created, this value is used to sample a Gaussian
+velocity distribution, which is superposed on the streaming velocity,
+when each particle's velocity is initialized.
 </P>
 <P>The <I>trot</I> keyword sets a global attribute of the mixture, namely the
-rotational temperature of its particles.  When particles are created,
-this value is used to sample a Gaussian energy distribution to define
-each particle's rotational energy.  If this keyword is not specified,
-the thermal temperature is used as the default.
+rotational temperature of its particles.  It must be a value >= zero.
+When particles are created, this value is used to sample a Gaussian
+energy distribution to define each particle's rotational energy.  If
+this keyword is not specified, the thermal temperature is used as the
+default.
 </P>
 <P>The <I>tvig</I> keyword sets a global attribute of the mixture, namely the
-vibrational temperature of its particles.  When particles are created,
-this value is used to sample a Gaussian energy distribution to define
-each particle's vibrational energy.  If this keyword is not specified,
-the thermal temperature is used as the default.
+vibrational temperature of its particles.  It must be a value >= zero.
+When particles are created, this value is used to sample a Gaussian
+energy distribution to define each particle's vibrational energy.  If
+this keyword is not specified, the thermal temperature is used as the
+default.
 </P>
 <HR>
 

--- a/doc/mixture.txt
+++ b/doc/mixture.txt
@@ -116,22 +116,24 @@ the streaming velocity.  Particles created using the mixture will use
 the specified {Vx,Vy,Vz} values.
 
 The {temp} keyword sets a global attribute of the mixture, namely the
-thermal temperature of its particles.  When particles are created,
-this value is used to sample a Gaussian velocity distribution, which
-is superposed on the streaming velocity, when each particle's velocity
-is initialized.
+thermal temperature of its particles.  It must be a value >= zero.
+When particles are created, this value is used to sample a Gaussian
+velocity distribution, which is superposed on the streaming velocity,
+when each particle's velocity is initialized.
 
 The {trot} keyword sets a global attribute of the mixture, namely the
-rotational temperature of its particles.  When particles are created,
-this value is used to sample a Gaussian energy distribution to define
-each particle's rotational energy.  If this keyword is not specified,
-the thermal temperature is used as the default.
+rotational temperature of its particles.  It must be a value >= zero.
+When particles are created, this value is used to sample a Gaussian
+energy distribution to define each particle's rotational energy.  If
+this keyword is not specified, the thermal temperature is used as the
+default.
 
 The {tvig} keyword sets a global attribute of the mixture, namely the
-vibrational temperature of its particles.  When particles are created,
-this value is used to sample a Gaussian energy distribution to define
-each particle's vibrational energy.  If this keyword is not specified,
-the thermal temperature is used as the default.
+vibrational temperature of its particles.  It must be a value >= zero.
+When particles are created, this value is used to sample a Gaussian
+energy distribution to define each particle's vibrational energy.  If
+this keyword is not specified, the thermal temperature is used as the
+default.
 
 :line
 

--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -21,7 +21,8 @@
 
 <LI>args = arguments for specific style 
 
-<PRE>  <I>specular</I> or <I>specular/kk</I> args = none
+<PRE>  <I>specular</I> or <I>specular/kk</I> args = noslip (optional)
+    noslip = reflect all velocity components off surface (not just normal component)
   <I>diffuse</I> or <I>diffuse/kk</I> args = Tsurf acc
     Tsurf = temperature of surface (temperature units)
             Tsurf can be a variable (see below)
@@ -128,6 +129,13 @@ requires no arguments.  Specular reflection means that a particle
 reflects off a surface element with its incident velocity vector
 reversed with respect to the outward normal of the surface element.
 The particle's speed is unchanged.
+</P>
+<P>Specular reflection means that a particle bounce off a surface element
+reverses only the component of its velocity normal to the surface. If
+the optional <I>noslip</I> keyword is used, the particle bounce flips the sign
+of all 3 xyz components of the particle's incident velocity, so that it
+now moves in the opposite direction, creating a no slip boundary condition.
+In either case, the particle's speed is unchanged.
 </P>
 <HR>
 

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -367,6 +367,8 @@ void ComputeReduce::init()
 
   if (flavor[0] == SURF) area_total = area_per_surf();
 
+  printf("AREATOTAL %g\n",area_total);
+
   // set indices of all computes,fixes,variables
 
   for (int m = 0; m < nvalues; m++) {
@@ -400,8 +402,9 @@ double ComputeReduce::compute_scalar()
 
   double one = compute_one(0,-1);
 
-  if (mode == SUM || mode == SUMSQ || SUMAREA) {
+  if (mode == SUM || mode == SUMSQ || mode == SUMAREA) {
     MPI_Allreduce(&one,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
+    printf("COMP SCALAR %g %g\n",one,scalar);
   } else if (mode == MINN) {
     MPI_Allreduce(&one,&scalar,1,MPI_DOUBLE,MPI_MIN,world);
   } else if (mode == MAXX) {
@@ -927,6 +930,8 @@ double ComputeReduce::area_per_surf()
       }
     } else {
       if (!distributed) {
+        printf("AREAPERSURF i %d flag %d mode %d\n",
+               i,tris[me+i*nprocs].mask & surfgroupbit,mode);
         if (!(tris[me+i*nprocs].mask & surfgroupbit)) continue;
         if (mode == SUMAREA || mode == AVEAREA)
           areasurf[i] = surf->tri_size(&tris[me+i*nprocs],tmp);
@@ -939,7 +944,9 @@ double ComputeReduce::area_per_surf()
       }
     }
 
+
     area_mine += areasurf[i];
+    printf("AREAMINE %g\n",area_mine);
   }
 
   MPI_Allreduce(&area_mine,&area_all,1,MPI_DOUBLE,MPI_SUM,world);

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -30,7 +30,7 @@
 
 using namespace SPARTA_NS;
 
-enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ};
+enum{SUM,SUMSQ,MINN,MAXX,AVE,AVESQ,SUMAREA,AVEAREA};
 enum{X,V,KE,EROT,EVIB,COMPUTE,FIX,VARIABLE};
 enum{PARTICLE,GRID,SURF};
 
@@ -53,6 +53,8 @@ ComputeReduce::ComputeReduce(SPARTA *spa, int narg, char **arg) :
   else if (strcmp(arg[2],"max") == 0) mode = MAXX;
   else if (strcmp(arg[2],"ave") == 0) mode = AVE;
   else if (strcmp(arg[2],"avesq") == 0) mode = AVESQ;
+  else if (strcmp(arg[2],"sum-area") == 0) mode = SUMAREA;
+  else if (strcmp(arg[2],"ave-area") == 0) mode = AVEAREA;
   else error->all(FLERR,"Illegal compute reduce command");
 
   MPI_Comm_rank(world,&me);
@@ -286,6 +288,11 @@ ComputeReduce::ComputeReduce(SPARTA *spa, int narg, char **arg) :
                  "particle, grid, or surf values");
   }
 
+  // require per-surf values for SUMAREA or AVEAREA
+
+  if ((mode == SUMAREA || mode == AVEAREA) && (flavor[0] != SURF))
+    error->all(FLERR,"Compure reduce sum-area/ave-area require surf values");
+
   // this compute produces either a scalar or vector
 
   if (nvalues == 1) {
@@ -303,6 +310,7 @@ ComputeReduce::ComputeReduce(SPARTA *spa, int narg, char **arg) :
 
   maxparticle = maxgrid = 0;
   varparticle = vargrid = NULL;
+  areasurf = NULL;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -326,6 +334,7 @@ ComputeReduce::~ComputeReduce()
 
   memory->destroy(varparticle);
   memory->destroy(vargrid);
+  memory->destroy(areasurf);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -352,6 +361,11 @@ void ComputeReduce::init()
       surfgroupbit = surf->bitmask[igroup];
     }
   }
+
+  // flavor = SURF, pre-compute area of all surfs
+  // if mode != SUMAREA or AVEAREA, area not computed, just set to 1.0
+
+  if (flavor[0] == SURF) area_total = area_per_surf();
 
   // set indices of all computes,fixes,variables
 
@@ -386,7 +400,7 @@ double ComputeReduce::compute_scalar()
 
   double one = compute_one(0,-1);
 
-  if (mode == SUM || mode == SUMSQ) {
+  if (mode == SUM || mode == SUMSQ || SUMAREA) {
     MPI_Allreduce(&one,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
   } else if (mode == MINN) {
     MPI_Allreduce(&one,&scalar,1,MPI_DOUBLE,MPI_MIN,world);
@@ -396,6 +410,9 @@ double ComputeReduce::compute_scalar()
     MPI_Allreduce(&one,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
     bigint n = count_included();
     if (n) scalar /= n;
+  } else if (mode == AVEAREA) {
+    MPI_Allreduce(&one,&scalar,1,MPI_DOUBLE,MPI_SUM,world);
+    if (area_total > 0.0) scalar /= area_total;
   }
 
   return scalar;
@@ -413,7 +430,7 @@ void ComputeReduce::compute_vector()
       indices[m] = index;
     }
 
-  if (mode == SUM || mode == SUMSQ) {
+  if (mode == SUM || mode == SUMSQ || mode == SUMAREA) {
     for (int m = 0; m < nvalues; m++)
       MPI_Allreduce(&onevec[m],&vector[m],1,MPI_DOUBLE,MPI_SUM,world);
 
@@ -466,6 +483,12 @@ void ComputeReduce::compute_vector()
     for (int m = 0; m < nvalues; m++) {
       MPI_Allreduce(&onevec[m],&vector[m],1,MPI_DOUBLE,MPI_SUM,world);
       if (n) vector[m] /= n;
+    }
+
+  } else if (mode == AVEAREA) {
+    for (int m = 0; m < nvalues; m++) {
+      MPI_Allreduce(&onevec[m],&vector[m],1,MPI_DOUBLE,MPI_SUM,world);
+      if (area_total > 0.0) vector[m] /= area_total;
     }
   }
 }
@@ -726,7 +749,7 @@ double ComputeReduce::compute_one(int m, int flag)
               }
             }
 
-            combine(one,fvec[i],i);
+            combine(one,areasurf[i]*fvec[i],i);
           }
         } else one = fvec[flag];
 
@@ -763,7 +786,7 @@ double ComputeReduce::compute_one(int m, int flag)
               }
             }
 
-            combine(one,farray[i][aidxm1],i);
+            combine(one,areasurf[i]*farray[i][aidxm1],i);
           }
         } else one = farray[flag][aidxm1];
       }
@@ -871,6 +894,58 @@ bigint ComputeReduce::count_included()
   return ncountall;
 }
 
+/* ---------------------------------------------------------------------- */
+
+double ComputeReduce::area_per_surf()
+{
+  double area_mine,area_all,tmp;
+
+  int dimension = domain->dimension;
+  Surf::Line *lines = surf->lines;
+  Surf::Line *mylines = surf->mylines;
+  Surf::Tri *tris = surf->tris;
+  Surf::Tri *mytris = surf->mytris;
+  int distributed = surf->distributed;
+  int n = surf->nown;
+    
+  memory->destroy(areasurf);
+  memory->create(areasurf,n,"reduce:areasurf");
+
+  area_mine = 0.0;
+  for (int i = 0; i < n; i++) {
+    if (dimension == 2) {
+      if (!distributed) {
+        if (!(lines[me+i*nprocs].mask & surfgroupbit)) continue;
+        if (mode == SUMAREA || mode == AVEAREA)
+          areasurf[i] = surf->line_size(&lines[me+i*nprocs]);
+        else areasurf[i] = 1.0;
+      } else {
+        if (!(mylines[i].mask & surfgroupbit)) continue;
+        if (mode == SUMAREA || mode == AVEAREA)
+          areasurf[i] = surf->line_size(&mylines[i]);
+        else areasurf[i] = 1.0;
+      }
+    } else {
+      if (!distributed) {
+        if (!(tris[me+i*nprocs].mask & surfgroupbit)) continue;
+        if (mode == SUMAREA || mode == AVEAREA)
+          areasurf[i] = surf->tri_size(&tris[me+i*nprocs],tmp);
+        else areasurf[i] = 1.0;
+      } else {
+        if (!(mytris[i].mask & surfgroupbit)) continue;
+        if (mode == SUMAREA || mode == AVEAREA)
+          areasurf[i] = surf->tri_size(&mytris[i],tmp);
+        else areasurf[i] = 1.0;
+      }
+    }
+
+    area_mine += areasurf[i];
+  }
+
+  MPI_Allreduce(&area_mine,&area_all,1,MPI_DOUBLE,MPI_SUM,world);
+  return area_all;
+}
+
 /* ----------------------------------------------------------------------
    combine two values according to reduction mode
    for MIN/MAX, also update index with winner
@@ -890,7 +965,7 @@ void ComputeReduce::combine(double &one, double two, int i)
       one = two;
       index = i;
     }
-  }
+  } else if (mode == SUMAREA || mode == AVEAREA) one += two;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/compute_reduce.h
+++ b/src/compute_reduce.h
@@ -37,6 +37,7 @@ class ComputeReduce : public Compute {
  protected:
   int me,nprocs;
   int mode,nvalues,iregion;
+  double area_total;
   int *which,*argindex,*flavor,*value2index;
   char **ids;
   double *onevec;
@@ -50,6 +51,7 @@ class ComputeReduce : public Compute {
 
   int maxparticle,maxgrid;
   double *varparticle,*vargrid;
+  double *areasurf;
 
   struct Pair {
     double value;
@@ -59,6 +61,7 @@ class ComputeReduce : public Compute {
 
   double compute_one(int, int);
   bigint count_included();
+  double area_per_surf();
   void combine(double &, double, int);
 };
 

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -316,6 +316,7 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
     switch (which[m]) {
     case NUM:
       vec[k++] += 1.0;
+      printf("COUNT %g\n",vec[k-1]);
       break;
     case NUMWT:
       vec[k++] += weight;
@@ -330,6 +331,7 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
       break;
     case MFLUX:
       vec[k] += origmass * fluxscale;
+      printf("MFLUX %g\n",vec[k-1]);
       if (!transparent) {
         if (ip) vec[k] -= imass * fluxscale;
         if (jp) vec[k] -= jmass * fluxscale;

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -85,8 +85,8 @@ ComputeSurf::ComputeSurf(SPARTA *sparta, int narg, char **arg) :
     if (strcmp(arg[iarg],"norm") == 0) {
       if (iarg+2 > narg) 
         error->all(FLERR,"Invalid compute surf optional keyword");
-      if (strcmp(arg[iarg+1],"no") == 0) normarea = 0;
-      else if (strcmp(arg[iarg+1],"yes") == 0) normarea = 1;
+      if (strcmp(arg[iarg+1],"flow") == 0) normarea = 0;
+      else if (strcmp(arg[iarg+1],"flux") == 0) normarea = 1;
       else error->all(FLERR,"Invalid compute surf optional keyword");
       iarg += 2;
     } else error->all(FLERR,"Invalid compute surf value or optional keyword");

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -316,7 +316,6 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
     switch (which[m]) {
     case NUM:
       vec[k++] += 1.0;
-      printf("COUNT %g\n",vec[k-1]);
       break;
     case NUMWT:
       vec[k++] += weight;
@@ -331,7 +330,6 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
       break;
     case MFLUX:
       vec[k] += origmass * fluxscale;
-      printf("MFLUX %g\n",vec[k-1]);
       if (!transparent) {
         if (ip) vec[k] -= imass * fluxscale;
         if (jp) vec[k] -= jmass * fluxscale;

--- a/src/compute_surf.h
+++ b/src/compute_surf.h
@@ -45,6 +45,7 @@ class ComputeSurf : public Compute {
  protected:
   int groupbit,imix,nvalue,ngroup,ntotal;
   int maxsurf,combined;
+  int normarea;            // 1 for value/area/time, 0 for value/time
   double nfactor_inverse;
   int *which;
 

--- a/src/mixture.cpp
+++ b/src/mixture.cpp
@@ -391,7 +391,7 @@ void Mixture::params(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal mixture command");
       temp_thermal_flag = 1;
       temp_thermal_user = atof(arg[iarg+1]);
-      if (temp_thermal_user <= 0.0)
+      if (temp_thermal_user < 0.0)
         error->all(FLERR,"Illegal mixture command");
       iarg += 2;
 
@@ -399,7 +399,7 @@ void Mixture::params(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal mixture command");
       temp_rot_flag = 1;
       temp_rot_user = atof(arg[iarg+1]);
-      if (temp_rot_user <= 0.0)
+      if (temp_rot_user < 0.0)
         error->all(FLERR,"Illegal mixture command");
       iarg += 2;
 
@@ -407,7 +407,7 @@ void Mixture::params(int narg, char **arg)
       if (iarg+2 > narg) error->all(FLERR,"Illegal mixture command");
       temp_vib_flag = 1;
       temp_vib_user = atof(arg[iarg+1]);
-      if (temp_vib_user <= 0.0)
+      if (temp_vib_user < 0.0)
         error->all(FLERR,"Illegal mixture command");
       iarg += 2;
 


### PR DESCRIPTION
## Purpose

Added a norm flux/flow option to compute surf.  Added sum-area and ave-area options to compute reduce.  These are to facilitate calculation of fluxes (or flows) through transparent surfs.

## Author(s)

Steve

## Backward Compatibility

N/A since these are new options, not changing old options.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


