### PR TITLE
Make example for particle style intuitive

### DIFF
--- a/doc/adapt_grid.html
+++ b/doc/adapt_grid.html
@@ -69,9 +69,9 @@
 </UL>
 <P><B>Examples:</B>
 </P>
-<PRE>adapt_grid all refine particle 10 50
-adapt_grid all coarsen particle 10 50
-adapt_grid all refine coarsen particle 10 50
+<PRE>adapt_grid all refine particle 50 10
+adapt_grid all coarsen particle 50 10
+adapt_grid all refine coarsen particle 50 10
 adapt_grid all refine surf all 0.15 iterate 1 dir 1 0 0 
 adapt_grid all refine coarsen value c_1<B>1</B> 5.0 10.0 iterate 2 
 </PRE>

--- a/doc/adapt_grid.txt
+++ b/doc/adapt_grid.txt
@@ -58,9 +58,9 @@ keyword = {iterate} or {maxlevel} or {minlevel} or {thresh} or {combine} or {cel
 
 [Examples:]
 
-adapt_grid all refine particle 10 50
-adapt_grid all coarsen particle 10 50
-adapt_grid all refine coarsen particle 10 50
+adapt_grid all refine particle 50 10
+adapt_grid all coarsen particle 50 10
+adapt_grid all refine coarsen particle 50 10
 adapt_grid all refine surf all 0.15 iterate 1 dir 1 0 0 
 adapt_grid all refine coarsen value c_1[1] 5.0 10.0 iterate 2 :pre
 


### PR DESCRIPTION
## Purpose

If I am not completely mistaken the current examples make no sense because the counters for refinement and coarsening are inverted. This pull request remedies this.

## Author(s)

Tim Teichmann (ITEP,KIT)

## Backward Compatibility

yes
## Implementation Notes

trivial


