### PR TITLE
Fix issue with balance rcb time

### DIFF
--- a/doc/balance_grid.txt
+++ b/doc/balance_grid.txt
@@ -145,6 +145,16 @@ before the balance command so that timer data is available. The timers
 used for balancing tally time from the move, sort, collide, and modify
 portions of each timestep.
 
+IMPORTANT NOTE: The adapt_grid"_adapt_grid.html zeros out timing data,
+so the weight {time} option is not available immediatly after this
+command.
+
+IMPORTANT NOTE: The coarsening option in adapt_grid"_adapt_grid.html
+and fix_adapt"_fix_adapt.html may shift cells to different processors,
+which makes the accumulated timing data for the weight {time} option
+less accurate when load balancing is performed immediately after these
+commands.
+
 Here is an example of an RCB partitioning for 24 processors, of a 2d
 hierarchical grid with 5 levels, refined around a tilted ellipsoidal
 surface object (outlined in pink).  This is for a {weight cell}

--- a/doc/balance_grid.txt
+++ b/doc/balance_grid.txt
@@ -145,15 +145,14 @@ before the balance command so that timer data is available. The timers
 used for balancing tally time from the move, sort, collide, and modify
 portions of each timestep.
 
-IMPORTANT NOTE: The adapt_grid"_adapt_grid.html zeros out timing data,
-so the weight {time} option is not available immediatly after this
-command.
+IMPORTANT NOTE: The adapt_grid"_adapt_grid.html command zeros out
+timing data, so the weight {time} option is not available immediatly
+after this command.
 
-IMPORTANT NOTE: The coarsening option in adapt_grid"_adapt_grid.html
-and fix_adapt"_fix_adapt.html may shift cells to different processors,
-which makes the accumulated timing data for the weight {time} option
-less accurate when load balancing is performed immediately after these
-commands.
+IMPORTANT NOTE: The coarsening option in fix_adapt"_fix_adapt.html may
+shift cells to different processors, which makes the accumulated
+timing data for the weight {time} option less accurate when load
+balancing is performed immediately after this command.
 
 Here is an example of an RCB partitioning for 24 processors, of a 2d
 hierarchical grid with 5 levels, refined around a tilted ellipsoidal

--- a/doc/fix_balance.txt
+++ b/doc/fix_balance.txt
@@ -126,15 +126,14 @@ of timesteps {Nfreq} between balancing steps also needs to be large
 enough to give reliable timings. The timers used for balancing tally
 time from the move, sort, collide, and modify portions of each timestep.
 
-IMPORTANT NOTE: The adapt_grid"_adapt_grid.html zeros out timing data,
-so the weight {time} option is not available immediatly after this
-command.
+IMPORTANT NOTE: The adapt_grid"_adapt_grid.html command zeros out
+timing data, so the weight {time} option is not available immediatly
+after this command.
 
-IMPORTANT NOTE: The coarsening option in adapt_grid"_adapt_grid.html
-and fix_adapt"_fix_adapt.html may shift cells to different processors,
-which makes the accumulated timing data for the weight {time} option
-less accurate when load balancing is performed immediately after these
-commands.
+IMPORTANT NOTE: The coarsening option in fix_adapt"_fix_adapt.html may
+shift cells to different processors, which makes the accumulated
+timing data for the weight {time} option less accurate when load
+balancing is performed immediately after this command.
 
 Here is an example of an RCB partitioning for 24 processors, of a 2d
 hierarchical grid with 5 levels, refined around a tilted ellipsoidal

--- a/doc/fix_balance.txt
+++ b/doc/fix_balance.txt
@@ -126,6 +126,16 @@ of timesteps {Nfreq} between balancing steps also needs to be large
 enough to give reliable timings. The timers used for balancing tally
 time from the move, sort, collide, and modify portions of each timestep.
 
+IMPORTANT NOTE: The adapt_grid"_adapt_grid.html zeros out timing data,
+so the weight {time} option is not available immediatly after this
+command.
+
+IMPORTANT NOTE: The coarsening option in adapt_grid"_adapt_grid.html
+and fix_adapt"_fix_adapt.html may shift cells to different processors,
+which makes the accumulated timing data for the weight {time} option
+less accurate when load balancing is performed immediately after these
+commands.
+
 Here is an example of an RCB partitioning for 24 processors, of a 2d
 hierarchical grid with 5 levels, refined around a tilted ellipsoidal
 surface object (outlined in pink).  This is for a {weight cell}

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -570,7 +570,8 @@ void BalanceGrid::timer_cell_weights(double* &weight)
   if (maxcost <= 0.0) {
     memory->destroy(weight);
     weight = NULL;
-    error->warning(FLERR,"No time history accumulated for balance_grid rcb time, using rcb cell option instead");
+      error->warning(FLERR,"No time history accumulated for balance_grid "
+        "rcb time, using rcb cell option instead");
     return;
   }
 

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -552,7 +552,7 @@ void BalanceGrid::procs2grid(int nx, int ny, int nz,
 
 /* -------------------------------------------------------------------- */
 
-void BalanceGrid::timer_cell_weights(double *weight)
+void BalanceGrid::timer_cell_weights(double* &weight)
 {
   // cost = CPU time for relevant timers since last invocation
 
@@ -570,6 +570,7 @@ void BalanceGrid::timer_cell_weights(double *weight)
   if (maxcost <= 0.0) {
     memory->destroy(weight);
     weight = NULL;
+    error->warning(FLERR,"No time history accumulated for balance_grid rcb time, using rcb cell option instead");
     return;
   }
 

--- a/src/balance_grid.h
+++ b/src/balance_grid.h
@@ -34,7 +34,7 @@ class BalanceGrid : protected Pointers {
   double last;
 
   void procs2grid(int, int, int, int &, int &, int &);
-  void timer_cell_weights(double *);
+  void timer_cell_weights(double *&);
 };
 
 }

--- a/src/fix_adapt.cpp
+++ b/src/fix_adapt.cpp
@@ -62,6 +62,10 @@ FixAdapt::FixAdapt(SPARTA *sparta, int narg, char **arg) :
   action2 = adapt->action2;
   file = adapt->file;
 
+  coarsen_flag = 0;
+  if (action1 == COARSEN || action2 == COARSEN)
+    coarsen_flag = 1;
+
   if (file && strchr(file,'*') == NULL)
     error->all(FLERR,"Fix adapt filename must contain '*' character");
 

--- a/src/fix_adapt.h
+++ b/src/fix_adapt.h
@@ -34,6 +34,7 @@ class FixAdapt : public Fix {
   virtual void end_of_step();
   double compute_scalar();
   double compute_vector(int);
+  int coarsen_flag;
 
  private:
   int me,nprocs;

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -346,7 +346,7 @@ void FixBalance::timer_cost()
 
 /* -------------------------------------------------------------------- */
 
-void FixBalance::timer_cell_weights(double *weight)
+void FixBalance::timer_cell_weights(double* &weight)
 {
   // localwt = weight assigned to each owned grid cell
   // just return if no time yet tallied
@@ -356,6 +356,7 @@ void FixBalance::timer_cell_weights(double *weight)
   if (maxcost <= 0.0) {
     memory->destroy(weight);
     weight = NULL;
+    error->warning(FLERR,"No time history accumulated for fix balance rcb time, using rcb cell option instead");
     return;
   }
 

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -31,6 +31,7 @@
 #include "memory.h"
 #include "error.h"
 #include "timer.h"
+#include "fix_adapt.h"
 
 using namespace SPARTA_NS;
 
@@ -152,6 +153,29 @@ void FixBalance::init()
 
   if (bstyle != BISECTION && grid->cutoff >= 0.0)
     error->all(FLERR,"Cannot use non-rcb fix balance with a grid cutoff");
+
+  // check if fix balance rcb time is after fix adapt with coarsening
+
+  if (rcbwt == TIME) {
+    int coarsen_flag = 0;
+    int after_flag = 0; 
+    for (int ifix = 0; ifix < modify->nfix; ifix++) {
+      if (strstr(modify->fix[ifix]->style,"adapt") != NULL)
+        if (((FixAdapt*)modify->fix[ifix])->coarsen_flag)
+          coarsen_flag = 1;
+
+      if (strstr(modify->fix[ifix]->style,"balance") != NULL)
+        if (coarsen_flag) {
+          after_flag = 1;
+          break;
+        }
+    }
+
+    if (after_flag && comm->me == 0) {
+      error->warning(FLERR,"Using fix_adapt coarsen before fix balance "
+        "rcb time may make the accumulated timing data less accurate");
+    }
+  }
 
   last = 0.0;
   timer->init();
@@ -356,8 +380,11 @@ void FixBalance::timer_cell_weights(double* &weight)
   if (maxcost <= 0.0) {
     memory->destroy(weight);
     weight = NULL;
-    error->warning(FLERR,"No time history accumulated for fix balance rcb time, using rcb cell option instead");
-    return;
+    if (comm->me == 0) {
+      error->warning(FLERR,"No time history accumulated for fix balance "
+        "rcb time, using rcb cell option instead");
+    }
+return;
   }
 
   Grid::ChildCell *cells = grid->cells;

--- a/src/fix_balance.h
+++ b/src/fix_balance.h
@@ -53,7 +53,7 @@ class FixBalance : public Fix {
 
   double imbalance_factor(double &);
   void timer_cost();
-  void timer_cell_weights(double *);
+  void timer_cell_weights(double *&);
 };
 
 }


### PR DESCRIPTION
## Purpose

Fix bug with balance rcb time that could give a segmentation fault when no time history is accumulated. Also add warnings and clarify doc pages. Fixes #350.

## Author(s)

Stan Moore (SNL), bug reported by Chonglin Zhang (RPI), helpful discussion with Steve Plimpton (SNL)

## Backward Compatibility

Yes