### PR TITLE
one line bug fix

### DIFF
--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -356,7 +356,7 @@ void ComputeReduce::init()
       gridgroupbit = grid->bitmask[igroup];
     } else if (flavor[0] == SURF) {
       int igroup = surf->find_group(subsetID);
-      if (isubset < 0)
+      if (igroup < 0)
         error->all(FLERR,"Compute reduce surf group ID does not exist");
       surfgroupbit = surf->bitmask[igroup];
     }


### PR DESCRIPTION
## Purpose

One-line bug fix for compute reduce with its subset option for per-surf value processing.
This allows the ave-area mode in compute surf to work correctly to measure fluxes thru transparent surfs
when there are also non-transparent surfs in the simulation.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


