### PR TITLE
GPU optimizations for KOKKOS package

### DIFF
--- a/doc/package.txt
+++ b/doc/package.txt
@@ -17,12 +17,12 @@ args = arguments specific to the style :l
   {kokkos} args = keyword value ...
     zero or more keyword/value pairs may be appended
     keywords = {comm} or {reduction}
-      {comm} value = {threaded} or {classic}
-        threaded = perform pack/unpack using KOKKOS (e.g. on GPU or using OpenMP) (default)
-        classic = perform communication pack/unpack in non-KOKKOS mode
+      {comm} value = {threaded} or {serial}
+        threaded = perform pack/unpack using KOKKOS (e.g. on GPU or using OpenMP) (default for GPUs)
+        serial = perform communication pack/unpack in non-KOKKOS mode (default for CPUs)
       {reduction} = {parallel/reduce} or {atomic}
-        parallel/reduce = use parallel reduction for statistics (default)
-        atomic = use atomic reduction for statistics
+        parallel/reduce = use parallel reduction for statistics (default for CPUs)
+        atomic = use atomic reduction for statistics (default for GPUs)
       {collide/extra} = {factor}
         factor = increase memory used for collisions by this factor (default)
       {collide/retry} = {yes} or {no}
@@ -35,7 +35,7 @@ args = arguments specific to the style :l
 
 [Examples:]
 
-package kokkos comm classic
+package kokkos comm serial
 package kokkos comm threaded reduction atomic
 package kokkos gpu/aware no :pre
 
@@ -110,15 +110,13 @@ be ignored. If reactions are not defined, both these options will be ignored.
 
 The {comm} keyword determines whether the host or device performs the
 packing and unpacking of data when communicating per-atom data between
-processors. The value options are {threaded} or {classic}.
+processors. The value options are {threaded} or {serial}.
 
 The optimal choice for this keyword depends on the hardware used.
-When running on CPUs or Xeon Phi, the {classic} option is typically
+When running on CPUs or Xeon Phi, the {serial} option is typically
 fastest. When using GPUs, the {threaded} value will typically be
 optimal. In this case data can stay on the GPU for many timesteps
-without being moved between the host and GPU.  This requires that your
-MPI is able to access GPU memory directly.  Currently that is true for
-OpenMPI 1.8 (or later versions), Mvapich2 1.9 (or later), and CrayMPI.
+without being moved between the host and GPU.
 
 The {gpu/aware} keyword chooses whether GPU-aware MPI will be used. When 
 this keyword is set to {on}, buffers in GPU memory are passed directly 
@@ -145,9 +143,10 @@ setting"_Section_start.html#start_6
 
 [Default:]
 
-For the KOKKOS package, the option defaults are comm = threaded, 
-reduction = parallel/reduce, collide/extra = 1.1, and collide/retry = 
-no, gpu/aware yes. These settings are made automatically by the 
-required "-k on" "command-line switch"_Section_start.html#start_6. You 
-can change them by using the package kokkos command in your input script 
-or via the "-pk kokkos" "command-line switch"_Section_start.html#start_6. 
+For the KOKKOS package, the option defaults are collide/extra = 1.1,
+collide/retry = no, and gpu/aware yes. For CPUs: comm = serial,
+reduction = parallel/reduce. For GPUs: comm = threaded, reduction =
+atomic. These settings are made automatically by the required "-k on"
+"command-line switch"_Section_start.html#start_6. You can change them
+by using the package kokkos command in your input script or via the
+"-pk kokkos" "command-line switch"_Section_start.html#start_6. 

--- a/doc/package.txt
+++ b/doc/package.txt
@@ -116,7 +116,7 @@ The optimal choice for this keyword depends on the hardware used.
 When running on CPUs or Xeon Phi, the {serial} option is typically
 fastest. When using GPUs, the {threaded} value will typically be
 optimal. In this case data can stay on the GPU for many timesteps
-without being moved between the host and GPU.
+without being fully moved between the host and GPU.
 
 The {gpu/aware} keyword chooses whether GPU-aware MPI will be used. When 
 this keyword is set to {on}, buffers in GPU memory are passed directly 
@@ -145,7 +145,7 @@ setting"_Section_start.html#start_6
 
 For the KOKKOS package, the option defaults are collide/extra = 1.1,
 collide/retry = no, and gpu/aware yes. For CPUs: comm = serial,
-reduction = parallel/reduce. For GPUs: comm = threaded, reduction =
+reduction = parallel/reduce, and for GPUs: comm = threaded, reduction =
 atomic. These settings are made automatically by the required "-k on"
 "command-line switch"_Section_start.html#start_6. You can change them
 by using the package kokkos command in your input script or via the

--- a/src/KOKKOS/collide_vss_kokkos.h
+++ b/src/KOKKOS/collide_vss_kokkos.h
@@ -149,7 +149,7 @@ class CollideVSSKokkos : public CollideVSS {
   tdual_struct_tdual_int_2d_1d k_eiarray;
   tdual_struct_tdual_float_2d_1d k_edarray;
   DAT::t_int_1d d_ionambi;
-  DAT::t_float_2d d_velambi;
+  DAT::t_float_2d_lr d_velambi;
   t_particle_2d d_elist;
 
   DAT::tdual_float_2d k_vremax_initial;
@@ -263,7 +263,7 @@ class CollideVSSKokkos : public CollideVSS {
   DAT::t_float_3d d_remain_backup;
   DAT::t_int_2d d_nn_last_partner_backup;
   DAT::t_int_1d d_ionambi_backup;
-  DAT::t_float_2d d_velambi_backup;
+  DAT::t_float_2d_lr d_velambi_backup;
   RanKnuth* random_backup;
 };
 

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -51,7 +51,7 @@ CommKokkos::~CommKokkos()
 {
   if (copymode) return;
 
-  if (!sparta->kokkos->comm_classic) {
+  if (!sparta->kokkos->comm_serial) {
     pproc = NULL;
   }
 
@@ -71,7 +71,7 @@ int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d d_plis
   particle_kk->update_class_variables();
   particle_kk_copy.copy(particle_kk);
 
-  if (sparta->kokkos->comm_classic) {
+  if (sparta->kokkos->comm_serial) {
     particle_kk->sync(Host,ALL_MASK);
     //grid_kk->sync(Host,ALL_MASK);
     int prev_auto_sync = sparta->kokkos->auto_sync;

--- a/src/KOKKOS/fix_ambipolar_kokkos.h
+++ b/src/KOKKOS/fix_ambipolar_kokkos.h
@@ -50,7 +50,7 @@ class FixAmbipolarKokkos : public FixAmbipolar {
   t_species_1d d_species;
 
   DAT::t_int_1d d_ionambi;
-  DAT::t_float_2d d_velambi;
+  DAT::t_float_2d_lr d_velambi;
 
 #ifndef SPARTA_KOKKOS_EXACT
   Kokkos::Random_XorShift64_Pool<DeviceType> rand_pool;

--- a/src/KOKKOS/fix_vibmode_kokkos.h
+++ b/src/KOKKOS/fix_vibmode_kokkos.h
@@ -57,7 +57,7 @@ class FixVibmodeKokkos : public FixVibmode {
   t_particle_1d d_particles;
   t_species_1d d_species;
 
-  DAT::t_int_2d d_vibmode;
+  DAT::t_int_2d_lr d_vibmode;
 };
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -143,15 +143,17 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
 
   // default settings for package kokkos command
 
-  comm_serial = 0;
   prewrap = 1;
   auto_sync = 1;
   gpu_aware_flag = 1;
 
-  if (ngpus > 0)
+  if (ngpus > 0) {
+    comm_serial = 0;
     atomic_reduction = 1;
-  else
+  } else {
+    comm_serial = 1;
     atomic_reduction = 0;
+  }
 
   need_atomics = 1;
   if (nthreads == 1 && ngpus == 0)
@@ -180,10 +182,6 @@ KokkosSPARTA::~KokkosSPARTA()
 
 void KokkosSPARTA::accelerator(int narg, char **arg)
 {
-  // defaults
-
-  comm_serial = 0;
-
   int iarg = 0;
   while (iarg < narg) {
     if (strcmp(arg[iarg],"comm") == 0) {

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -23,7 +23,7 @@ namespace SPARTA_NS {
 class KokkosSPARTA : protected Pointers {
  public:
   int kokkos_exists;
-  int comm_classic;
+  int comm_serial;
   int atomic_reduction;
   int prewrap;
   int auto_sync;

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -503,7 +503,7 @@ typedef tdual_bigint_1d::t_dev_const_um t_bigint_1d_const_um;
 typedef tdual_bigint_1d::t_dev_const_randomread t_bigint_1d_randomread;
 
 typedef Kokkos::
-  DualView<int*[3], Kokkos::LayoutRight, DeviceType> tdual_int_1d_3;
+  DualView<int*[3], DeviceType::array_layout, DeviceType> tdual_int_1d_3;
 typedef tdual_int_1d_3::t_dev t_int_1d_3;
 typedef tdual_int_1d_3::t_dev_const t_int_1d_3_const;
 typedef tdual_int_1d_3::t_dev_um t_int_1d_3_um;
@@ -511,30 +511,20 @@ typedef tdual_int_1d_3::t_dev_const_um t_int_1d_3_const_um;
 typedef tdual_int_1d_3::t_dev_const_randomread t_int_1d_3_randomread;
 
 typedef Kokkos::
-  DualView<int**, Kokkos::LayoutRight, DeviceType> tdual_int_2d;
+  DualView<int**, Kokkos::LayoutRight, DeviceType> tdual_int_2d_lr;
+typedef tdual_int_2d_lr::t_dev t_int_2d_lr;
+typedef tdual_int_2d_lr::t_dev_const t_int_2d_const_lr;
+typedef tdual_int_2d_lr::t_dev_um t_int_2d_um_lr;
+typedef tdual_int_2d_lr::t_dev_const_um t_int_2d_const_um_lr;
+typedef tdual_int_2d_lr::t_dev_const_randomread t_int_2d_randomread_lr;
+
+typedef Kokkos::
+  DualView<int**, DeviceType::array_layout, DeviceType> tdual_int_2d;
 typedef tdual_int_2d::t_dev t_int_2d;
 typedef tdual_int_2d::t_dev_const t_int_2d_const;
 typedef tdual_int_2d::t_dev_um t_int_2d_um;
 typedef tdual_int_2d::t_dev_const_um t_int_2d_const_um;
 typedef tdual_int_2d::t_dev_const_randomread t_int_2d_randomread;
-
-typedef Kokkos::
-  DualView<SPARTA_NS::cellint*, DeviceType::array_layout, DeviceType>
-  tdual_cellint_1d;
-typedef tdual_cellint_1d::t_dev t_cellint_1d;
-typedef tdual_cellint_1d::t_dev_const t_cellint_1d_const;
-typedef tdual_cellint_1d::t_dev_um t_cellint_1d_um;
-typedef tdual_cellint_1d::t_dev_const_um t_cellint_1d_const_um;
-typedef tdual_cellint_1d::t_dev_const_randomread t_cellint_1d_randomread;
-
-typedef Kokkos::
-  DualView<SPARTA_NS::cellint**, Kokkos::LayoutRight, DeviceType>
-  tdual_cellint_2d;
-typedef tdual_cellint_2d::t_dev t_cellint_2d;
-typedef tdual_cellint_2d::t_dev_const t_cellint_2d_const;
-typedef tdual_cellint_2d::t_dev_um t_cellint_2d_um;
-typedef tdual_cellint_2d::t_dev_const_um t_cellint_2d_const_um;
-typedef tdual_cellint_2d::t_dev_const_randomread t_cellint_2d_randomread;
 
 typedef Kokkos::
   DualView<SPARTA_NS::surfint*, DeviceType::array_layout, DeviceType>
@@ -545,31 +535,6 @@ typedef tdual_surfint_1d::t_dev_um t_surfint_1d_um;
 typedef tdual_surfint_1d::t_dev_const_um t_surfint_1d_const_um;
 typedef tdual_surfint_1d::t_dev_const_randomread t_surfint_1d_randomread;
 
-typedef Kokkos::
-  DualView<SPARTA_NS::surfint**, Kokkos::LayoutRight, DeviceType>
-  tdual_surfint_2d;
-typedef tdual_surfint_2d::t_dev t_surfint_2d;
-typedef tdual_surfint_2d::t_dev_const t_surfint_2d_const;
-typedef tdual_surfint_2d::t_dev_um t_surfint_2d_um;
-typedef tdual_surfint_2d::t_dev_const_um t_surfint_2d_const_um;
-typedef tdual_surfint_2d::t_dev_const_randomread t_surfint_2d_randomread;
-
-typedef Kokkos::
-  DualView<double*, Kokkos::LayoutRight, DeviceType> tdual_double_1d;
-typedef tdual_double_1d::t_dev t_double_1d;
-typedef tdual_double_1d::t_dev_const t_double_1d_const;
-typedef tdual_double_1d::t_dev_um t_double_1d_um;
-typedef tdual_double_1d::t_dev_const_um t_double_1d_const_um;
-typedef tdual_double_1d::t_dev_const_randomread t_double_1d_randomread;
-
-typedef Kokkos::
-  DualView<double**, Kokkos::LayoutRight, DeviceType> tdual_double_2d;
-typedef tdual_double_2d::t_dev t_double_2d;
-typedef tdual_double_2d::t_dev_const t_double_2d_const;
-typedef tdual_double_2d::t_dev_um t_double_2d_um;
-typedef tdual_double_2d::t_dev_const_um t_double_2d_const_um;
-typedef tdual_double_2d::t_dev_const_randomread t_double_2d_randomread;
-
 // 1d float array n
 
 typedef Kokkos::DualView<SPARTA_FLOAT*, DeviceType::array_layout, DeviceType> tdual_float_1d;
@@ -578,6 +543,11 @@ typedef tdual_float_1d::t_dev_const t_float_1d_const;
 typedef tdual_float_1d::t_dev_um t_float_1d_um;
 typedef tdual_float_1d::t_dev_const_um t_float_1d_const_um;
 typedef tdual_float_1d::t_dev_const_randomread t_float_1d_randomread;
+
+//1d float array strided
+typedef Kokkos::DualView<SPARTA_FLOAT*, Kokkos::LayoutStride, DeviceType> tdual_float_1d_strided;
+typedef tdual_float_1d_strided::t_dev t_float_1d_strided;
+typedef tdual_float_1d_strided::t_dev_um t_float_1d_strided_um;
 
 // 1d float array n[3]
 
@@ -596,81 +566,7 @@ typedef tdual_float_2d::t_dev_um t_float_2d_um;
 typedef tdual_float_2d::t_dev_const_um t_float_2d_const_um;
 typedef tdual_float_2d::t_dev_const_randomread t_float_2d_randomread;
 
-//3d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT***, DeviceType::array_layout, DeviceType> tdual_float_3d;
-typedef tdual_float_3d::t_dev t_float_3d;
-typedef tdual_float_3d::t_dev_const t_float_3d_const;
-typedef tdual_float_3d::t_dev_um t_float_3d_um;
-typedef tdual_float_3d::t_dev_const_um t_float_3d_const_um;
-typedef tdual_float_3d::t_dev_const_randomread t_float_3d_randomread;
-
-//Position Types
-//1d X_FLOAT array n
-typedef Kokkos::DualView<X_FLOAT*, DeviceType::array_layout, DeviceType> tdual_xfloat_1d;
-typedef tdual_xfloat_1d::t_dev t_xfloat_1d;
-typedef tdual_xfloat_1d::t_dev_const t_xfloat_1d_const;
-typedef tdual_xfloat_1d::t_dev_um t_xfloat_1d_um;
-typedef tdual_xfloat_1d::t_dev_const_um t_xfloat_1d_const_um;
-typedef tdual_xfloat_1d::t_dev_const_randomread t_xfloat_1d_randomread;
-
-//2d X_FLOAT array n*m
-typedef Kokkos::DualView<X_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_xfloat_2d;
-typedef tdual_xfloat_2d::t_dev t_xfloat_2d;
-typedef tdual_xfloat_2d::t_dev_const t_xfloat_2d_const;
-typedef tdual_xfloat_2d::t_dev_um t_xfloat_2d_um;
-typedef tdual_xfloat_2d::t_dev_const_um t_xfloat_2d_const_um;
-typedef tdual_xfloat_2d::t_dev_const_randomread t_xfloat_2d_randomread;
-
-//2d X_FLOAT array n*4
-#ifdef SPARTA_KOKKOS_NO_LEGACY
-typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutLeft, DeviceType> tdual_x_array;
-#else
-typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_x_array;
-#endif
-typedef tdual_x_array::t_dev t_x_array;
-typedef tdual_x_array::t_dev_const t_x_array_const;
-typedef tdual_x_array::t_dev_um t_x_array_um;
-typedef tdual_x_array::t_dev_const_um t_x_array_const_um;
-typedef tdual_x_array::t_dev_const_randomread t_x_array_randomread;
-
-//Velocity Types
-//1d V_FLOAT array n
-typedef Kokkos::DualView<V_FLOAT*, DeviceType::array_layout, DeviceType> tdual_vfloat_1d;
-typedef tdual_vfloat_1d::t_dev t_vfloat_1d;
-typedef tdual_vfloat_1d::t_dev_const t_vfloat_1d_const;
-typedef tdual_vfloat_1d::t_dev_um t_vfloat_1d_um;
-typedef tdual_vfloat_1d::t_dev_const_um t_vfloat_1d_const_um;
-typedef tdual_vfloat_1d::t_dev_const_randomread t_vfloat_1d_randomread;
-
-//2d V_FLOAT array n*m
-typedef Kokkos::DualView<V_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_vfloat_2d;
-typedef tdual_vfloat_2d::t_dev t_vfloat_2d;
-typedef tdual_vfloat_2d::t_dev_const t_vfloat_2d_const;
-typedef tdual_vfloat_2d::t_dev_um t_vfloat_2d_um;
-typedef tdual_vfloat_2d::t_dev_const_um t_vfloat_2d_const_um;
-typedef tdual_vfloat_2d::t_dev_const_randomread t_vfloat_2d_randomread;
-
-//2d V_FLOAT array n*3
-typedef Kokkos::DualView<V_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_v_array;
-//typedef Kokkos::DualView<V_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_v_array;
-typedef tdual_v_array::t_dev t_v_array;
-typedef tdual_v_array::t_dev_const t_v_array_const;
-typedef tdual_v_array::t_dev_um t_v_array_um;
-typedef tdual_v_array::t_dev_const_um t_v_array_const_um;
-typedef tdual_v_array::t_dev_const_randomread t_v_array_randomread;
-
-//Force Types
-//1d F_FLOAT array n
-
-typedef Kokkos::DualView<F_FLOAT*, DeviceType::array_layout, DeviceType> tdual_ffloat_1d;
-typedef tdual_ffloat_1d::t_dev t_ffloat_1d;
-typedef tdual_ffloat_1d::t_dev_const t_ffloat_1d_const;
-typedef tdual_ffloat_1d::t_dev_um t_ffloat_1d_um;
-typedef tdual_ffloat_1d::t_dev_const_um t_ffloat_1d_const_um;
-typedef tdual_ffloat_1d::t_dev_const_randomread t_ffloat_1d_randomread;
-
-//2d F_FLOAT array n*m
-
+//2d float array n Kokkos::LayoutRight
 typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_float_2d_lr;
 typedef tdual_float_2d_lr::t_dev t_float_2d_lr;
 typedef tdual_float_2d_lr::t_dev_const t_float_2d_lr_const;
@@ -678,65 +574,13 @@ typedef tdual_float_2d_lr::t_dev_um t_float_2d_lr_um;
 typedef tdual_float_2d_lr::t_dev_const_um t_float_2d_lr_const_um;
 typedef tdual_float_2d_lr::t_dev_const_randomread t_float_2d_lr_randomread;
 
-//2d F_FLOAT array n*3
-
-typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_f_array;
-//typedef Kokkos::DualView<F_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_f_array;
-typedef tdual_f_array::t_dev t_f_array;
-typedef tdual_f_array::t_dev_const t_f_array_const;
-typedef tdual_f_array::t_dev_um t_f_array_um;
-typedef tdual_f_array::t_dev_const_um t_f_array_const_um;
-typedef tdual_f_array::t_dev_const_randomread t_f_array_randomread;
-
-//2d F_FLOAT array n*6 (for virial)
-
-typedef Kokkos::DualView<F_FLOAT*[6], Kokkos::LayoutRight, DeviceType> tdual_virial_array;
-typedef tdual_virial_array::t_dev t_virial_array;
-typedef tdual_virial_array::t_dev_const t_virial_array_const;
-typedef tdual_virial_array::t_dev_um t_virial_array_um;
-typedef tdual_virial_array::t_dev_const_um t_virial_array_const_um;
-typedef tdual_virial_array::t_dev_const_randomread t_virial_array_randomread;
-
-//Energy Types
-//1d E_FLOAT array n
-
-typedef Kokkos::DualView<E_FLOAT*, DeviceType::array_layout, DeviceType> tdual_efloat_1d;
-typedef tdual_efloat_1d::t_dev t_efloat_1d;
-typedef tdual_efloat_1d::t_dev_const t_efloat_1d_const;
-typedef tdual_efloat_1d::t_dev_um t_efloat_1d_um;
-typedef tdual_efloat_1d::t_dev_const_um t_efloat_1d_const_um;
-typedef tdual_efloat_1d::t_dev_const_randomread t_efloat_1d_randomread;
-
-//2d E_FLOAT array n*m
-
-typedef Kokkos::DualView<E_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_efloat_2d;
-typedef tdual_efloat_2d::t_dev t_efloat_2d;
-typedef tdual_efloat_2d::t_dev_const t_efloat_2d_const;
-typedef tdual_efloat_2d::t_dev_um t_efloat_2d_um;
-typedef tdual_efloat_2d::t_dev_const_um t_efloat_2d_const_um;
-typedef tdual_efloat_2d::t_dev_const_randomread t_efloat_2d_randomread;
-
-//2d E_FLOAT array n*3
-
-typedef Kokkos::DualView<E_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_e_array;
-typedef tdual_e_array::t_dev t_e_array;
-typedef tdual_e_array::t_dev_const t_e_array_const;
-typedef tdual_e_array::t_dev_um t_e_array_um;
-typedef tdual_e_array::t_dev_const_um t_e_array_const_um;
-typedef tdual_e_array::t_dev_const_randomread t_e_array_randomread;
-
-//Neighbor Types
-
-typedef Kokkos::DualView<int**, DeviceType::array_layout, DeviceType> tdual_neighbors_2d;
-typedef tdual_neighbors_2d::t_dev t_neighbors_2d;
-typedef tdual_neighbors_2d::t_dev_const t_neighbors_2d_const;
-typedef tdual_neighbors_2d::t_dev_um t_neighbors_2d_um;
-typedef tdual_neighbors_2d::t_dev_const_um t_neighbors_2d_const_um;
-typedef tdual_neighbors_2d::t_dev_const_randomread t_neighbors_2d_randomread;
-
-typedef Kokkos::DualView<double*,Kokkos::LayoutStride> tdual_float_1d_strided;
-typedef tdual_float_1d_strided::t_dev t_float_1d_strided;
-typedef tdual_float_1d_strided::t_dev_um t_float_1d_strided_um;
+//3d float array n
+typedef Kokkos::DualView<SPARTA_FLOAT***, DeviceType::array_layout, DeviceType> tdual_float_3d;
+typedef tdual_float_3d::t_dev t_float_3d;
+typedef tdual_float_3d::t_dev_const t_float_3d_const;
+typedef tdual_float_3d::t_dev_um t_float_3d_um;
+typedef tdual_float_3d::t_dev_const_um t_float_3d_const_um;
+typedef tdual_float_3d::t_dev_const_randomread t_float_3d_randomread;
 };
 
 #ifdef SPARTA_KOKKOS_GPU
@@ -787,28 +631,19 @@ typedef tdual_int_1d_3::t_host_um t_int_1d_3_um;
 typedef tdual_int_1d_3::t_host_const_um t_int_1d_3_const_um;
 typedef tdual_int_1d_3::t_host_const_randomread t_int_1d_3_randomread;
 
-typedef Kokkos::DualView<int**, Kokkos::LayoutRight, DeviceType> tdual_int_2d;
+typedef Kokkos::DualView<int**, Kokkos::LayoutRight, DeviceType> tdual_int_2d_lr;
+typedef tdual_int_2d_lr::t_host t_int_2d_lr;
+typedef tdual_int_2d_lr::t_host_const t_int_2d_const_lr;
+typedef tdual_int_2d_lr::t_host_um t_int_2d_um_lr;
+typedef tdual_int_2d_lr::t_host_const_um t_int_2d_const_um_lr;
+typedef tdual_int_2d_lr::t_host_const_randomread t_int_2d_randomread_lr;
+
+typedef Kokkos::DualView<int**, DeviceType::array_layout, DeviceType> tdual_int_2d;
 typedef tdual_int_2d::t_host t_int_2d;
 typedef tdual_int_2d::t_host_const t_int_2d_const;
 typedef tdual_int_2d::t_host_um t_int_2d_um;
 typedef tdual_int_2d::t_host_const_um t_int_2d_const_um;
 typedef tdual_int_2d::t_host_const_randomread t_int_2d_randomread;
-
-typedef Kokkos::DualView<SPARTA_NS::cellint*, DeviceType::array_layout, DeviceType> tdual_cellint_1d;
-typedef tdual_cellint_1d::t_host t_cellint_1d;
-typedef tdual_cellint_1d::t_host_const t_cellint_1d_const;
-typedef tdual_cellint_1d::t_host_um t_cellint_1d_um;
-typedef tdual_cellint_1d::t_host_const_um t_cellint_1d_const_um;
-typedef tdual_cellint_1d::t_host_const_randomread t_cellint_1d_randomread;
-
-typedef Kokkos::
-  DualView<SPARTA_NS::cellint**, Kokkos::LayoutRight, DeviceType>
-  tdual_cellint_2d;
-typedef tdual_cellint_2d::t_host t_cellint_2d;
-typedef tdual_cellint_2d::t_host_const t_cellint_2d_const;
-typedef tdual_cellint_2d::t_host_um t_cellint_2d_um;
-typedef tdual_cellint_2d::t_host_const_um t_cellint_2d_const_um;
-typedef tdual_cellint_2d::t_host_const_randomread t_cellint_2d_randomread;
 
 typedef Kokkos::DualView<SPARTA_NS::surfint*, DeviceType::array_layout, DeviceType> tdual_surfint_1d;
 typedef tdual_surfint_1d::t_host t_surfint_1d;
@@ -817,38 +652,18 @@ typedef tdual_surfint_1d::t_host_um t_surfint_1d_um;
 typedef tdual_surfint_1d::t_host_const_um t_surfint_1d_const_um;
 typedef tdual_surfint_1d::t_host_const_randomread t_surfint_1d_randomread;
 
-typedef Kokkos::
-  DualView<SPARTA_NS::surfint**, Kokkos::LayoutRight, DeviceType>
-  tdual_surfint_2d;
-typedef tdual_surfint_2d::t_host t_surfint_2d;
-typedef tdual_surfint_2d::t_host_const t_surfint_2d_const;
-typedef tdual_surfint_2d::t_host_um t_surfint_2d_um;
-typedef tdual_surfint_2d::t_host_const_um t_surfint_2d_const_um;
-typedef tdual_surfint_2d::t_host_const_randomread t_surfint_2d_randomread;
-
-typedef Kokkos::
-  DualView<double*, Kokkos::LayoutRight, DeviceType> tdual_double_1d;
-typedef tdual_double_1d::t_host t_double_1d;
-typedef tdual_double_1d::t_host_const t_double_1d_const;
-typedef tdual_double_1d::t_host_um t_double_1d_um;
-typedef tdual_double_1d::t_host_const_um t_double_1d_const_um;
-typedef tdual_double_1d::t_host_const_randomread t_double_1d_randomread;
-
-typedef Kokkos::
-  DualView<double**, Kokkos::LayoutRight, DeviceType> tdual_double_2d;
-typedef tdual_double_2d::t_host t_double_2d;
-typedef tdual_double_2d::t_host_const t_double_2d_const;
-typedef tdual_double_2d::t_host_um t_double_2d_um;
-typedef tdual_double_2d::t_host_const_um t_double_2d_const_um;
-typedef tdual_double_2d::t_host_const_randomread t_double_2d_randomread;
-
-//1d float array n
+//1d float array
 typedef Kokkos::DualView<SPARTA_FLOAT*, DeviceType::array_layout, DeviceType> tdual_float_1d;
 typedef tdual_float_1d::t_host t_float_1d;
 typedef tdual_float_1d::t_host_const t_float_1d_const;
 typedef tdual_float_1d::t_host_um t_float_1d_um;
 typedef tdual_float_1d::t_host_const_um t_float_1d_const_um;
 typedef tdual_float_1d::t_host_const_randomread t_float_1d_randomread;
+
+//1d float array strided
+typedef Kokkos::DualView<SPARTA_FLOAT*, Kokkos::LayoutStride, DeviceType> tdual_float_1d_strided;
+typedef tdual_float_1d_strided::t_host t_float_1d_strided;
+typedef tdual_float_1d_strided::t_host_um t_float_1d_strided_um;
 
 //1d float array n[3]
 typedef Kokkos::DualView<SPARTA_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_float_1d_3;
@@ -858,7 +673,7 @@ typedef tdual_float_1d_3::t_host_um t_float_1d_3_um;
 typedef tdual_float_1d_3::t_host_const_um t_float_1d_3_const_um;
 typedef tdual_float_1d_3::t_host_const_randomread t_float_1d_3_randomread;
 
-//2d float array n
+//2d float array
 typedef Kokkos::DualView<SPARTA_FLOAT**, DeviceType::array_layout, DeviceType> tdual_float_2d;
 typedef tdual_float_2d::t_host t_float_2d;
 typedef tdual_float_2d::t_host_const t_float_2d_const;
@@ -866,76 +681,7 @@ typedef tdual_float_2d::t_host_um t_float_2d_um;
 typedef tdual_float_2d::t_host_const_um t_float_2d_const_um;
 typedef tdual_float_2d::t_host_const_randomread t_float_2d_randomread;
 
-//3d float array n
-typedef Kokkos::DualView<SPARTA_FLOAT***, DeviceType::array_layout, DeviceType> tdual_float_3d;
-typedef tdual_float_3d::t_host t_float_3d;
-typedef tdual_float_3d::t_host_const t_float_3d_const;
-typedef tdual_float_3d::t_host_um t_float_3d_um;
-typedef tdual_float_3d::t_host_const_um t_float_3d_const_um;
-typedef tdual_float_3d::t_host_const_randomread t_float_3d_randomread;
-
-
-//Position Types
-//1d X_FLOAT array n
-typedef Kokkos::DualView<X_FLOAT*, DeviceType::array_layout, DeviceType> tdual_xfloat_1d;
-typedef tdual_xfloat_1d::t_host t_xfloat_1d;
-typedef tdual_xfloat_1d::t_host_const t_xfloat_1d_const;
-typedef tdual_xfloat_1d::t_host_um t_xfloat_1d_um;
-typedef tdual_xfloat_1d::t_host_const_um t_xfloat_1d_const_um;
-typedef tdual_xfloat_1d::t_host_const_randomread t_xfloat_1d_randomread;
-
-//2d X_FLOAT array n*m
-typedef Kokkos::DualView<X_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_xfloat_2d;
-typedef tdual_xfloat_2d::t_host t_xfloat_2d;
-typedef tdual_xfloat_2d::t_host_const t_xfloat_2d_const;
-typedef tdual_xfloat_2d::t_host_um t_xfloat_2d_um;
-typedef tdual_xfloat_2d::t_host_const_um t_xfloat_2d_const_um;
-typedef tdual_xfloat_2d::t_host_const_randomread t_xfloat_2d_randomread;
-
-//2d X_FLOAT array n*3
-typedef Kokkos::DualView<X_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_x_array;
-typedef tdual_x_array::t_host t_x_array;
-typedef tdual_x_array::t_host_const t_x_array_const;
-typedef tdual_x_array::t_host_um t_x_array_um;
-typedef tdual_x_array::t_host_const_um t_x_array_const_um;
-typedef tdual_x_array::t_host_const_randomread t_x_array_randomread;
-
-//Velocity Types
-//1d V_FLOAT array n
-typedef Kokkos::DualView<V_FLOAT*, DeviceType::array_layout, DeviceType> tdual_vfloat_1d;
-typedef tdual_vfloat_1d::t_host t_vfloat_1d;
-typedef tdual_vfloat_1d::t_host_const t_vfloat_1d_const;
-typedef tdual_vfloat_1d::t_host_um t_vfloat_1d_um;
-typedef tdual_vfloat_1d::t_host_const_um t_vfloat_1d_const_um;
-typedef tdual_vfloat_1d::t_host_const_randomread t_vfloat_1d_randomread;
-
-//2d V_FLOAT array n*m
-typedef Kokkos::DualView<V_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_vfloat_2d;
-typedef tdual_vfloat_2d::t_host t_vfloat_2d;
-typedef tdual_vfloat_2d::t_host_const t_vfloat_2d_const;
-typedef tdual_vfloat_2d::t_host_um t_vfloat_2d_um;
-typedef tdual_vfloat_2d::t_host_const_um t_vfloat_2d_const_um;
-typedef tdual_vfloat_2d::t_host_const_randomread t_vfloat_2d_randomread;
-
-//2d V_FLOAT array n*3
-typedef Kokkos::DualView<V_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_v_array;
-//typedef Kokkos::DualView<V_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_v_array;
-typedef tdual_v_array::t_host t_v_array;
-typedef tdual_v_array::t_host_const t_v_array_const;
-typedef tdual_v_array::t_host_um t_v_array_um;
-typedef tdual_v_array::t_host_const_um t_v_array_const_um;
-typedef tdual_v_array::t_host_const_randomread t_v_array_randomread;
-
-//Force Types
-//1d F_FLOAT array n
-typedef Kokkos::DualView<F_FLOAT*, DeviceType::array_layout, DeviceType> tdual_ffloat_1d;
-typedef tdual_ffloat_1d::t_host t_ffloat_1d;
-typedef tdual_ffloat_1d::t_host_const t_ffloat_1d_const;
-typedef tdual_ffloat_1d::t_host_um t_ffloat_1d_um;
-typedef tdual_ffloat_1d::t_host_const_um t_ffloat_1d_const_um;
-typedef tdual_ffloat_1d::t_host_const_randomread t_ffloat_1d_randomread;
-
-//2d F_FLOAT array n*m
+//2d float array LayoutRight
 typedef Kokkos::DualView<F_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_float_2d_lr;
 typedef tdual_float_2d_lr::t_host t_float_2d_lr;
 typedef tdual_float_2d_lr::t_host_const t_float_2d_lr_const;
@@ -943,62 +689,15 @@ typedef tdual_float_2d_lr::t_host_um t_float_2d_lr_um;
 typedef tdual_float_2d_lr::t_host_const_um t_float_2d_lr_const_um;
 typedef tdual_float_2d_lr::t_host_const_randomread t_float_2d_lr_randomread;
 
-//2d F_FLOAT array n*3
-typedef Kokkos::DualView<F_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_f_array;
-//typedef Kokkos::DualView<F_FLOAT*[3], DeviceType::array_layout, DeviceType> tdual_f_array;
-typedef tdual_f_array::t_host t_f_array;
-typedef tdual_f_array::t_host_const t_f_array_const;
-typedef tdual_f_array::t_host_um t_f_array_um;
-typedef tdual_f_array::t_host_const_um t_f_array_const_um;
-typedef tdual_f_array::t_host_const_randomread t_f_array_randomread;
-
-//2d F_FLOAT array n*6 (for virial)
-typedef Kokkos::DualView<F_FLOAT*[6], Kokkos::LayoutRight, DeviceType> tdual_virial_array;
-typedef tdual_virial_array::t_host t_virial_array;
-typedef tdual_virial_array::t_host_const t_virial_array_const;
-typedef tdual_virial_array::t_host_um t_virial_array_um;
-typedef tdual_virial_array::t_host_const_um t_virial_array_const_um;
-typedef tdual_virial_array::t_host_const_randomread t_virial_array_randomread;
-
-
-
-//Energy Types
-//1d E_FLOAT array n
-typedef Kokkos::DualView<E_FLOAT*, DeviceType::array_layout, DeviceType> tdual_efloat_1d;
-typedef tdual_efloat_1d::t_host t_efloat_1d;
-typedef tdual_efloat_1d::t_host_const t_efloat_1d_const;
-typedef tdual_efloat_1d::t_host_um t_efloat_1d_um;
-typedef tdual_efloat_1d::t_host_const_um t_efloat_1d_const_um;
-typedef tdual_efloat_1d::t_host_const_randomread t_efloat_1d_randomread;
-
-//2d E_FLOAT array n*m
-typedef Kokkos::DualView<E_FLOAT**, Kokkos::LayoutRight, DeviceType> tdual_efloat_2d;
-typedef tdual_efloat_2d::t_host t_efloat_2d;
-typedef tdual_efloat_2d::t_host_const t_efloat_2d_const;
-typedef tdual_efloat_2d::t_host_um t_efloat_2d_um;
-typedef tdual_efloat_2d::t_host_const_um t_efloat_2d_const_um;
-typedef tdual_efloat_2d::t_host_const_randomread t_efloat_2d_randomread;
-
-//2d E_FLOAT array n*3
-typedef Kokkos::DualView<E_FLOAT*[3], Kokkos::LayoutRight, DeviceType> tdual_e_array;
-typedef tdual_e_array::t_host t_e_array;
-typedef tdual_e_array::t_host_const t_e_array_const;
-typedef tdual_e_array::t_host_um t_e_array_um;
-typedef tdual_e_array::t_host_const_um t_e_array_const_um;
-typedef tdual_e_array::t_host_const_randomread t_e_array_randomread;
-
-//Neighbor Types
-typedef Kokkos::DualView<int**, DeviceType::array_layout, DeviceType> tdual_neighbors_2d;
-typedef tdual_neighbors_2d::t_host t_neighbors_2d;
-typedef tdual_neighbors_2d::t_host_const t_neighbors_2d_const;
-typedef tdual_neighbors_2d::t_host_um t_neighbors_2d_um;
-typedef tdual_neighbors_2d::t_host_const_um t_neighbors_2d_const_um;
-typedef tdual_neighbors_2d::t_host_const_randomread t_neighbors_2d_randomread;
-
-typedef Kokkos::DualView<double*,Kokkos::LayoutStride> tdual_float_1d_strided;
-typedef tdual_float_1d_strided::t_host t_float_1d_strided;
-typedef tdual_float_1d_strided::t_host_um t_float_1d_strided_um;
+//3d float array
+typedef Kokkos::DualView<SPARTA_FLOAT***, DeviceType::array_layout, DeviceType> tdual_float_3d;
+typedef tdual_float_3d::t_host t_float_3d;
+typedef tdual_float_3d::t_host_const t_float_3d_const;
+typedef tdual_float_3d::t_host_um t_float_3d_um;
+typedef tdual_float_3d::t_host_const_um t_float_3d_const_um;
+typedef tdual_float_3d::t_host_const_randomread t_float_3d_randomread;
 };
+
 #endif
 
 template <typename D>
@@ -1032,17 +731,16 @@ namespace SPARTA_NS {
   { DAT::tdual_float_1d k_view; };
 
   struct struct_tdual_int_2d
-  { DAT::tdual_int_2d k_view; };
+  { DAT::tdual_int_2d_lr k_view; };
 
   struct struct_tdual_float_2d
-  { DAT::tdual_float_2d k_view; };
+  { DAT::tdual_float_2d_lr k_view; };
 
   typedef Kokkos::DualView<struct_tdual_int_1d*, DeviceType::array_layout, DeviceType> tdual_struct_tdual_int_1d_1d;
   typedef Kokkos::DualView<struct_tdual_float_1d*, DeviceType::array_layout, DeviceType> tdual_struct_tdual_float_1d_1d;
   typedef Kokkos::DualView<struct_tdual_int_2d*, DeviceType::array_layout, DeviceType> tdual_struct_tdual_int_2d_1d;
   typedef Kokkos::DualView<struct_tdual_float_2d*, DeviceType::array_layout, DeviceType> tdual_struct_tdual_float_2d_1d;
 }
-
 
 template<class DeviceType, class BufferView, class DualView>
 void buffer_view(BufferView &buf, DualView &view,
@@ -1084,5 +782,11 @@ namespace SPARTA_NS {
 template <typename Device>
 Kokkos::View<int*, Device> offset_scan(Kokkos::View<int*, Device> a, int& total);
 }
+
+#ifdef SPARTA_KOKKOS_GPU
+#if defined(__CUDA_ARCH__) || defined(__HIP_DEVICE_COMPILE__) || defined(__SYCL_DEVICE_ONLY__)
+#define SPARTA_KK_DEVICE_COMPILE
+#endif
+#endif
 
 #endif

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -198,8 +198,11 @@ void ParticleKokkos::sort_kokkos()
 {
   sorted_kk = 1;
   int reorder_scheme = COPYPARTICLELIST;
-  if (update->have_mem_limit())
-    reorder_scheme = FIXEDMEMORY;
+
+  // FIXEDMEMORY reorder temporarily disabled due to bug on GPUs
+
+  //if (update->have_mem_limit())
+  //  reorder_scheme = FIXEDMEMORY;
 
   const int reorder_flag = (update->reorder_period &&
       (update->ntimestep % update->reorder_period == 0));

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -201,20 +201,20 @@ void ParticleKokkos::sort_kokkos()
   if (update->have_mem_limit())
     reorder_scheme = FIXEDMEMORY;
 
+  const int reorder_flag = (update->reorder_period &&
+      (update->ntimestep % update->reorder_period == 0));
+
   ngrid = grid->nlocal;
   GridKokkos* grid_kk = (GridKokkos*)grid;
   d_cellcount = grid_kk->d_cellcount;
   d_plist = grid_kk->d_plist;
 
   if (ngrid > int(d_cellcount.extent(0))) {
-    grid_kk->d_cellcount = DAT::t_int_1d("particle:cellcount",ngrid);
+    grid_kk->d_cellcount = DAT::t_int_1d(Kokkos::NoInit("particle:cellcount"),ngrid);
     d_cellcount = grid_kk->d_cellcount;
-  } else {
-    copymode = 1;
-    Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleZero_cellcount>(0,d_cellcount.extent(0)),*this);
-    DeviceType().fence();
-    copymode = 0;
   }
+
+  Kokkos::deep_copy(d_cellcount,0);
 
   if (ngrid > int(d_plist.extent(0)) || maxcellcount > int(d_plist.extent(1))) {
     grid_kk->d_plist = DAT::t_int_2d(); // destroy reference to reduce memory use
@@ -225,6 +225,13 @@ void ParticleKokkos::sort_kokkos()
   this->sync(Device,PARTICLE_MASK);
   d_particles = k_particles.d_view;
 
+  if (reorder_flag && reorder_scheme == COPYPARTICLELIST) {
+    if (d_particles.extent(0) > d_offsets_part.extent(0)) {
+      d_offsets_part = DAT::t_int_1d();
+      d_offsets_part = DAT::t_int_1d(Kokkos::NoInit("particle:offsets_part"),d_particles.extent(0));
+    }
+  }
+
   // icell = global cell the particle is in
 
   // Cannot grow a Kokkos view in a parallel loop, so
@@ -234,20 +241,24 @@ void ParticleKokkos::sort_kokkos()
 
   do {
     copymode = 1;
-    if (sparta->kokkos->need_atomics)
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<1> >(0,nlocal),*this);
-    else
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<0> >(0,nlocal),*this);
+    if (sparta->kokkos->need_atomics) {
+      if (reorder_flag && reorder_scheme == COPYPARTICLELIST)
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<1,1> >(0,nlocal),*this);
+      else
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<1,0> >(0,nlocal),*this);
+    } else {
+      if (reorder_flag && reorder_scheme == COPYPARTICLELIST)
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<0,1> >(0,nlocal),*this);
+      else
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<0,0> >(0,nlocal),*this);
+    }
     DeviceType().fence();
     copymode = 0;
 
     Kokkos::deep_copy(h_fail_flag,d_fail_flag);
 
     if (h_fail_flag()) {
-      copymode = 1;
-      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleZero_cellcount>(0,ngrid),*this);
-      DeviceType().fence();
-      copymode = 0;
+      Kokkos::deep_copy(d_cellcount,0);
       maxcellcount += DELTACELLCOUNT;
       grid_kk->d_plist = DAT::t_int_2d(); // destroy reference to reduce memory use
       grid_kk->d_plist = DAT::t_int_2d(Kokkos::view_alloc("particle:plist",Kokkos::WithoutInitializing),ngrid,maxcellcount);
@@ -257,14 +268,19 @@ void ParticleKokkos::sort_kokkos()
     }
   } while (h_fail_flag());
 
-  if (update->reorder_period &&
-      (update->ntimestep % update->reorder_period == 0)) {
+  if (reorder_flag) {
 
-    if (reorder_scheme == COPYPARTICLELIST && d_particles.extent(0) > d_sorted.extent(0)) {
-      d_sorted = t_particle_1d();
-      d_sorted = t_particle_1d("particle:sorted",d_particles.extent(0));
-    }
-    else if (reorder_scheme == FIXEDMEMORY && d_pswap1.size() == 0){
+    if (reorder_scheme == COPYPARTICLELIST) {
+      if (d_particles.extent(0) > d_sorted.extent(0)) {
+        d_sorted = t_particle_1d();
+        d_sorted = t_particle_1d(Kokkos::NoInit("particle:sorted"),d_particles.extent(0));
+      }
+
+      if (d_particles.extent(0) > d_sorted_id.extent(0)) {
+        d_sorted_id = DAT::t_int_1d();
+        d_sorted_id = DAT::t_int_1d(Kokkos::NoInit("particle:sorted_id"),d_particles.extent(0));
+      }
+    } else if (reorder_scheme == FIXEDMEMORY && d_pswap1.size() == 0) {
       nParticlesWksp = MIN(nlocal,(double)update->global_mem_limit/sizeof(Particle::OnePart));
       d_pswap1 = t_particle_1d(Kokkos::view_alloc("particle:swap1",Kokkos::WithoutInitializing),nParticlesWksp);
       d_pswap2 = t_particle_1d(Kokkos::view_alloc("particle:swap2",Kokkos::WithoutInitializing),nParticlesWksp);
@@ -274,9 +290,14 @@ void ParticleKokkos::sort_kokkos()
 
     if (reorder_scheme == COPYPARTICLELIST) {
       copymode = 1;
-      Kokkos::parallel_scan(Kokkos::RangePolicy<DeviceType, TagParticleReorder_COPYPARTICLELIST>(0,ngrid),*this);
+      Kokkos::parallel_scan(Kokkos::RangePolicy<DeviceType, TagParticleReorder_COPYPARTICLELIST1>(0,ngrid),*this);
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleReorder_COPYPARTICLELIST2>(0,nlocal),*this);
       copymode = 0;
-      Kokkos::deep_copy(k_particles.d_view,d_sorted);
+      auto tmp = k_particles.d_view;
+      k_particles.d_view = d_sorted;
+      d_particles = k_particles.d_view;
+      d_sorted = tmp;
+      
       this->modify(Device,PARTICLE_MASK);
     }
     else if (reorder_scheme == FIXEDMEMORY) {
@@ -397,9 +418,9 @@ void ParticleKokkos::operator()(TagSetIcellFromPlist, const int &icell) const
   }
 }
 
-template<int NEED_ATOMICS>
+template<int NEED_ATOMICS, int REORDER_FLAG>
 KOKKOS_INLINE_FUNCTION
-void ParticleKokkos::operator()(TagParticleSort<NEED_ATOMICS>, const int &i) const
+void ParticleKokkos::operator()(TagParticleSort<NEED_ATOMICS,REORDER_FLAG>, const int &i) const
 {
   const int icell = d_particles[i].icell;
   int j;
@@ -409,29 +430,40 @@ void ParticleKokkos::operator()(TagParticleSort<NEED_ATOMICS>, const int &i) con
     j = d_cellcount[icell];
     d_cellcount[icell]++;
   }
+
   if (j+1 > maxcellcount)
     d_fail_flag() = 1;
-  if (d_fail_flag()) return;
-  d_plist(icell,j) = i;
-}
+  else {
+    d_plist(icell,j) = i;
 
-KOKKOS_INLINE_FUNCTION
-void ParticleKokkos::operator()(TagParticleReorder_COPYPARTICLELIST, const int icell, int &m_fill, const bool &final) const
-{
-  for (int j = 0; j < d_cellcount[icell]; j++) {
-    if (final) {
-      const int iparticle = d_plist(icell,j);
-      //memcpy(&d_sorted[m_fill],&d_particles[iparticle],nbytes);
-      d_sorted[m_fill] = d_particles[iparticle];
-      d_plist(icell,j) = m_fill;
-    }
-    m_fill++;
+    if (REORDER_FLAG)
+      d_offsets_part[i] = j;
   }
+
+  if (d_fail_flag()) return;
 }
 
 KOKKOS_INLINE_FUNCTION
-void ParticleKokkos::operator()(TagParticleZero_cellcount, const int &i) const {
-  d_cellcount[i] = 0.0;
+void ParticleKokkos::operator()(TagParticleReorder_COPYPARTICLELIST1, const int icell, int &m_fill, const bool &final) const
+{
+  if (final) {
+    for (int j = 0; j < d_cellcount[icell]; j++) {
+      const int iparticle = d_plist(icell,j);
+      d_sorted_id[m_fill++] = iparticle;
+    }
+  } else
+    m_fill += d_cellcount[icell];
+}
+
+KOKKOS_INLINE_FUNCTION
+void ParticleKokkos::operator()(TagParticleReorder_COPYPARTICLELIST2, const int offset) const
+{
+  const int iparticle = d_sorted_id[offset];
+  const Particle::OnePart &particle_i = d_particles[iparticle];
+  d_sorted[offset] = particle_i;
+  const int icell = particle_i.icell;
+  const int j = d_offsets_part[iparticle];
+  d_plist(icell,j) = offset;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/KOKKOS/particle_kokkos.h
+++ b/src/KOKKOS/particle_kokkos.h
@@ -23,16 +23,16 @@
 
 namespace SPARTA_NS {
 
-struct TagParticleZero_cellcount{};
 struct TagParticleCompressReactions{};
 struct TagCopyParticleReorderDestinations{};
 struct TagFixedMemoryReorder{};
 struct TagFixedMemoryReorderInit{};
 struct TagSetIcellFromPlist{};
-struct TagParticleReorder_COPYPARTICLELIST{};
+struct TagParticleReorder_COPYPARTICLELIST1{};
+struct TagParticleReorder_COPYPARTICLELIST2{};
 struct TagSetDPlistNewStyle{};
 
-template<int NEED_ATOMICS>
+template<int NEED_ATOMICS, int REORDER_FLAG>
 struct TagParticleSort{};
 
 
@@ -91,17 +91,17 @@ class ParticleKokkos : public Particle {
   void modify(ExecutionSpace, unsigned int);
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagParticleZero_cellcount, const int&) const;
-
-  KOKKOS_INLINE_FUNCTION
   void operator()(TagParticleCompressReactions, const int&) const;
 
-  template<int NEED_ATOMICS>
+  template<int NEED_ATOMICS, int REORDER_FLAG>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagParticleSort<NEED_ATOMICS>, const int&) const;
+  void operator()(TagParticleSort<NEED_ATOMICS,REORDER_FLAG>, const int&) const;
 
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagParticleReorder_COPYPARTICLELIST, const int, int&, const bool&) const;
+  void operator()(TagParticleReorder_COPYPARTICLELIST1, const int, int&, const bool&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagParticleReorder_COPYPARTICLELIST2, const int) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(TagCopyParticleReorderDestinations, const int, int&, const bool&) const;
@@ -142,8 +142,11 @@ class ParticleKokkos : public Particle {
 
  private:
   t_particle_1d d_particles;
-  t_particle_1d d_sorted;
   t_species_1d d_species;
+
+  t_particle_1d d_sorted;
+  DAT::t_int_1d d_sorted_id;
+  DAT::t_int_1d d_offsets_part;
   int nParticlesWksp;
   DAT::tdual_int_scalar k_reorder_pass;
   DAT::t_int_scalar d_reorder_pass;

--- a/src/grid.h
+++ b/src/grid.h
@@ -85,7 +85,7 @@ class Grid : protected Pointers {
   // includes unsplit cells, split cells, sub cells in any order
   // ghost cells are appended to owned
 
-  struct ChildCell {
+  struct SPARTA_ALIGN(128) ChildCell {
     cellint id;               // ID of child cell
     int level;                // level of cell in hierarchical grid, 0 = root
     int proc;                 // proc that owns this cell

--- a/src/particle.h
+++ b/src/particle.h
@@ -67,7 +67,7 @@ class Particle : protected Pointers {
   int nmixture;
   int maxmixture;
 
-  struct OnePart {
+  struct SPARTA_ALIGN(128) OnePart {
     int id;                 // particle ID
     int ispecies;           // particle species index
     int icell;              // which local Grid::cells the particle is in

--- a/src/spatype.h
+++ b/src/spatype.h
@@ -46,6 +46,12 @@ namespace SPARTA_NS {
 
 enum ExecutionSpace{Host,Device};
 
+#if defined(SPARTA_KOKKOS)
+#define SPARTA_ALIGN(n) alignas(n)
+#else
+#define SPARTA_ALIGN(n)
+#endif
+
 // default settings: 32-bit smallint, 64-bit bigint, 32-bit cellint
 
 #if !defined(SPARTA_SMALL) && !defined(SPARTA_BIG) && !defined(SPARTA_BIGBIG)

--- a/src/spatype.h
+++ b/src/spatype.h
@@ -46,7 +46,9 @@ namespace SPARTA_NS {
 
 enum ExecutionSpace{Host,Device};
 
-#if defined(SPARTA_KOKKOS)
+// struct alignment for GPUs
+
+#if defined(SPARTA_KOKKOS_GPU)
 #define SPARTA_ALIGN(n) alignas(n)
 #else
 #define SPARTA_ALIGN(n)


### PR DESCRIPTION
## Purpose

Several optimizations for NVIDIA V100 GPUs, especially reducing cost of the `global particle/reorder` option, which allows one to reorder more often, improving performance of the `move` algorithm due to better data locality.

For the `in.collide` benchmark with 10 million particles on   a V100 GPU, I see 1.45x overall speedup going from the `master` branch with `particle/reorder 10` to this branch with `particle/reorder 5`.

Also use better default KOKKOS package options for CPUs vs GPUs, and change the `comm classic` command to `comm serial`. The `classic` option is still accepted for backwards compatibility but deprecated.

## Author(s)

Stan Moore (SNL), with helpful discussions/ideas from Evan Weinberg (NVIDIA), @weinbe2

## Backward Compatibility

Yes