### PR TITLE
Fix issue from #357 and some other small tweaks

### DIFF
--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -336,7 +336,6 @@ void CollideVSSKokkos::reset_vremax()
 
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagCollideResetVremax>(0,nglocal),*this);
-  DeviceType().fence();
   copymode = 0;
 
   this->modified(Device,ALL_MASK);
@@ -575,7 +574,6 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
 
   particle->nlocal = h_nlocal();
 
-  DeviceType().fence();
   copymode = 0;
 
   if (h_error_flag())
@@ -923,7 +921,6 @@ void CollideVSSKokkos::collisions_one_ambipolar(COLLIDE_REDUCE &reduce)
 
   particle->nlocal = h_nlocal();
 
-  DeviceType().fence();
   copymode = 0;
 
   if (h_error_flag() == 1)

--- a/src/KOKKOS/compute_count_kokkos.cpp
+++ b/src/KOKKOS/compute_count_kokkos.cpp
@@ -169,7 +169,6 @@ void ComputeCountKokkos::per_species_tally_kokkos()
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeCount_per_species_tally_atomic<1> >(0,nlocal),*this);
   else
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeCount_per_species_tally_atomic<0> >(0,nlocal),*this);
-  DeviceType().fence();
   copymode = 0;
 
   if (need_dup) {

--- a/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_distsurf_grid_kokkos.cpp
@@ -116,7 +116,6 @@ void ComputeDistSurfGridKokkos::compute_per_grid_kokkos()
   // pre-compute center point of each eligible surf
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeDistSurfGrid_surf_centroid>(0,nsurf),*this);
-  DeviceType().fence();
   copymode = 0;
 
   // loop over my unsplit/split grid cells
@@ -134,7 +133,6 @@ void ComputeDistSurfGridKokkos::compute_per_grid_kokkos()
 
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeDistSurfGrid_surf_distance>(0,nglocal),*this);
-  DeviceType().fence();
   copymode = 0;
 
   memoryKK->destroy_kokkos(k_eflag);

--- a/src/KOKKOS/compute_eflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.cpp
@@ -129,7 +129,6 @@ void ComputeEFluxGridKokkos::compute_per_grid_kokkos()
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeEFluxGrid_compute_per_grid_atomic<0> >(0,nlocal),*this);
   }
-  DeviceType().fence();
   copymode = 0;
 
   if (need_dup) {
@@ -403,7 +402,6 @@ void ComputeEFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
 
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeEFluxGrid_post_process_grid>(lo,hi),*this);
-  DeviceType().fence();
   copymode = 0;
 }
 

--- a/src/KOKKOS/compute_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_grid_kokkos.cpp
@@ -128,7 +128,6 @@ void ComputeGridKokkos::compute_per_grid_kokkos()
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_compute_per_grid_atomic<0> >(0,nlocal),*this);
   }
-  DeviceType().fence();
   copymode = 0;
 
   if (need_dup) {
@@ -354,7 +353,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
     {
       count = emap[0];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_NUM>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -363,7 +361,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       mass = emap[0];
       count = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_MASS>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -371,7 +368,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
     {
       count = emap[0];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_NRHO>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -379,7 +375,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
     {
       mass = emap[0];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_MASSRHO>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -389,7 +384,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       count_or_mass = emap[0];
       cell_count_or_mass = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_NFRAC>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -403,7 +397,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       velocity = emap[0];
       mass = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_U>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -412,7 +405,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       mvsq = emap[0];
       count = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_KE>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -421,7 +413,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       mvsq = emap[0];
       count = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_TEMPERATURE>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -431,7 +422,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       eng = emap[0];
       count = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_EROT>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -441,7 +431,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
       eng = emap[0];
       dof = emap[1];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_TROT>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -451,7 +440,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
     {
       mom = emap[0];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_PXRHO>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
 
@@ -459,7 +447,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
     {
       ke = emap[0];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeGrid_KERHO>(lo,hi),*this);
-      DeviceType().fence();
       break;
     }
   }

--- a/src/KOKKOS/compute_ke_particle_kokkos.cpp
+++ b/src/KOKKOS/compute_ke_particle_kokkos.cpp
@@ -79,7 +79,6 @@ void ComputeKEParticleKokkos::compute_per_particle_kokkos()
   // compute kinetic energy for each atom in group
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType>(0,nlocal),*this);
-  DeviceType().fence();
   copymode = 0;
 
   d_particles = t_particle_1d(); // destroy reference to reduce memory use

--- a/src/KOKKOS/compute_lambda_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_lambda_grid_kokkos.cpp
@@ -105,7 +105,6 @@ void ComputeLambdaGridKokkos::compute_per_grid_kokkos()
       d_array = computeKKBase->d_array_grid;
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeLambdaGrid_LoadNrhoVecFromArray>(0,nglocal),*this);
-      DeviceType().fence();
       copymode = 0;
     }
   } else if (nrhowhich == FIX) {
@@ -118,7 +117,6 @@ void ComputeLambdaGridKokkos::compute_per_grid_kokkos()
       d_array = computeKKBase->d_array_grid;
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeLambdaGrid_LoadNrhoVecFromArray>(0,nglocal),*this);
-      DeviceType().fence();
       copymode = 0;
     }
   }
@@ -141,7 +139,6 @@ void ComputeLambdaGridKokkos::compute_per_grid_kokkos()
       d_array = computeKKBase->d_array_grid;
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeLambdaGrid_LoadTempVecFromArray>(0,nglocal),*this);
-      DeviceType().fence();
       copymode = 0;
     }
   } else if (tempwhich == FIX) {
@@ -154,7 +151,6 @@ void ComputeLambdaGridKokkos::compute_per_grid_kokkos()
       d_array = computeKKBase->d_array_grid;
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeLambdaGrid_LoadTempVecFromArray>(0,nglocal),*this);
-      DeviceType().fence();
       copymode = 0;
     }
   }
@@ -165,7 +161,6 @@ void ComputeLambdaGridKokkos::compute_per_grid_kokkos()
   dimension = domain->dimension;
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeLambdaGrid_ComputePerGrid>(0,nglocal),*this);
-  DeviceType().fence();
   copymode = 0;
 
   if (kflag == KNONE) {

--- a/src/KOKKOS/compute_pflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.cpp
@@ -126,7 +126,6 @@ void ComputePFluxGridKokkos::compute_per_grid_kokkos()
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputePFluxGrid_compute_per_grid_atomic<0> >(0,nlocal),*this);
   }
-  DeviceType().fence();
   copymode = 0;
 
   if (need_dup) {
@@ -332,7 +331,6 @@ void ComputePFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
       mvv = emap[2];
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputePFluxGrid_post_process_grid_diag>(lo,hi),*this);
-      DeviceType().fence();
       copymode = 0;
       break;
     }
@@ -345,7 +343,6 @@ void ComputePFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
       mvv = emap[3];
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputePFluxGrid_post_process_grid_offdiag>(lo,hi),*this);
-      DeviceType().fence();
       copymode = 0;
       break;
     }

--- a/src/KOKKOS/compute_property_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_property_grid_kokkos.cpp
@@ -89,7 +89,6 @@ void ComputePropertyGridKokkos::compute_per_grid_kokkos()
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputePropertyGrid_ComputePerGrid_vector>(0,nglocal),*this);
   else
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputePropertyGrid_ComputePerGrid_array>(0,nglocal),*this);
-  DeviceType().fence();
   copymode = 0;
 }
 

--- a/src/KOKKOS/compute_sonine_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.cpp
@@ -133,10 +133,8 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSonineGrid_compute_vcom_init_atomic<1> >(0,nlocal),*this);
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSonineGrid_compute_vcom_init_atomic<0> >(0,nlocal),*this);
-    DeviceType().fence();
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSonineGrid_normalize_vcom>(0,nglocal),*this);
   }
-  DeviceType().fence();
 
   if (need_dup) {
     Kokkos::Experimental::contribute(d_vcom, dup_vcom_tally);
@@ -152,7 +150,6 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSonineGrid_compute_per_grid_atomic<0> >(0,nlocal),*this);
   }
-  DeviceType().fence();
   copymode = 0;
 
   if (need_dup) {
@@ -390,7 +387,6 @@ void ComputeSonineGridKokkos::post_process_grid_kokkos(int index,
 
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeSonineGrid_post_process_grid>(lo,hi),*this);
-  DeviceType().fence();
   copymode = 0;
 }
 

--- a/src/KOKKOS/compute_temp_kokkos.cpp
+++ b/src/KOKKOS/compute_temp_kokkos.cpp
@@ -70,7 +70,6 @@ double ComputeTempKokkos::compute_scalar_kokkos()
   double t = 0.0;
   auto range_policy = Kokkos::RangePolicy<DeviceType>(0, nlocal);
   Kokkos::parallel_reduce(range_policy, *this, t);
-  DeviceType().fence();
   copymode = 0;
 
   d_particles = t_particle_1d(); // destroy reference to reduce memory use

--- a/src/KOKKOS/compute_thermal_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_thermal_grid_kokkos.cpp
@@ -110,7 +110,6 @@ void ComputeThermalGridKokkos::compute_per_grid_kokkos()
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeThermalGrid_compute_per_grid_atomic<0> >(0,nlocal),*this);
   }
-  DeviceType().fence();
   copymode = 0;
 
   if (need_dup) {
@@ -265,7 +264,6 @@ post_process_grid_kokkos(int index, int nsample,
 
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagComputeThermalGrid_post_process_grid>(lo,hi),*this);
-  DeviceType().fence();
   copymode = 0;
 }
 

--- a/src/KOKKOS/fix_ave_grid_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_grid_kokkos.cpp
@@ -169,10 +169,8 @@ void FixAveGridKokkos::end_of_step()
   // could do this with memset()
 
   copymode = 1;
-  if (ave == ONE && irepeat == 0) {
+  if (ave == ONE && irepeat == 0)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Zero_tally>(0,nglocal),*this);
-    DeviceType().fence();
-  }
 
   // accumulate results of computes,fixes,variables
   // compute/fix/variable may invoke computes so wrap with clear/add
@@ -208,18 +206,15 @@ void FixAveGridKokkos::end_of_step()
         ntally = numap[m];
         computeKKBase->query_tally_grid_kokkos(d_ctally);
         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Add_ctally>(0,nglocal),*this);
-        DeviceType().fence();
       } else {
         k = umap[m][0];
         if (j == 0) {
           d_compute_vector = computeKKBase->d_vector;
           Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Add_compute_vector>(0,nglocal),*this);
-          DeviceType().fence();
         } else {
           jm1 = j - 1;
           d_compute_array = computeKKBase->d_array_grid;
           Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Add_compute_array>(0,nglocal),*this);
-          DeviceType().fence();
         }
       }
 
@@ -231,12 +226,10 @@ void FixAveGridKokkos::end_of_step()
       //if (j == 0) {
       //  double *d_fix_vector = modify->fix[n]->vector_grid; // need Kokkos version
       //  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Add_fix_vector>(0,nglocal),*this);
-      //  DeviceType().fence();
       //} else {
       //  int jm1 = j - 1;
       //  double **fix_array = modify->fix[n]->array_grid; // need Kokkos version
       //  Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Add_fix_array>(0,nglocal),*this);
-      //  DeviceType().fence();
       //}
 
     // evaluate grid-style variable, sum values to Kth column of tally array
@@ -279,7 +272,6 @@ void FixAveGridKokkos::end_of_step()
     } else {
       k = map[0][0];
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Norm_vector_grid>(0,nglocal),*this);
-      DeviceType().fence();
     }
 
   } else {
@@ -294,7 +286,6 @@ void FixAveGridKokkos::end_of_step()
       } else {
         k = map[m][0];
         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Norm_array_grid>(0,nglocal),*this);
-        DeviceType().fence();
       }
     }
   }
@@ -317,7 +308,6 @@ void FixAveGridKokkos::end_of_step()
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Zero_group_vector>(0,nglocal),*this);
     else
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Zero_group_array>(0,nglocal),*this);
-    DeviceType().fence();
   }
 
   // reset nsample if ave = ONE

--- a/src/KOKKOS/fix_ave_histo_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_kokkos.cpp
@@ -488,7 +488,6 @@ void FixAveHistoKokkos::bin_vector(
 
   auto policy = Kokkos::RangePolicy<TagFixAveHisto_BinVector,DeviceType>(0, n);
   Kokkos::parallel_reduce(policy, *this, reducer);
-  DeviceType().fence();
 }
 
 /* ----------------------------------------------------------------------
@@ -526,7 +525,6 @@ void FixAveHistoKokkos::bin_particles(
       auto policy = RangePolicy<TagFixAveHisto_BinParticlesX4,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
     }
-    DeviceType().fence();
 
   } else if (attribute == V) {
 
@@ -543,7 +541,6 @@ void FixAveHistoKokkos::bin_particles(
       auto policy = RangePolicy<TagFixAveHisto_BinParticlesV4,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
     }
-    DeviceType().fence();
   }
 }
 
@@ -583,7 +580,6 @@ void FixAveHistoKokkos::bin_particles(
     auto policy = RangePolicy<TagFixAveHisto_BinParticles4,DeviceType>(0, n);
     Kokkos::parallel_reduce(policy, *this, reducer);
   }
-  DeviceType().fence();
 }
 
 /* ----------------------------------------------------------------------
@@ -608,7 +604,6 @@ void FixAveHistoKokkos::bin_grid_cells(
     auto policy = RangePolicy<TagFixAveHisto_BinGridCells2,DeviceType>(0, n);
     Kokkos::parallel_reduce(policy, *this, reducer);
   }
-  DeviceType().fence();
 }
 
 

--- a/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
@@ -297,7 +297,6 @@ void FixAveHistoWeightKokkos::bin_vector(
 
   auto policy = Kokkos::RangePolicy<TagFixAveHistoWeight_BinVector,DeviceType>(0, n);
   Kokkos::parallel_reduce(policy, *this, reducer);
-  DeviceType().fence();
 }
 
 /* ----------------------------------------------------------------------
@@ -336,7 +335,6 @@ void FixAveHistoWeightKokkos::bin_particles(
       auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesX4,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
     }
-    DeviceType().fence();
 
   } else if (attribute == V) {
 
@@ -353,7 +351,6 @@ void FixAveHistoWeightKokkos::bin_particles(
       auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesV4,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
     }
-    DeviceType().fence();
   }
 }
 
@@ -393,7 +390,6 @@ void FixAveHistoWeightKokkos::bin_particles(
     auto policy = RangePolicy<TagFixAveHistoWeight_BinParticles4,DeviceType>(0, n);
     Kokkos::parallel_reduce(policy, *this, reducer);
   }
-  DeviceType().fence();
 }
 
 /* ----------------------------------------------------------------------
@@ -419,7 +415,6 @@ void FixAveHistoWeightKokkos::bin_grid_cells(
     auto policy = RangePolicy<TagFixAveHistoWeight_BinGridCells2,DeviceType>(0, n);
     Kokkos::parallel_reduce(policy, *this, reducer);
   }
-  DeviceType().fence();
 }
 
 /* ------------------------------------------------------------------------- */

--- a/src/KOKKOS/kokkos.h
+++ b/src/KOKKOS/kokkos.h
@@ -65,7 +65,7 @@ Self-explanatory.  See Section ? of the manual for details.
 
 E: Could not determine local MPI rank for multiple GPUs with Kokkos CUDA because MPI library not recognized
 
-The local MPI rank was not found in one of four supported environment variables.
+The local MPI rank was not found in one of five supported environment variables.
 
 E: GPUs are requested but Kokkos has not been compiled for CUDA
 

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -768,14 +768,6 @@ struct MemsetZeroFunctor {
   }
 };
 
-template<class ViewType>
-void memset_kokkos (ViewType &view) {
-  static MemsetZeroFunctor<typename ViewType::execution_space> f;
-  f.ptr = view.data();
-  Kokkos::parallel_for(view.scan()*sizeof(typename ViewType::value_type)/4, f);
-  ViewType::execution_space::fence();
-}
-
 #define SPARTA_LAMBDA KOKKOS_LAMBDA
 
 namespace SPARTA_NS {

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -120,11 +120,11 @@ void ParticleKokkos::compress_migrate(int ndelete, int *dellist)
   nbytes = sizeof(OnePart);
 
   if (ndelete > d_lists.extent(1)) {
-    d_lists = DAT::t_int_2d(Kokkos::view_alloc("particle:lists",Kokkos::WithoutInitializing),2,ndelete);
+    d_lists = DAT::t_int_2d_lr(Kokkos::view_alloc("particle:lists",Kokkos::WithoutInitializing),2,ndelete);
     d_mlist = Kokkos::subview(d_lists,0,Kokkos::ALL);
     d_slist = Kokkos::subview(d_lists,1,Kokkos::ALL);
 
-    h_lists = HAT::t_int_2d(Kokkos::view_alloc("particle:lists_mirror",Kokkos::WithoutInitializing),2,ndelete);
+    h_lists = HAT::t_int_2d_lr(Kokkos::view_alloc("particle:lists_mirror",Kokkos::WithoutInitializing),2,ndelete);
     h_mlist = Kokkos::subview(h_lists,0,Kokkos::ALL);
     h_slist = Kokkos::subview(h_lists,1,Kokkos::ALL);
   }

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -167,7 +167,6 @@ void ParticleKokkos::compress_migrate(int ndelete, int *dellist)
 
   copymode = 1;
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleCompressReactions>(0,ncopy),*this);
-  DeviceType().fence();
   copymode = 0;
 
   this->modify(Device,PARTICLE_MASK|CUSTOM_MASK);
@@ -182,7 +181,6 @@ KOKKOS_INLINE_FUNCTION
 void ParticleKokkos::operator()(TagParticleCompressReactions, const int &i) const {
   const int j = d_mlist[i];
   const int k = d_slist[i];
-  //memcpy(&d_particles[j],&d_particles[k],nbytes);
   d_particles[j] = d_particles[k];
   copy_custom_kokkos(j,k);
 }
@@ -255,7 +253,6 @@ void ParticleKokkos::sort_kokkos()
       else
         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagParticleSort<0,0> >(0,nlocal),*this);
     }
-    DeviceType().fence();
     copymode = 0;
 
     Kokkos::deep_copy(h_fail_flag,d_fail_flag);
@@ -310,7 +307,6 @@ void ParticleKokkos::sort_kokkos()
       // the variable naming.
       copymode = 1;
       Kokkos::parallel_scan(Kokkos::RangePolicy<DeviceType, TagCopyParticleReorderDestinations>(0,ngrid),*this);
-      DeviceType().fence();
       copymode = 0;
 
       int npasses = (nlocal-1)/nParticlesWksp + 1;
@@ -323,20 +319,17 @@ void ParticleKokkos::sort_kokkos()
         // identify next set of particles to reorder
         copymode = 1;
         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixedMemoryReorderInit>(0,nParticlesWksp),*this);
-        DeviceType().fence();
         copymode = 0;
 
         // reorder this set of particles
         copymode = 1;
         Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixedMemoryReorder>(0,nParticlesWksp),*this);
-        DeviceType().fence();
         copymode = 0;
       }
 
       // reset the icell values in the particle list
       copymode = 1;
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagSetIcellFromPlist>(0,ngrid),*this);
-      DeviceType().fence();
       copymode = 0;
       this->modify(Device,PARTICLE_MASK);
 

--- a/src/KOKKOS/particle_kokkos.h
+++ b/src/KOKKOS/particle_kokkos.h
@@ -160,11 +160,11 @@ class ParticleKokkos : public Particle {
   DAT::t_int_2d d_plist;
   DAT::t_int_1d d_cellcount;
 
-  DAT::t_int_2d d_lists;
+  DAT::t_int_2d_lr d_lists;
   DAT::t_int_1d d_mlist;
   DAT::t_int_1d d_slist;
 
-  HAT::t_int_2d h_lists;
+  HAT::t_int_2d_lr h_lists;
   HAT::t_int_1d h_mlist;
   HAT::t_int_1d h_slist;
 

--- a/src/KOKKOS/rand_pool_wrap.h
+++ b/src/KOKKOS/rand_pool_wrap.h
@@ -60,10 +60,12 @@ class RandPoolWrap : protected Pointers {
     typedef Kokkos::Experimental::UniqueToken<
       DeviceType, Kokkos::Experimental::UniqueTokenScope::Global> unique_token_type;
 
+#ifndef SPARTA_KK_DEVICE_COMPILE
     unique_token_type unique_token;
     int tid = unique_token.acquire();
     rand_wrap.rng = random_thr[tid];
     unique_token.release(tid);
+#endif
 
     return rand_wrap;
   }

--- a/src/comm.cpp
+++ b/src/comm.cpp
@@ -37,6 +37,11 @@ Comm::Comm(SPARTA *sparta) : Pointers(sparta)
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
 
+  if (me == 0) {
+    if (screen) fprintf(screen,"Running on %d MPI task(s)\n",nprocs);
+    if (logfile) fprintf(logfile,"Running on %d MPI task(s)\n",nprocs);
+  }
+
   ncomm = 0;
   commsortflag = 0;
   commpartstyle = 1;


### PR DESCRIPTION
## Purpose

Fix issue from #357 and some other small tweaks

Sample output:

```
SPARTA (18 Jul 2022)
KOKKOS mode is enabled (../kokkos.cpp:40)
  requested 1 GPU(s) per node
  requested 1 thread(s) per MPI task
Running on 1 MPI task(s)
Created orthogonal box = (-5 -5 -5) to (5 5 5)
```

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes