### PR TITLE
Expose `SPARTA_KOKKOS_GPU` macro

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,8 +17,8 @@ set(SPARTA_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 # ######### END   SETUP COMMANDS ##########
 
 # ######### BEGIN PROCESSING PACKAGES - RECURSE COMMANDS ##########
-add_subdirectory(${SPARTA_SRC_DIR}/FFT)
 add_subdirectory(${SPARTA_SRC_DIR}/KOKKOS)
+add_subdirectory(${SPARTA_SRC_DIR}/FFT)
 add_subdirectory(${SPARTA_SRC_DIR}/STUBS)
 # message(VERBOSE "${CMAKE_CURRENT_SOURCE_DIR}:
 # CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")

--- a/src/FFT/CMakeLists.txt
+++ b/src/FFT/CMakeLists.txt
@@ -17,6 +17,10 @@ if(PKG_FFT)
   target_link_libraries(${TARGET_SPARTA_PKG_FFT} LINK_PRIVATE
                         ${TARGET_SPARTA_BUILD_MPI})
 
+  # Get Kokkos header files
+  target_link_libraries(${TARGET_SPARTA_PKG_FFT} LINK_PRIVATE
+                        ${Kokkos_INCLUDE_DIRS_RET})
+
   # Get FFT header files
   if(FFT)
     target_link_libraries(${TARGET_SPARTA_PKG_FFT} LINK_PRIVATE

--- a/src/FFT/CMakeLists.txt
+++ b/src/FFT/CMakeLists.txt
@@ -19,7 +19,7 @@ if(PKG_FFT)
 
   # Get Kokkos header files
   target_link_libraries(${TARGET_SPARTA_PKG_FFT} LINK_PRIVATE
-                        ${Kokkos_INCLUDE_DIRS_RET})
+                        ${TARGET_SPARTA_BUILD_KOKKOS})
 
   # Get FFT header files
   if(FFT)

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -23,14 +23,10 @@
 #include "grid.h"
 #include "surf.h"
 #include "spatype.h"
+#include "accelerator_kokkos_defs.h"
 
 #define MAX_TYPES_STACKPARAMS 12
 #define NeighClusterSize 8
-
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET)
-
-#define SPARTA_KOKKOS_GPU
-#endif
 
 namespace Kokkos {
   static auto NoInit = [](std::string const& label) {

--- a/src/KOKKOS/rand_pool_wrap.h
+++ b/src/KOKKOS/rand_pool_wrap.h
@@ -60,7 +60,7 @@ class RandPoolWrap : protected Pointers {
     typedef Kokkos::Experimental::UniqueToken<
       DeviceType, Kokkos::Experimental::UniqueTokenScope::Global> unique_token_type;
 
-#ifndef SPARTA_KK_DEVICE_COMPILE
+#ifndef SPARTA_KOKKOS_GPU
     unique_token_type unique_token;
     int tid = unique_token.acquire();
     rand_wrap.rng = random_thr[tid];

--- a/src/accelerator_kokkos.h
+++ b/src/accelerator_kokkos.h
@@ -43,8 +43,6 @@
 #include "surf.h"
 #include "modify.h"
 
-#define ALL_MASK       0xffffffff
-
 namespace SPARTA_NS {
 
 class KokkosSPARTA {
@@ -56,8 +54,6 @@ class KokkosSPARTA {
   KokkosSPARTA(class SPARTA *, int, char **) {kokkos_exists = 0;}
   ~KokkosSPARTA() {}
   void accelerator(int, char **) {}
-  //int neigh_list_kokkos(int) {return 0;}
-  //int neigh_count(int) {return 0;}
 };
 
 class Kokkos {
@@ -105,13 +101,6 @@ class ModifyKokkos : public Modify {
  public:
   ModifyKokkos(class SPARTA *sparta) : Modify(sparta) {}
   ~ModifyKokkos() {}
-};
-
-class DAT {
- public:
-  typedef double* t_float_1d;
-  typedef double** t_float_2d_lr;
-  typedef double* t_float_1d_strided;
 };
 
 }

--- a/src/accelerator_kokkos_defs.h
+++ b/src/accelerator_kokkos_defs.h
@@ -1,0 +1,28 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@sandia.gov, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_ACCELERATOR_KOKKOS_DEFS_H
+#define SPARTA_ACCELERATOR_KOKKOS_DEFS_H
+
+#ifdef SPARTA_KOKKOS
+
+#include <Kokkos_Core.hpp>
+
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL) || defined(KOKKOS_ENABLE_OPENMPTARGET)
+
+#define SPARTA_KOKKOS_GPU
+
+#endif
+#endif
+#endif

--- a/src/spatype.h
+++ b/src/spatype.h
@@ -33,6 +33,7 @@
 #include "limits.h"
 #include "stdint.h"
 #include "inttypes.h"
+#include "accelerator_kokkos_defs.h"
 
 // grrr - IBM Power6 does not provide this def in their system header files
 


### PR DESCRIPTION
## Purpose

Expose `SPARTA_KOKKOS_GPU` macro, which wasn't properly defined in #357, so the value in `spatype.h` was always 0.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes