### PR TITLE
Fix bug regarding transparent surfaces in grid_surf

### DIFF
--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -278,13 +278,17 @@ void Grid::surf2grid_cell_algorithm(int outflag)
       if (dim == 2) {
 
         for (i = 0; i < nsurf; i++) {
-          if (!lines[ptr[i]].transparent) nontrans = 1;
-          break;
+          if (!lines[ptr[i]].transparent) {
+            nontrans = 1;
+            break;
+          }
         }
       } else {
         for (i = 0; i < nsurf; i++) {
-          if (!tris[ptr[i]].transparent) nontrans = 1;
-          break;
+          if (!tris[ptr[i]].transparent) {
+            nontrans = 1;
+            break;
+          }
         }
       }
 
@@ -950,13 +954,17 @@ void Grid::surf2grid_surf_algorithm(int outflag)
 
     if (dim == 2) {
       for (i = 0; i < n; i++) {
-	if (!lines[list[i]].transparent) nontrans = 1;
-	break;
+        if (!lines[list[i]].transparent) {
+          nontrans = 1;
+          break;
+        }
       }
     } else {
       for (i = 0; i < n; i++) {
-	if (!tris[list[i]].transparent) nontrans = 1;
-	break;
+        if (!tris[list[i]].transparent) {
+          nontrans = 1;
+          break;
+        }
       }
     }
 


### PR DESCRIPTION
## Purpose

Discovered this while I was tracking something different. I have not seen this blow up, but the code makes no sense if the conditionals do not include the `break` as it will always only inspect the first element in the `for`-loop in the current implementation? If I am wrong feel free to just close this.

## Author(s)

Tim Teichmann (KIT)

## Backward Compatibility

I think it should be compatible, but not 100% sure.

## Implementation Notes



## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines


