### PR TITLE
Remove unused Kokkos impl header to fix compile warning

### DIFF
--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -16,7 +16,6 @@
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DualView.hpp>
-#include <Kokkos_Vectorization.hpp>
 #include <Kokkos_ScatterView.hpp>
 
 #include "particle.h"


### PR DESCRIPTION
## Purpose

Remove unused Kokkos impl header to fix compile warning

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes
