### PR TITLE
Increase MAXLINE in fix_emit_face_file to prevent overflow

### DIFF
--- a/src/fix_emit_face_file.cpp
+++ b/src/fix_emit_face_file.cpp
@@ -45,7 +45,7 @@ enum{NOSUBSONIC,PTBOTH,PONLY};
 
 #define DELTATASK 256
 #define TEMPLIMIT 1.0e5
-#define MAXLINE 1024
+#define MAXLINE 16384
 
 /* ---------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Purpose

Increase `MAXLINE` in `fix_emit_face_file` to prevent overflow for a large number of cells.

## Author(s)

Stan Moore (SNL), reported on the mail list by Sachin Nair (UT Austin), fixed by Steve Plimpton

## Backward Compatibility

Yes