### PR TITLE
Properly align pointers for Kokkos GPU

### DIFF
--- a/src/KOKKOS/compute_eflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_eflux_grid_kokkos.cpp
@@ -360,7 +360,6 @@ void ComputeEFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
 
   this->d_etally = d_etally;
   this->d_vec = d_vec;
-  this->nstride = nstride;
   this->nsample = nsample;
 
   // compute normalized final value for each grid cell

--- a/src/KOKKOS/compute_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_grid_kokkos.cpp
@@ -335,7 +335,6 @@ void ComputeGridKokkos::post_process_grid_kokkos(int index, int nsample,
   this->nsample = nsample;
   this->d_etally = d_etally;
   this->d_vec = d_vec;
-  this->nstride = nstride;
 
   GridKokkos* grid_kk = (GridKokkos*) grid;
   grid_kk->sync(Device,CINFO_MASK);

--- a/src/KOKKOS/compute_pflux_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_pflux_grid_kokkos.cpp
@@ -302,7 +302,6 @@ void ComputePFluxGridKokkos::post_process_grid_kokkos(int index, int nsample,
 
   this->d_etally = d_etally;
   this->d_vec = d_vec;
-  this->nstride = nstride;
   this->nsample = nsample;
 
   // compute normalized final value for each grid cell

--- a/src/KOKKOS/compute_thermal_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_thermal_grid_kokkos.cpp
@@ -238,7 +238,6 @@ post_process_grid_kokkos(int index, int nsample,
 
   this->d_etally = d_etally;
   this->d_vec = d_vec;
-  this->nstride = nstride;
   this->nsample = nsample;
 
   // compute normalized final value for each grid cell

--- a/src/KOKKOS/compute_tvib_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_tvib_grid_kokkos.cpp
@@ -293,7 +293,6 @@ post_process_grid_kokkos(int index, int nsample,
 
   this->d_etally = d_etally;
   this->d_vec = d_vec;
-  this->nstride = nstride;
 
   // compute normalized single Tgroup value for each grid cell
   // compute Ibar and Tspecies for each species in the requested group

--- a/src/KOKKOS/fix_emit_face_kokkos.h
+++ b/src/KOKKOS/fix_emit_face_kokkos.h
@@ -36,8 +36,8 @@ class FixEmitFaceKokkos : public FixEmitFace {
   typedef int value_type;
 
   FixEmitFaceKokkos(class SPARTA *, int, char **);
-  ~FixEmitFaceKokkos();
-  void init();
+  ~FixEmitFaceKokkos() override;
+  void init() override;
   void perform_task() override;
   void perform_task_twopass() override { perform_task(); }
 
@@ -95,9 +95,9 @@ class FixEmitFaceKokkos : public FixEmitFace {
   DAT::t_float_1d d_cummulative;
   DAT::t_int_1d d_species;
 
-  void create_task(int);
-  void grow_task();
-  void realloc_nspecies();
+  void create_task(int) override;
+  void grow_task() override;
+  void realloc_nspecies() override;
 };
 
 }

--- a/src/KOKKOS/kokkos_copy.h
+++ b/src/KOKKOS/kokkos_copy.h
@@ -39,14 +39,14 @@ class KKCopy {
 
   ~KKCopy() {}
 
-  void copy(ClassStyle* orig) {
-    memcpy(&obj, orig, sizeof(ClassStyle));
+  void copy(void* orig) {
+    memcpy((void*)&obj, orig, sizeof(ClassStyle));
     obj.copy = 1;
   }
 
   void uncopy(int copy = 0) {
     if (ptr_temp != NULL) {
-      memcpy(&obj, ptr_temp, sizeof(ClassStyle));
+      memcpy((void*)&obj, ptr_temp, sizeof(ClassStyle));
       free(ptr_temp);
       ptr_temp = NULL;
     }
@@ -55,11 +55,11 @@ class KKCopy {
   }
 
  private:
-  ClassStyle* ptr_temp;
+  void* ptr_temp;
 
   void save() {
     ptr_temp = (ClassStyle*) malloc(sizeof(ClassStyle));
-    memcpy(ptr_temp, &obj, sizeof(ClassStyle));
+    memcpy(ptr_temp, (void*)&obj, sizeof(ClassStyle));
   }
 
 };

--- a/src/KOKKOS/particle_kokkos.h
+++ b/src/KOKKOS/particle_kokkos.h
@@ -43,25 +43,25 @@ class ParticleKokkos : public Particle {
   // methods
 
   ParticleKokkos(class SPARTA *);
-  ~ParticleKokkos();
+  ~ParticleKokkos() override;
   static KOKKOS_INLINE_FUNCTION
   int add_particle_kokkos(t_particle_1d particles, int, int, int, int,
                            double *, double *, double, double);
 #ifndef SPARTA_KOKKOS_EXACT
-  void compress_migrate(int, int *);
+  void compress_migrate(int, int *) override;
 #endif
   void sort_kokkos();
-  void grow(int);
-  void grow_species();
+  void grow(int) override;
+  void grow_species() override;
   void pre_weight() override;
   void post_weight() override;
   void update_class_variables();
-  int add_custom(char *, int, int);
-  void grow_custom(int, int, int);
-  void remove_custom(int);
-  void copy_custom(int, int);
-  void pack_custom(int, char *);
-  void unpack_custom(char *, int);
+  int add_custom(char *, int, int) override;
+  void grow_custom(int, int, int) override;
+  void remove_custom(int) override;
+  void copy_custom(int, int) override;
+  void pack_custom(int, char *) override;
+  void unpack_custom(char *, int) override;
 
   KOKKOS_INLINE_FUNCTION
   void copy_custom_kokkos(int, int) const;

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -1159,38 +1159,43 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,ATOMIC_REDUCTION>, const in
           int sc_type = sc_type_list[n];
           int m = sc_map[n];
 
-          if (DIM == 3)
-            if (sc_type == 0)
+          if (DIM == 3) {
+            if (sc_type == 0) {
               jpart = sc_kk_specular_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction);
-            else if (sc_type == 1)
+            } else if (sc_type == 1) {
               jpart = sc_kk_diffuse_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction);
-            else if (sc_type == 2)
+            } else if (sc_type == 2) {
               jpart = sc_kk_vanish_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction);
-            else if (sc_type == 3)
+            } else if (sc_type == 3) {
               jpart = sc_kk_piston_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction);
-            else if (sc_type == 4)
+            } else if (sc_type == 4) {
               jpart = sc_kk_transparent_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction);
-          if (DIM != 3)
-            if (sc_type == 0)
+            }
+          }
+
+          if (DIM != 3) {
+            if (sc_type == 0) {
               jpart = sc_kk_specular_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction);
-            else if (sc_type == 1)
+            } else if (sc_type == 1) {
               jpart = sc_kk_diffuse_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction);
-            else if (sc_type == 2)
+            } else if (sc_type == 2) {
               jpart = sc_kk_vanish_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction);
-            else if (sc_type == 3)
+            } else if (sc_type == 3) {
               jpart = sc_kk_piston_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction);
-            else if (sc_type == 4)
+            } else if (sc_type == 4) {
               jpart = sc_kk_transparent_copy[m].obj.
                 collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction);
+            }
+          }
 
           //Need to error out for now if surface reactions create (or destroy?) particles
           //if (jpart) {

--- a/src/MAKE/Makefile.kokkos_hip
+++ b/src/MAKE/Makefile.kokkos_hip
@@ -1,4 +1,4 @@
-# spock_kokkos = KOKKOS/HIP, AMD MI100 GPU and AMD EPYC 7662 "Rome" CPU, Cray MPICH, hipcc compiler
+# kokkos_hip = KOKKOS/HIP, AMD MI250X GPU and AMD EPYC Gen3 CPU, Cray MPICH, hipcc compiler
 
 SHELL = /bin/sh
 
@@ -7,7 +7,7 @@ SHELL = /bin/sh
 # specify flags and libraries needed for your compiler
 
 CC =		hipcc
-CCFLAGS =	-g -O3 -DNDEBUG
+CCFLAGS =	-g -O3 -munsafe-fp-atomics -DNDEBUG -DKOKKOS_ENABLE_HIP_MULTIPLE_KERNEL_INSTANTIATIONS
 SHFLAGS =	-fPIC
 DEPFLAGS =	-M
 
@@ -20,7 +20,7 @@ ARCHIVE =	ar
 ARFLAGS =	-rc
 SHLIBFLAGS =	-shared
 KOKKOS_DEVICES = HIP
-KOKKOS_ARCH = Zen2,Vega908
+KOKKOS_ARCH = Zen3,Vega90a
 
 # ---------------------------------------------------------------------
 # SPARTA-specific settings

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -2005,7 +2005,8 @@ void Grid::grow_cells(int n, int m)
     int oldmax = maxcell;
     while (maxcell < nlocal+nghost+n) maxcell += DELTA;
     cells = (ChildCell *)
-      memory->srealloc(cells,maxcell*sizeof(ChildCell),"grid:cells");
+      memory->srealloc(cells,maxcell*sizeof(ChildCell),"grid:cells",
+                       SPARTA_GET_ALIGN(ChildCell));
     memset(&cells[oldmax],0,(maxcell-oldmax)*sizeof(ChildCell));
   }
 

--- a/src/grid.h
+++ b/src/grid.h
@@ -100,7 +100,7 @@ class Grid : protected Pointers {
   // includes unsplit cells, split cells, sub cells in any order
   // ghost cells are appended to owned
 
-  struct SPARTA_ALIGN(128) ChildCell {
+  struct SPARTA_ALIGN(64) ChildCell {
     cellint id;               // ID of child cell
     int level;                // level of cell in hierarchical grid, 0 = root
     int proc;                 // proc that owns this cell

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -19,6 +19,12 @@
 #include "memory.h"
 #include "error.h"
 
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#else
+#include <malloc.h>
+#endif
+
 using namespace SPARTA_NS;
 
 /* ---------------------------------------------------------------------- */
@@ -29,11 +35,19 @@ Memory::Memory(SPARTA *sparta) : Pointers(sparta) {}
    safe malloc
 ------------------------------------------------------------------------- */
 
-void *Memory::smalloc(bigint nbytes, const char *name)
+void *Memory::smalloc(bigint nbytes, const char *name, int align)
 {
   if (nbytes == 0) return NULL;
 
-  void *ptr = malloc(nbytes);
+  void *ptr;
+
+  if (align) {
+    int retval = posix_memalign(&ptr, align, nbytes);
+    if (retval) ptr = nullptr;
+  } else {
+    ptr = malloc(nbytes);
+  }
+
   if (ptr == NULL) {
     char str[128];
     sprintf(str,"Failed to allocate " BIGINT_FORMAT " bytes for array %s",
@@ -47,14 +61,29 @@ void *Memory::smalloc(bigint nbytes, const char *name)
    safe realloc
 ------------------------------------------------------------------------- */
 
-void *Memory::srealloc(void *ptr, bigint nbytes, const char *name)
+void *Memory::srealloc(void *ptr, bigint nbytes, const char *name, int align)
 {
   if (nbytes == 0) {
     destroy(ptr);
     return NULL;
   }
 
-  ptr = realloc(ptr,nbytes);
+  if (align) {
+    ptr = realloc(ptr, nbytes);
+    uintptr_t offset = ((uintptr_t)(const void *)(ptr)) % align;
+    if (offset) {
+      void *optr = ptr;
+      ptr = smalloc(nbytes, name, align);
+#if defined(__APPLE__)
+      memcpy(ptr, optr, MIN(nbytes,malloc_size(optr)));
+#else
+      memcpy(ptr, optr, MIN(nbytes,malloc_usable_size(optr)));
+#endif
+      free(optr);
+    }
+  } else
+    ptr = realloc(ptr,nbytes);
+
   if (ptr == NULL) {
     char str[128];
     sprintf(str,"Failed to reallocate " BIGINT_FORMAT " bytes for array %s",

--- a/src/memory.h
+++ b/src/memory.h
@@ -23,8 +23,8 @@ class Memory : protected Pointers {
  public:
   Memory(class SPARTA *);
 
-  void *smalloc(bigint n, const char *);
-  void *srealloc(void *, bigint n, const char *);
+  void *smalloc(bigint n, const char *, int = 0);
+  void *srealloc(void *, bigint n, const char *, int = 0);
   void sfree(void *);
   void fail(const char *);
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -590,7 +590,7 @@ void Particle::grow(int nextra)
   maxlocal = newmax;
   particles = (OnePart *)
     memory->srealloc(particles,maxlocal*sizeof(OnePart),
-		     "particle:particles");
+		     "particle:particles",SPARTA_GET_ALIGN(OnePart));
   memset(&particles[oldmax],0,(maxlocal-oldmax)*sizeof(OnePart));
 
   if (ncustom == 0) return;

--- a/src/particle.h
+++ b/src/particle.h
@@ -67,7 +67,7 @@ class Particle : protected Pointers {
   int nmixture;
   int maxmixture;
 
-  struct SPARTA_ALIGN(128) OnePart {
+  struct SPARTA_ALIGN(64) OnePart {
     int id;                 // particle ID
     int ispecies;           // particle species index
     int icell;              // which local Grid::cells the particle is in

--- a/src/spatype.h
+++ b/src/spatype.h
@@ -51,8 +51,10 @@ enum ExecutionSpace{Host,Device};
 
 #if defined(SPARTA_KOKKOS_GPU)
 #define SPARTA_ALIGN(n) alignas(n)
+#define SPARTA_GET_ALIGN(type) alignof(type)
 #else
 #define SPARTA_ALIGN(n)
+#define SPARTA_GET_ALIGN(type)
 #endif
 
 // default settings: 32-bit smallint, 64-bit bigint, 32-bit cellint

--- a/src/spatype.h
+++ b/src/spatype.h
@@ -54,7 +54,7 @@ enum ExecutionSpace{Host,Device};
 #define SPARTA_GET_ALIGN(type) alignof(type)
 #else
 #define SPARTA_ALIGN(n)
-#define SPARTA_GET_ALIGN(type)
+#define SPARTA_GET_ALIGN(type) 0
 #endif
 
 // default settings: 32-bit smallint, 64-bit bigint, 32-bit cellint


### PR DESCRIPTION
## Purpose

This fixes a segmentation fault on some hardware/compilers with Kokkos and GPUs, introduced in #357. Also fix some compiler warnings and update Kokkos AMD Makefile

## Author(s)

Stan Moore (SNL), memory alignment code adapted from LAMMPS

## Backward Compatibility

Yes