### PR TITLE
Remove nullptr (requires C++11)

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -43,7 +43,7 @@ void *Memory::smalloc(bigint nbytes, const char *name, int align)
 
   if (align) {
     int retval = posix_memalign(&ptr, align, nbytes);
-    if (retval) ptr = nullptr;
+    if (retval) ptr = NULL;
   } else {
     ptr = malloc(nbytes);
   }


### PR DESCRIPTION
## Purpose

Remove `nullptr` which crept in because it requires C++11 which is not yet required in SPARTA.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes