### PR TITLE
Eliminate compiler warnings with g++ 11.3

### DIFF
--- a/src/MAKE/Makefile.png
+++ b/src/MAKE/Makefile.png
@@ -1,0 +1,105 @@
+# mpi = Linux box/cluster, g++, installed MPI
+
+SHELL = /bin/sh
+
+# ---------------------------------------------------------------------
+# compiler/linker settings
+# specify flags and libraries needed for your compiler
+
+CC =		mpic++
+CCFLAGS =	-O3
+SHFLAGS =	-fPIC
+DEPFLAGS =	-M
+
+LINK =		mpic++
+LINKFLAGS =	-O
+LIB =           
+SIZE =		size
+
+ARCHIVE =	ar
+ARFLAGS =	-rc
+SHLIBFLAGS =	-shared
+
+# ---------------------------------------------------------------------
+# SPARTA-specific settings
+# specify settings for SPARTA features you will use
+# if you change any -D setting, do full re-compile after "make clean"
+
+# SPARTA ifdef settings, OPTIONAL
+# see possible settings in doc/Section_start.html#2_2 (step 4)
+
+SPARTA_INC =	-DSPARTA_GZIP -DSPARTA_PNG
+
+# MPI library, REQUIRED
+# see discussion in doc/Section_start.html#2_2 (step 5)
+# can point to dummy MPI library in src/STUBS as in Makefile.serial
+# INC = path for mpi.h, MPI compiler settings
+# PATH = path for MPI library
+# LIB = name of MPI library
+
+MPI_INC =       
+MPI_PATH =      
+MPI_LIB =	
+
+# FFT library, OPTIONAL
+# see discussion in doc/Section_start.html#2_2 (step 6)
+# can be left blank to use provided KISS FFT library
+# INC = -DFFT setting, e.g. -DFFT_FFTW, FFT compiler settings
+# PATH = path for FFT library
+# LIB = name of FFT library
+
+FFT_INC =    	
+FFT_PATH = 
+FFT_LIB =	
+
+# JPEG library, OPTIONAL
+# see discussion in doc/Section_start.html#2_2 (step 7)
+# only needed if -DSPARTA_JPEG listed with SPARTA_INC
+# INC = path for jpeglib.h
+# PATH = path for JPEG library
+# LIB = name of JPEG library
+
+JPG_INC =     -I/usr/include  
+JPG_PATH =    -L/usr/lib
+JPG_LIB =     -lpng
+
+# ---------------------------------------------------------------------
+# build rules and dependencies
+# no need to edit this section
+
+EXTRA_INC = $(SPARTA_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC)
+EXTRA_PATH = $(MPI_PATH) $(FFT_PATH) $(JPG_PATH)
+EXTRA_LIB = $(MPI_LIB) $(FFT_LIB) $(JPG_LIB)
+
+# Path to src files
+
+vpath %.cpp ..
+vpath %.h ..
+
+# Link target
+
+$(EXE):	$(OBJ)
+	$(LINK) $(LINKFLAGS) $(EXTRA_PATH) $(OBJ) $(EXTRA_LIB) $(LIB) -o $(EXE)
+	$(SIZE) $(EXE)
+
+# Library targets
+
+lib:	$(OBJ)
+	$(ARCHIVE) $(ARFLAGS) $(EXE) $(OBJ)
+
+shlib:	$(OBJ)
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(SHLIBFLAGS) $(EXTRA_PATH) -o $(EXE) \
+        $(OBJ) $(EXTRA_LIB) $(LIB)
+
+# Compilation rules
+
+%.o:%.cpp
+	$(CC) $(CCFLAGS) $(SHFLAGS) $(EXTRA_INC) -c $<
+
+%.d:%.cpp
+	$(CC) $(CCFLAGS) $(EXTRA_INC) $(DEPFLAGS) $< > $@
+
+# Individual dependencies
+
+DEPENDS = $(OBJ:.o=.d)
+include $(DEPENDS)

--- a/src/compute_reduce.cpp
+++ b/src/compute_reduce.cpp
@@ -905,7 +905,7 @@ double ComputeReduce::area_per_surf()
   Surf::Tri *mytris = surf->mytris;
   int distributed = surf->distributed;
   int n = surf->nown;
-    
+
   memory->destroy(areasurf);
   memory->create(areasurf,n,"reduce:areasurf");
 

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -83,7 +83,7 @@ ComputeSurf::ComputeSurf(SPARTA *sparta, int narg, char **arg) :
 
   while (iarg < narg) {
     if (strcmp(arg[iarg],"norm") == 0) {
-      if (iarg+2 > narg) 
+      if (iarg+2 > narg)
         error->all(FLERR,"Invalid compute surf optional keyword");
       if (strcmp(arg[iarg+1],"flow") == 0) normarea = 0;
       else if (strcmp(arg[iarg+1],"flux") == 0) normarea = 1;

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -790,7 +790,7 @@ void DumpSurf::pack_custom(int n)
   int m;
 
   int index = custom[field2index[n]];
-  
+
   // for now, custom data only allowed for explicit all
   // so custom data is nlocal in length, not nown
   // when enable distributed, commented out lines replace 2 previous ones

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -796,7 +796,7 @@ void FixAveHisto::end_of_step()
     fflush(fp);
     if (overwrite) {
       long fileend = ftell(fp);
-      if (fileend > 0) ftruncate(fileno(fp),fileend);
+      if (fileend > 0) int tmp = ftruncate(fileno(fp),fileend);
     }
   }
 }

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -158,7 +158,7 @@ void FixBalance::init()
 
   if (rcbwt == TIME) {
     int coarsen_flag = 0;
-    int after_flag = 0; 
+    int after_flag = 0;
     for (int ifix = 0; ifix < modify->nfix; ifix++) {
       if (strstr(modify->fix[ifix]->style,"adapt") != NULL)
         if (((FixAdapt*)modify->fix[ifix])->coarsen_flag)

--- a/src/fix_emit_face_file.cpp
+++ b/src/fix_emit_face_file.cpp
@@ -507,7 +507,7 @@ void FixEmitFaceFile::read_file(char *file, char *section)
 {
   int i,m,n,ii,jj,offset;
   char line[MAXLINE];
-  char *word;
+  char *word,*tmp;
 
   int dimension = domain->dimension;
 
@@ -530,33 +530,33 @@ void FixEmitFaceFile::read_file(char *file, char *section)
     word = strtok(line," \t\n\r");
     if (strcmp(word,section) == 0) break;           // matching keyword
 
-    fgets(line,MAXLINE,fp);                         // no match, read NIJ or NI
-    word = strtok(line," \t\n\r");                  // skip 2d or 3d section
+    tmp = fgets(line,MAXLINE,fp);               // no match, read NIJ or NI
+    word = strtok(line," \t\n\r");              // skip 2d or 3d section
     int nskip;
     if (strcmp(word,"NIJ") == 0) {
       word = strtok(NULL," \t\n\r");
       nskip = atoi(word);
       word = strtok(NULL," \t\n\r");
       nskip *= atoi(word);
-      fgets(line,MAXLINE,fp);                         // NV line
-      fgets(line,MAXLINE,fp);                         // values line
-      fgets(line,MAXLINE,fp);                         // imesh line
-      fgets(line,MAXLINE,fp);                         // jmesh line
+      tmp = fgets(line,MAXLINE,fp);                   // NV line
+      tmp = fgets(line,MAXLINE,fp);                   // values line
+      tmp = fgets(line,MAXLINE,fp);                   // imesh line
+      tmp = fgets(line,MAXLINE,fp);                   // jmesh line
     } else if (strcmp(word,"NI") == 0) {
       word = strtok(NULL," \t\n\r");
       nskip = atoi(word);
-      fgets(line,MAXLINE,fp);                         // NV line
-      fgets(line,MAXLINE,fp);                         // values line
-      fgets(line,MAXLINE,fp);                         // imesh line
+      tmp = fgets(line,MAXLINE,fp);                   // NV line
+      tmp = fgets(line,MAXLINE,fp);                   // values line
+      tmp = fgets(line,MAXLINE,fp);                   // imesh line
     } else error->one(FLERR,"Misformatted section in inflow file");
 
-    fgets(line,MAXLINE,fp);                               // blank line
-    for (i = 0; i < nskip; i++) fgets(line,MAXLINE,fp);   // value lines
+    tmp = fgets(line,MAXLINE,fp);                     // blank line
+    for (i = 0; i < nskip; i++) tmp = fgets(line,MAXLINE,fp);   // value lines
   }
 
   // read and store the matching section
 
-  fgets(line,MAXLINE,fp);                             // read NIJ or NI
+  tmp = fgets(line,MAXLINE,fp);                       // read NIJ or NI
   word = strtok(line," \t\n\r");
   if (strcmp(word,"NIJ") == 0) {
     if (dimension != 3)
@@ -578,7 +578,7 @@ void FixEmitFaceFile::read_file(char *file, char *section)
 
   // read NV line
 
-  fgets(line,MAXLINE,fp);
+  tmp = fgets(line,MAXLINE,fp);
   word = strtok(line," \t\n\r");
   if (strcmp(word,"NV") != 0)
     error->one(FLERR,"Misformatted section in inflow file");
@@ -590,7 +590,7 @@ void FixEmitFaceFile::read_file(char *file, char *section)
   // read VALUES line and convert names to which vector
 
   mesh.which = new int[mesh.nvalues];
-  fgets(line,MAXLINE,fp);
+  tmp = fgets(line,MAXLINE,fp);
   word = strtok(line," \t\n\r");
   for (i = 0; i < mesh.nvalues; i++) {
     word = strtok(NULL," \t\n\r");
@@ -614,7 +614,7 @@ void FixEmitFaceFile::read_file(char *file, char *section)
   mesh.imesh = new double[mesh.ni];
   mesh.jmesh = new double[mesh.nj];
 
-  fgets(line,MAXLINE,fp);
+  tmp = fgets(line,MAXLINE,fp);
   word = strtok(line," \t\n\r");
   if (strcmp(word,"IMESH") != 0)
     error->one(FLERR,"Misformatted section in inflow file");
@@ -628,7 +628,7 @@ void FixEmitFaceFile::read_file(char *file, char *section)
   mesh.hi[0] = mesh.imesh[mesh.ni-1];
 
   if (dimension == 3) {
-    fgets(line,MAXLINE,fp);
+    tmp = fgets(line,MAXLINE,fp);
     word = strtok(line," \t\n\r");
     if (strcmp(word,"JMESH") != 0)
       error->one(FLERR,"Misformatted section in inflow file");
@@ -645,13 +645,13 @@ void FixEmitFaceFile::read_file(char *file, char *section)
   // N = Ni by Nj values lines, store values in mesh
   // II,JJ stored with II varying fastest in 2d
 
-  fgets(line,MAXLINE,fp);    // blank line
+  tmp = fgets(line,MAXLINE,fp);    // blank line
 
   n = mesh.ni * mesh.nj;
   memory->create(mesh.values,n,mesh.nvalues,"inflow/file:values");
 
   for (i = 0; i < n; i++) {
-    fgets(line,MAXLINE,fp);
+    tmp = fgets(line,MAXLINE,fp);
     word = strtok(line," \t\n\r");
     ii = atoi(word);
     if (dimension == 3) {

--- a/src/fix_surf_temp.cpp
+++ b/src/fix_surf_temp.cpp
@@ -86,7 +86,7 @@ FixSurfTemp::FixSurfTemp(SPARTA *sparta, int narg, char **arg) :
       error->all(FLERR,"Fix surf/temp compute does not compute per-surf array");
     if (qwindex > 0 && qwindex > cqw->size_per_surf_cols)
       error->all(FLERR,"Fix surf/temp compute array is accessed out-of-range");
-    
+
   } else if (strncmp(arg[4],"f_",2) == 0) {
     source = FIX;
     int n = strlen(arg[4]);
@@ -125,7 +125,7 @@ FixSurfTemp::FixSurfTemp(SPARTA *sparta, int narg, char **arg) :
   emi = input->numeric(FLERR,arg[6]);
   if (emi <= 0.0 || emi > 1.0)
     error->all(FLERR,"Fix surf/temp emissivity must be > 0.0 and <= 1");
-  
+
   int n = strlen(arg[7]) + 1;
   char *id_custom = new char[n];
   strcpy(id_custom,arg[7]);
@@ -181,7 +181,7 @@ int FixSurfTemp::setmask()
 void FixSurfTemp::init()
 {
   // one-time initialization of temperature for all surfs in custom vector
-  
+
   if (!firstflag) return;
   firstflag = 0;
 
@@ -251,7 +251,7 @@ void FixSurfTemp::end_of_step()
     } else array = fqw->array_surf;
 
     int icol = qwindex-1;
-    
+
     m = 0;
     for (i = me; i < nlocal; i += nprocs) {
       if (dimension == 3) mask = tris[i].mask;

--- a/src/fix_temp_rescale.cpp
+++ b/src/fix_temp_rescale.cpp
@@ -224,7 +224,7 @@ void FixTempRescale::end_of_step_average(double t_target)
 
   bigint n_current_mine = 0.0;
   double t_current_mine = 0.0;
-  
+
   for (int icell = 0; icell < nglocal; icell++) {
     if (cells[icell].nsplit > 1) continue;
 

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -2440,7 +2440,7 @@ void Grid::write_restart(FILE *fp)
 void Grid::read_restart(FILE *fp)
 {
   int tmp;
-  
+
   // read_restart may have reset maxsurfpercell in its header() method
   // if so, need to reallocate surf arrays to correct max length
 

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -2439,6 +2439,8 @@ void Grid::write_restart(FILE *fp)
 
 void Grid::read_restart(FILE *fp)
 {
+  int tmp;
+  
   // read_restart may have reset maxsurfpercell in its header() method
   // if so, need to reallocate surf arrays to correct max length
 
@@ -2448,8 +2450,8 @@ void Grid::read_restart(FILE *fp)
   // read level info
 
   if (me == 0) {
-    fread(&maxlevel,sizeof(int),1,fp);
-    fread(plevels,sizeof(ParentLevel),maxlevel,fp);
+    tmp = fread(&maxlevel,sizeof(int),1,fp);
+    tmp = fread(plevels,sizeof(ParentLevel),maxlevel,fp);
   }
   MPI_Bcast(&maxlevel,1,MPI_INT,0,world);
   MPI_Bcast(plevels,maxlevel*sizeof(ParentLevel),MPI_CHAR,0,world);
@@ -2458,15 +2460,15 @@ void Grid::read_restart(FILE *fp)
 
   for (int i = 0; i < ngroup; i++) delete [] gnames[i];
 
-  if (me == 0) fread(&ngroup,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&ngroup,sizeof(int),1,fp);
   MPI_Bcast(&ngroup,1,MPI_INT,0,world);
 
   int n;
   for (int i = 0; i < ngroup; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     gnames[i] = new char[n];
-    if (me == 0) fread(gnames[i],sizeof(char),n,fp);
+    if (me == 0) tmp = fread(gnames[i],sizeof(char),n,fp);
     MPI_Bcast(gnames[i],n,MPI_CHAR,0,world);
   }
 }

--- a/src/grid.h
+++ b/src/grid.h
@@ -72,7 +72,7 @@ class Grid : protected Pointers {
   int **eivec;              // pointer to each integer vector
   int ***eiarray;           // pointer to each integer array
   double **edvec;           // pointer to each double vector
-  double ***edarray;        // pointer to each double array  
+  double ***edarray;        // pointer to each double array
 
   // cell ID hash (owned + ghost, no sub-cells)
 
@@ -357,7 +357,7 @@ class Grid : protected Pointers {
   int *edcol;               // # of columns in each double array (esize)
 
   int *custom_ghost_flag;   // flag on each custom vec/arr for owned+ghost or not
-  int *custom_restart_flag; // flag on each custom vec/array read from restart 
+  int *custom_restart_flag; // flag on each custom vec/array read from restart
 
   int nbytes_custom;        // size of packed custom values for one grid cell
 

--- a/src/grid_custom.cpp
+++ b/src/grid_custom.cpp
@@ -24,8 +24,8 @@ enum{INT,DOUBLE};                               // several files
 // per grid cell custom attributes
 
 /* ----------------------------------------------------------------------
-   find custom per-atom vector/array with name                            
-   return index if found           
+   find custom per-atom vector/array with name
+   return index if found
    return -1 if not found
 ------------------------------------------------------------------------- */
 
@@ -36,11 +36,11 @@ int Grid::find_custom(char *name)
   return -1;
 }
 
-/* ----------------------------------------------------------------------       
-   add a custom attribute with name            
-   assumes name does not already exist, except in case of restart             
-   type = 0/1 for int/double         
-   size = 0 for vector, size > 0 for array with size columns            
+/* ----------------------------------------------------------------------
+   add a custom attribute with name
+   assumes name does not already exist, except in case of restart
+   type = 0/1 for int/double
+   size = 0 for vector, size > 0 for array with size columns
    ghostflag = 1 if ghost cells are included, else 0
    return index of its location;
 ------------------------------------------------------------------------- */
@@ -52,7 +52,7 @@ int Grid::add_custom(char *name, int type, int size, int ghostflag)
   // if name already exists
   // just return index if a restart script and re-defining the name
   // else error
-  
+
   index = find_custom(name);
   if (index >= 0) {
     if (custom_restart_flag == NULL || custom_restart_flag[index] == 1)
@@ -128,8 +128,8 @@ int Grid::add_custom(char *name, int type, int size, int ghostflag)
   return index;
 }
 
-/* ----------------------------------------------------------------------      
-   allocate vector/array associated with custom attribute with index 
+/* ----------------------------------------------------------------------
+   allocate vector/array associated with custom attribute with index
    set new values to 0 via memset()
 ------------------------------------------------------------------------- */
 
@@ -157,8 +157,8 @@ void Grid::allocate_custom(int index, int n)
   }
 }
 
-/* ----------------------------------------------------------------------      
-   reallocate vector/array associated with custom attribute with index 
+/* ----------------------------------------------------------------------
+   reallocate vector/array associated with custom attribute with index
    set new values to 0 via memset()
 ------------------------------------------------------------------------- */
 
@@ -312,7 +312,7 @@ void Grid::write_restart_custom(FILE *fp)
 void Grid::read_restart_custom(FILE *fp)
 {
   int tmp;
-  
+
   // ncustom is 0 at time restart file is read
   // will be incremented as add_custom() for each nactive
 

--- a/src/grid_custom.cpp
+++ b/src/grid_custom.cpp
@@ -311,11 +311,13 @@ void Grid::write_restart_custom(FILE *fp)
 
 void Grid::read_restart_custom(FILE *fp)
 {
+  int tmp;
+  
   // ncustom is 0 at time restart file is read
   // will be incremented as add_custom() for each nactive
 
   int nactive;
-  if (me == 0) fread(&nactive,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&nactive,sizeof(int),1,fp);
   MPI_Bcast(&nactive,1,MPI_INT,0,world);
   if (nactive == 0) return;
 
@@ -326,16 +328,16 @@ void Grid::read_restart_custom(FILE *fp)
   char *name;
 
   for (int i = 0; i < nactive; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     name = new char[n];
-    if (me == 0) fread(name,sizeof(char),n,fp);
+    if (me == 0) tmp = fread(name,sizeof(char),n,fp);
     MPI_Bcast(name,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&type,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&type,sizeof(int),1,fp);
     MPI_Bcast(&type,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&size,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&size,sizeof(int),1,fp);
     MPI_Bcast(&size,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&ghostflag,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&ghostflag,sizeof(int),1,fp);
     MPI_Bcast(&ghostflag,n,MPI_CHAR,0,world);
 
     // create the custom attribute

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1105,7 +1105,7 @@ void Input::shell()
 
   if (strcmp(arg[0],"cd") == 0) {
     if (narg != 2) error->all(FLERR,"Illegal shell cd command");
-    chdir(arg[1]);
+    int tmp = chdir(arg[1]);
 
   } else if (strcmp(arg[0],"mkdir") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal shell mkdir command");
@@ -1157,7 +1157,7 @@ void Input::shell()
       strcat(work,arg[i]);
     }
 
-    if (me == 0) system(work);
+    if (me == 0) int tmp = system(work);
   }
 }
 

--- a/src/mixture.cpp
+++ b/src/mixture.cpp
@@ -1,3 +1,4 @@
+
 /* ----------------------------------------------------------------------
    SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
    http://sparta.sandia.gov
@@ -683,69 +684,71 @@ void Mixture::write_restart(FILE *fp)
 
 void Mixture::read_restart(FILE *fp)
 {
+  int tmp;
+  
   int me = comm->me;
 
-  if (me == 0) fread(&nspecies,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&nspecies,sizeof(int),1,fp);
   MPI_Bcast(&nspecies,1,MPI_INT,0,world);
 
   while (nspecies > maxspecies) allocate();
 
-  if (me == 0) fread(species,sizeof(int),nspecies,fp);
+  if (me == 0) tmp = fread(species,sizeof(int),nspecies,fp);
   MPI_Bcast(species,nspecies,MPI_INT,0,world);
 
-  if (me == 0) fread(&nrho_flag,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&nrho_flag,sizeof(int),1,fp);
   MPI_Bcast(&nrho_flag,1,MPI_INT,0,world);
   if (nrho_flag) {
-    if (me == 0) fread(&nrho_user,sizeof(double),1,fp);
+    if (me == 0) tmp = fread(&nrho_user,sizeof(double),1,fp);
     MPI_Bcast(&nrho_user,1,MPI_DOUBLE,0,world);
   }
-  if (me == 0) fread(&vstream_flag,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&vstream_flag,sizeof(int),1,fp);
   MPI_Bcast(&vstream_flag,1,MPI_INT,0,world);
   if (vstream_flag) {
-    if (me == 0) fread(vstream_user,sizeof(double),3,fp);
+    if (me == 0) tmp = fread(vstream_user,sizeof(double),3,fp);
     MPI_Bcast(vstream_user,3,MPI_DOUBLE,0,world);
   }
-  if (me == 0) fread(&temp_thermal_flag,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&temp_thermal_flag,sizeof(int),1,fp);
   MPI_Bcast(&temp_thermal_flag,1,MPI_INT,0,world);
   if (temp_thermal_flag) {
-    if (me == 0) fread(&temp_thermal_user,sizeof(double),1,fp);
+    if (me == 0) tmp = fread(&temp_thermal_user,sizeof(double),1,fp);
     MPI_Bcast(&temp_thermal_user,1,MPI_DOUBLE,0,world);
   }
-  if (me == 0) fread(&temp_rot_flag,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&temp_rot_flag,sizeof(int),1,fp);
   MPI_Bcast(&temp_rot_flag,1,MPI_INT,0,world);
   if (temp_rot_flag) {
-    if (me == 0) fread(&temp_rot_user,sizeof(double),1,fp);
+    if (me == 0) tmp = fread(&temp_rot_user,sizeof(double),1,fp);
     MPI_Bcast(&temp_rot_user,1,MPI_DOUBLE,0,world);
   }
-  if (me == 0) fread(&temp_vib_flag,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&temp_vib_flag,sizeof(int),1,fp);
   MPI_Bcast(&temp_vib_flag,1,MPI_INT,0,world);
   if (temp_vib_flag) {
-    if (me == 0) fread(&temp_vib_user,sizeof(double),1,fp);
+    if (me == 0) tmp = fread(&temp_vib_user,sizeof(double),1,fp);
     MPI_Bcast(&temp_vib_user,1,MPI_DOUBLE,0,world);
   }
 
-  if (me == 0) fread(fraction_flag,sizeof(int),nspecies,fp);
+  if (me == 0) tmp = fread(fraction_flag,sizeof(int),nspecies,fp);
   MPI_Bcast(fraction_flag,nspecies,MPI_INT,0,world);
-  if (me == 0) fread(fraction_user,sizeof(double),nspecies,fp);
+  if (me == 0) tmp = fread(fraction_user,sizeof(double),nspecies,fp);
   MPI_Bcast(fraction_user,nspecies,MPI_DOUBLE,0,world);
 
   int ngroup_file;
-  if (me == 0) fread(&ngroup_file,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&ngroup_file,sizeof(int),1,fp);
   MPI_Bcast(&ngroup_file,1,MPI_INT,0,world);
 
   int n;
   char *id;
 
   for (int i = 0; i < ngroup_file; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     id = new char[n];
-    if (me == 0) fread(id,sizeof(char),n,fp);
+    if (me == 0) tmp = fread(id,sizeof(char),n,fp);
     MPI_Bcast(id,n,MPI_CHAR,0,world);
     add_group(id);
     delete [] id;
   }
 
-  if (me == 0) fread(mix2group,sizeof(int),nspecies,fp);
+  if (me == 0) tmp = fread(mix2group,sizeof(int),nspecies,fp);
   MPI_Bcast(mix2group,nspecies,MPI_INT,0,world);
 }

--- a/src/mixture.cpp
+++ b/src/mixture.cpp
@@ -1,4 +1,3 @@
-
 /* ----------------------------------------------------------------------
    SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
    http://sparta.sandia.gov
@@ -685,7 +684,7 @@ void Mixture::write_restart(FILE *fp)
 void Mixture::read_restart(FILE *fp)
 {
   int tmp;
-  
+
   int me = comm->me;
 
   if (me == 0) tmp = fread(&nspecies,sizeof(int),1,fp);

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1343,7 +1343,7 @@ void Particle::write_restart_species(FILE *fp)
 void Particle::read_restart_species(FILE *fp)
 {
   int tmp;
-  
+
   if (me == 0) tmp = fread(&nspecies,sizeof(int),1,fp);
   MPI_Bcast(&nspecies,1,MPI_INT,0,world);
 
@@ -1383,7 +1383,7 @@ void Particle::write_restart_mixture(FILE *fp)
 void Particle::read_restart_mixture(FILE *fp)
 {
   int tmp;
-  
+
   // must first clear existing default mixtures
 
   for (int i = 0; i < nmixture; i++) delete mixture[i];
@@ -1943,7 +1943,7 @@ void Particle::write_restart_custom(FILE *fp)
 void Particle::read_restart_custom(FILE *fp)
 {
   int tmp;
-  
+
   // ncustom is 0 at time restart file is read
   // will be incremented as add_custom() for each nactive
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1342,7 +1342,9 @@ void Particle::write_restart_species(FILE *fp)
 
 void Particle::read_restart_species(FILE *fp)
 {
-  if (me == 0) fread(&nspecies,sizeof(int),1,fp);
+  int tmp;
+  
+  if (me == 0) tmp = fread(&nspecies,sizeof(int),1,fp);
   MPI_Bcast(&nspecies,1,MPI_INT,0,world);
 
   if (nspecies > maxspecies) {
@@ -1350,7 +1352,7 @@ void Particle::read_restart_species(FILE *fp)
     grow_species();
   }
 
-  if (me == 0) fread(species,sizeof(Species),nspecies,fp);
+  if (me == 0) tmp = fread(species,sizeof(Species),nspecies,fp);
   MPI_Bcast(species,nspecies*sizeof(Species),MPI_CHAR,0,world);
 
   maxvibmode = 0;
@@ -1380,6 +1382,8 @@ void Particle::write_restart_mixture(FILE *fp)
 
 void Particle::read_restart_mixture(FILE *fp)
 {
+  int tmp;
+  
   // must first clear existing default mixtures
 
   for (int i = 0; i < nmixture; i++) delete mixture[i];
@@ -1387,7 +1391,7 @@ void Particle::read_restart_mixture(FILE *fp)
 
   // now process restart file data
 
-  if (me == 0) fread(&nmixture,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&nmixture,sizeof(int),1,fp);
   MPI_Bcast(&nmixture,1,MPI_INT,0,world);
 
   if (nmixture > maxmixture) {
@@ -1400,10 +1404,10 @@ void Particle::read_restart_mixture(FILE *fp)
   char *id;
 
   for (int i = 0; i < nmixture; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     id = new char[n];
-    if (me == 0) fread(id,sizeof(char),n,fp);
+    if (me == 0) tmp = fread(id,sizeof(char),n,fp);
     MPI_Bcast(id,n,MPI_CHAR,0,world);
     mixture[i] = new Mixture(sparta,id);
     mixture[i]->read_restart(fp);
@@ -1938,11 +1942,13 @@ void Particle::write_restart_custom(FILE *fp)
 
 void Particle::read_restart_custom(FILE *fp)
 {
+  int tmp;
+  
   // ncustom is 0 at time restart file is read
   // will be incremented as add_custom() for each nactive
 
   int nactive;
-  if (me == 0) fread(&nactive,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&nactive,sizeof(int),1,fp);
   MPI_Bcast(&nactive,1,MPI_INT,0,world);
   if (nactive == 0) return;
 
@@ -1953,14 +1959,14 @@ void Particle::read_restart_custom(FILE *fp)
   char *name;
 
   for (int i = 0; i < nactive; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     name = new char[n];
-    if (me == 0) fread(name,sizeof(char),n,fp);
+    if (me == 0) tmp = fread(name,sizeof(char),n,fp);
     MPI_Bcast(name,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&type,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&type,sizeof(int),1,fp);
     MPI_Bcast(&type,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&size,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&size,sizeof(int),1,fp);
     MPI_Bcast(&size,n,MPI_CHAR,0,world);
 
     // create the custom attribute

--- a/src/read_isurf.cpp
+++ b/src/read_isurf.cpp
@@ -247,7 +247,7 @@ void ReadISurf::create_hash(int count)
 
 void ReadISurf::read_corners_serial(char *gridfile)
 {
-  int nchunk;
+  int nchunk,tmp;
   int nxyz[3];
   FILE *fp;
 
@@ -268,7 +268,7 @@ void ReadISurf::read_corners_serial(char *gridfile)
                gridfile);
       error->one(FLERR,str);
     }
-    fread(nxyz,sizeof(int),dim,fp);
+    tmp = fread(nxyz,sizeof(int),dim,fp);
   }
 
   MPI_Bcast(nxyz,dim,MPI_INT,0,world);
@@ -295,10 +295,10 @@ void ReadISurf::read_corners_serial(char *gridfile)
     else nchunk = ncorners-nread;
 
     if (precision == INT) {
-      if (me == 0) fread(ibuf,sizeof(uint8_t),nchunk,fp);
+      if (me == 0) tmp = fread(ibuf,sizeof(uint8_t),nchunk,fp);
       MPI_Bcast(ibuf,nchunk,MPI_CHAR,0,world);
     } else if (precision == DOUBLE) {
-      if (me == 0) fread(dbuf,sizeof(double),nchunk,fp);
+      if (me == 0) tmp = fread(dbuf,sizeof(double),nchunk,fp);
       MPI_Bcast(dbuf,nchunk,MPI_DOUBLE,0,world);
     }
 
@@ -400,7 +400,7 @@ void ReadISurf::assign_corners(int n, bigint offset, uint8_t *ibuf, double *dbuf
 
 void ReadISurf::read_types_serial(char *typefile)
 {
-  int nchunk;
+  int nchunk,tmp;
   int nxyz[3];
   FILE *fp;
 
@@ -417,7 +417,7 @@ void ReadISurf::read_types_serial(char *typefile)
       snprintf(str,128,"Cannot open read_isurf type file %s",typefile);
       error->one(FLERR,str);
     }
-    fread(nxyz,sizeof(int),dim,fp);
+    tmp = fread(nxyz,sizeof(int),dim,fp);
   }
 
   MPI_Bcast(nxyz,dim,MPI_INT,0,world);
@@ -439,7 +439,7 @@ void ReadISurf::read_types_serial(char *typefile)
     if (ntypes-nread > CHUNK) nchunk = CHUNK;
     else nchunk = ntypes-nread;
 
-    if (me == 0) fread(buf,sizeof(uint8_t),nchunk,fp);
+    if (me == 0) tmp = fread(buf,sizeof(uint8_t),nchunk,fp);
     MPI_Bcast(buf,nchunk,MPI_CHAR,0,world);
 
     assign_types(nchunk,nread,buf);
@@ -495,7 +495,7 @@ void ReadISurf::assign_types(int n, bigint offset, uint8_t *buf)
 
 void ReadISurf::read_corners_parallel(char *gridfile)
 {
-  int nchunk;
+  int nchunk,tmp;
   int nxyz[3];
   FILE *fp;
 
@@ -510,7 +510,7 @@ void ReadISurf::read_corners_parallel(char *gridfile)
                gridfile);
       error->one(FLERR,str);
     }
-    fread(nxyz,sizeof(int),dim,fp);
+    tmp = fread(nxyz,sizeof(int),dim,fp);
   }
 
   MPI_Bcast(nxyz,dim,MPI_INT,0,world);
@@ -555,10 +555,10 @@ void ReadISurf::read_corners_parallel(char *gridfile)
   fp = fopen(gridfile,"rb");
   if (precision == INT) {
     fseek(fp,offset*sizeof(uint8_t)+dim*sizeof(int),SEEK_SET);
-    fread(ibuf,sizeof(uint8_t),nvalues,fp);
+    tmp = fread(ibuf,sizeof(uint8_t),nvalues,fp);
   } else if (precision == DOUBLE) {
     fseek(fp,offset*sizeof(double)+dim*sizeof(int),SEEK_SET);
-    fread(dbuf,sizeof(double),nvalues,fp);
+    tmp = fread(dbuf,sizeof(double),nvalues,fp);
   }
   fclose(fp);
 

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -193,13 +193,13 @@ void ReadRestart::command(int narg, char **arg)
 
     if (me == 0) {
       for (int iproc = 0; iproc < nprocs_file; iproc++) {
-        fread(&value,sizeof(int),1,fp);
+        tmp = fread(&value,sizeof(int),1,fp);
         if (value != PERPROC)
           error->one(FLERR,"Invalid flag in peratom section of restart file");
 
         if (iproc == 0) filepos = ftell(fp);
 
-        fread(&n_big,sizeof(bigint),1,fp);
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
         if (n_big > MAXSMALLINT)
           error->one(FLERR,"Restart file read buffer too large, use global mem/limit");
         n = n_big;
@@ -210,7 +210,7 @@ void ReadRestart::command(int narg, char **arg)
         }
 
         if (iproc > 0) {
-          fread(buf,sizeof(char),n,fp);
+          tmp = fread(buf,sizeof(char),n,fp);
           MPI_Send(&n,1,MPI_INT,iproc,0,world);
           MPI_Recv(&tmp,0,MPI_INT,iproc,0,world,&status);
           MPI_Send(buf,n,MPI_CHAR,iproc,0,world);
@@ -220,11 +220,11 @@ void ReadRestart::command(int narg, char **arg)
       // rewind and read my chunk
 
       fseek(fp,filepos,SEEK_SET);
-      fread(&n_big,sizeof(bigint),1,fp);
+      tmp = fread(&n_big,sizeof(bigint),1,fp);
       if (n_big > MAXSMALLINT)
         error->one(FLERR,"Restart file read buffer too large, use global mem/limit");
       n = n_big;
-      fread(buf,sizeof(char),n,fp);
+      tmp = fread(buf,sizeof(char),n,fp);
 
       fclose(fp);
 
@@ -235,6 +235,7 @@ void ReadRestart::command(int narg, char **arg)
         memory->destroy(buf);
         memory->create(buf,maxbuf,"read_restart:buf");
       }
+      tmp = 0;
       MPI_Irecv(buf,n,MPI_CHAR,0,0,world,&request);
       MPI_Send(&tmp,0,MPI_INT,0,0,world);
       MPI_Wait(&request,&status);
@@ -305,18 +306,18 @@ void ReadRestart::command(int narg, char **arg)
         error->one(FLERR,str);
       }
 
-      fread(&flag,sizeof(int),1,fp);
+      tmp = fread(&flag,sizeof(int),1,fp);
       if (flag != PROCSPERFILE)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
       int procsperfile;
-      fread(&procsperfile,sizeof(int),1,fp);
+      tmp = fread(&procsperfile,sizeof(int),1,fp);
 
       for (int i = 0; i < procsperfile; i++) {
-        fread(&flag,sizeof(int),1,fp);
+        tmp = fread(&flag,sizeof(int),1,fp);
         if (flag != PERPROC)
           error->one(FLERR,"Invalid flag in peratom section of restart file");
 
-        fread(&n_big,sizeof(bigint),1,fp);
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
         if (n_big > MAXSMALLINT)
           error->one(FLERR,"Restart file read buffer too large, use global mem/limit");
         n = n_big;
@@ -325,7 +326,7 @@ void ReadRestart::command(int narg, char **arg)
           memory->destroy(buf);
           memory->create(buf,maxbuf,"read_restart:buf");
         }
-        fread(buf,sizeof(char),n,fp);
+        tmp = fread(buf,sizeof(char),n,fp);
 
         n = grid->unpack_restart(buf);
         create_child_cells(0);
@@ -357,29 +358,29 @@ void ReadRestart::command(int narg, char **arg)
         error->one(FLERR,str);
       }
 
-      fread(&flag,sizeof(int),1,fp);
+      tmp = fread(&flag,sizeof(int),1,fp);
       if (flag != PROCSPERFILE)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
       int procsperfile;
-      fread(&procsperfile,sizeof(int),1,fp);
+      tmp = fread(&procsperfile,sizeof(int),1,fp);
 
       int step_size,npasses;
 
       for (int i = 0; i < procsperfile; i++) {
-        fread(&flag,sizeof(int),1,fp);
+        tmp = fread(&flag,sizeof(int),1,fp);
         if (flag != PERPROC)
           error->one(FLERR,"Invalid flag in peratom section of restart file");
 
-        fread(&n_big,sizeof(bigint),1,fp);
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
 
         int grid_nlocal;
-        fread(&grid_nlocal,sizeof(int),1,fp);
+        tmp = fread(&grid_nlocal,sizeof(int),1,fp);
         fseek(fp,-sizeof(int),SEEK_CUR);
         int grid_read_size = grid->size_restart(grid_nlocal);
         bigint particle_read_size = n_big - grid_read_size;
         int particle_nlocal;
         fseek(fp,grid_read_size,SEEK_CUR);
-        fread(&particle_nlocal,sizeof(int),1,fp);
+        tmp = fread(&particle_nlocal,sizeof(int),1,fp);
         fseek(fp,-(sizeof(int)+grid_read_size),SEEK_CUR);
 
         if (update->mem_limit_grid_flag)
@@ -419,7 +420,7 @@ void ReadRestart::command(int narg, char **arg)
             if (ii == npasses-1) n = particle_read_size - total_read_part;
             total_read_part += n;
           }
-          fread(buf,sizeof(char),n,fp);
+          tmp = fread(buf,sizeof(char),n,fp);
 
           if (ii == 0) {
             grid->unpack_restart(buf);
@@ -488,10 +489,10 @@ void ReadRestart::command(int narg, char **arg)
     int flag,procsperfile;
 
     if (filereader) {
-      fread(&flag,sizeof(int),1,fp);
+      tmp = fread(&flag,sizeof(int),1,fp);
       if (flag != PROCSPERFILE)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
-      fread(&procsperfile,sizeof(int),1,fp);
+      tmp = fread(&procsperfile,sizeof(int),1,fp);
     }
     MPI_Bcast(&procsperfile,1,MPI_INT,0,clustercomm);
 
@@ -499,7 +500,7 @@ void ReadRestart::command(int narg, char **arg)
     if (procsperfile == nclusterprocs) procmatch = 1;
     else procmatch = 0;
 
-    int tmp,iproc;
+    int iproc;
     MPI_Status status;
     MPI_Request request;
 
@@ -507,20 +508,20 @@ void ReadRestart::command(int narg, char **arg)
 
     for (int i = 0; i < procsperfile; i++) {
       if (filereader) {
-        fread(&flag,sizeof(int),1,fp);
+        tmp = fread(&flag,sizeof(int),1,fp);
         if (flag != PERPROC)
           error->one(FLERR,"Invalid flag in peratom section of restart file");
 
-        fread(&n_big,sizeof(bigint),1,fp);
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
 
         int grid_nlocal;
-        fread(&grid_nlocal,sizeof(int),1,fp);
+        tmp = fread(&grid_nlocal,sizeof(int),1,fp);
         fseek(fp,-sizeof(int),SEEK_CUR);
         int grid_read_size = grid->size_restart(grid_nlocal);
         bigint particle_read_size = n_big - grid_read_size;
         int particle_nlocal;
         fseek(fp,grid_read_size,SEEK_CUR);
-        fread(&particle_nlocal,sizeof(int),1,fp);
+        tmp = fread(&particle_nlocal,sizeof(int),1,fp);
         fseek(fp,-(sizeof(int)+grid_read_size),SEEK_CUR);
 
         if (update->mem_limit_grid_flag)
@@ -566,7 +567,7 @@ void ReadRestart::command(int narg, char **arg)
             if (ii == npasses-1) n = particle_read_size - total_read_part;
             total_read_part += n;
           }
-          fread(buf,sizeof(char),n,fp);
+          tmp = fread(buf,sizeof(char),n,fp);
 
           if (i % nclusterprocs) {
             iproc = me + (i % nclusterprocs);
@@ -595,6 +596,7 @@ void ReadRestart::command(int narg, char **arg)
             memory->destroy(buf);
             memory->create(buf,maxbuf,"read_restart:buf");
           }
+          tmp = 0;
           MPI_Irecv(buf,n,MPI_CHAR,fileproc,0,world,&request);
           MPI_Send(&tmp,0,MPI_INT,fileproc,0,world);
           MPI_Wait(&request,&status);
@@ -655,10 +657,10 @@ void ReadRestart::command(int narg, char **arg)
     int flag,procsperfile;
 
     if (filereader) {
-      fread(&flag,sizeof(int),1,fp);
+      tmp = fread(&flag,sizeof(int),1,fp);
       if (flag != PROCSPERFILE)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
-      fread(&procsperfile,sizeof(int),1,fp);
+      tmp = fread(&procsperfile,sizeof(int),1,fp);
     }
     MPI_Bcast(&procsperfile,1,MPI_INT,0,clustercomm);
 
@@ -672,11 +674,11 @@ void ReadRestart::command(int narg, char **arg)
 
     for (int i = 0; i < procsperfile; i++) {
       if (filereader) {
-        fread(&flag,sizeof(int),1,fp);
+        tmp = fread(&flag,sizeof(int),1,fp);
         if (flag != PERPROC)
           error->one(FLERR,"Invalid flag in peratom section of restart file");
 
-        fread(&n_big,sizeof(bigint),1,fp);
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
         if (n_big > MAXSMALLINT)
           error->one(FLERR,"Restart file read buffer too large, use global mem/limit");
         n = n_big;
@@ -685,7 +687,7 @@ void ReadRestart::command(int narg, char **arg)
           memory->destroy(buf);
           memory->create(buf,maxbuf,"read_restart:buf");
         }
-        fread(buf,sizeof(char),n,fp);
+        tmp = fread(buf,sizeof(char),n,fp);
 
         if (i % nclusterprocs) {
           iproc = me + (i % nclusterprocs);
@@ -701,6 +703,7 @@ void ReadRestart::command(int narg, char **arg)
           memory->destroy(buf);
           memory->create(buf,maxbuf,"read_restart:buf");
         }
+        tmp = 0;
         MPI_Irecv(buf,n,MPI_CHAR,fileproc,0,world,&request);
         MPI_Send(&tmp,0,MPI_INT,fileproc,0,world);
         MPI_Wait(&request,&status);
@@ -1357,7 +1360,7 @@ void ReadRestart::magic_string()
 void ReadRestart::endian()
 {
   int endian;
-  if (me == 0) fread(&endian,sizeof(int),1,fp);
+  if (me == 0) int tmp = fread(&endian,sizeof(int),1,fp);
   MPI_Bcast(&endian,1,MPI_INT,0,world);
   if (endian == ENDIAN) return;
   if (endian == ENDIANSWAP)
@@ -1370,7 +1373,7 @@ void ReadRestart::endian()
 int ReadRestart::version_numeric()
 {
   int vn;
-  if (me == 0) fread(&vn,sizeof(int),1,fp);
+  if (me == 0) int tmp = fread(&vn,sizeof(int),1,fp);
   MPI_Bcast(&vn,1,MPI_INT,0,world);
   if (vn != VERSION_NUMERIC) return 1;
   return 0;
@@ -1383,7 +1386,7 @@ int ReadRestart::version_numeric()
 int ReadRestart::read_int()
 {
   int value;
-  if (me == 0) fread(&value,sizeof(int),1,fp);
+  if (me == 0) int tmp = fread(&value,sizeof(int),1,fp);
   MPI_Bcast(&value,1,MPI_INT,0,world);
   return value;
 }
@@ -1395,7 +1398,7 @@ int ReadRestart::read_int()
 bigint ReadRestart::read_bigint()
 {
   bigint value;
-  if (me == 0) fread(&value,sizeof(bigint),1,fp);
+  if (me == 0) int tmp = fread(&value,sizeof(bigint),1,fp);
   MPI_Bcast(&value,1,MPI_SPARTA_BIGINT,0,world);
   return value;
 }
@@ -1407,7 +1410,7 @@ bigint ReadRestart::read_bigint()
 double ReadRestart::read_double()
 {
   double value;
-  if (me == 0) fread(&value,sizeof(double),1,fp);
+  if (me == 0) int tmp = fread(&value,sizeof(double),1,fp);
   MPI_Bcast(&value,1,MPI_DOUBLE,0,world);
   return value;
 }
@@ -1419,11 +1422,11 @@ double ReadRestart::read_double()
 
 char *ReadRestart::read_string()
 {
-  int n;
-  if (me == 0) fread(&n,sizeof(int),1,fp);
+  int n,tmp;
+  if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
   MPI_Bcast(&n,1,MPI_INT,0,world);
   char *value = new char[n];
-  if (me == 0) fread(value,sizeof(char),n,fp);
+  if (me == 0) tmp = fread(value,sizeof(char),n,fp);
   MPI_Bcast(value,n,MPI_CHAR,0,world);
   return value;
 }
@@ -1434,7 +1437,7 @@ char *ReadRestart::read_string()
 
 void ReadRestart::read_int_vec(int n, int *vec)
 {
-  if (me == 0) fread(vec,sizeof(int),n,fp);
+  if (me == 0) int tmp = fread(vec,sizeof(int),n,fp);
   MPI_Bcast(vec,n,MPI_INT,0,world);
 }
 
@@ -1444,7 +1447,7 @@ void ReadRestart::read_int_vec(int n, int *vec)
 
 void ReadRestart::read_double_vec(int n, double *vec)
 {
-  if (me == 0) fread(vec,sizeof(double),n,fp);
+  if (me == 0) int tmp = fread(vec,sizeof(double),n,fp);
   MPI_Bcast(vec,n,MPI_DOUBLE,0,world);
 }
 
@@ -1454,6 +1457,6 @@ void ReadRestart::read_double_vec(int n, double *vec)
 
 void ReadRestart::read_char_vec(bigint n, char *vec)
 {
-  if (me == 0) fread(vec,sizeof(char),n,fp);
+  if (me == 0) int tmp = fread(vec,sizeof(char),n,fp);
   MPI_Bcast(vec,(int)n,MPI_CHAR,0,world);
 }

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -3933,6 +3933,8 @@ void Surf::write_restart(FILE *fp)
 
 void Surf::read_restart(FILE *fp)
 {
+  int tmp;
+  
   if (distributed || implicit)
     error->all(FLERR,
                "Restart files with distributed surfaces are not yet supported");
@@ -3943,20 +3945,20 @@ void Surf::read_restart(FILE *fp)
 
   for (int i = 0; i < ngroup; i++) delete [] gnames[i];
 
-  if (me == 0) fread(&ngroup,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&ngroup,sizeof(int),1,fp);
   MPI_Bcast(&ngroup,1,MPI_INT,0,world);
 
   int n;
   for (int i = 0; i < ngroup; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     gnames[i] = new char[n];
-    if (me == 0) fread(gnames[i],sizeof(char),n,fp);
+    if (me == 0) tmp = fread(gnames[i],sizeof(char),n,fp);
     MPI_Bcast(gnames[i],n,MPI_CHAR,0,world);
   }
 
   if (domain->dimension == 2) {
-    if (me == 0) fread(&nsurf,sizeof(bigint),1,fp);
+    if (me == 0) tmp = fread(&nsurf,sizeof(bigint),1,fp);
     MPI_Bcast(&nsurf,1,MPI_SPARTA_BIGINT,0,world);
     lines = (Line *) memory->smalloc(nsurf*sizeof(Line),"surf:lines");
     // NOTE: need different logic for different surf styles
@@ -3965,13 +3967,13 @@ void Surf::read_restart(FILE *fp)
 
     if (me == 0) {
       for (int i = 0; i < nsurf; i++) {
-        fread(&lines[i].id,sizeof(surfint),1,fp);
-        fread(&lines[i].type,sizeof(int),1,fp);
-        fread(&lines[i].mask,sizeof(int),1,fp);
-        fread(&lines[i].transparent,sizeof(int),1,fp);
+        tmp = fread(&lines[i].id,sizeof(surfint),1,fp);
+        tmp = fread(&lines[i].type,sizeof(int),1,fp);
+        tmp = fread(&lines[i].mask,sizeof(int),1,fp);
+        tmp = fread(&lines[i].transparent,sizeof(int),1,fp);
         lines[i].isc = lines[i].isr = -1;
-        fread(lines[i].p1,sizeof(double),3,fp);
-        fread(lines[i].p2,sizeof(double),3,fp);
+        tmp = fread(lines[i].p1,sizeof(double),3,fp);
+        tmp = fread(lines[i].p2,sizeof(double),3,fp);
         lines[i].norm[0] = lines[i].norm[1] = lines[i].norm[2] = 0.0;
       }
     }
@@ -3981,7 +3983,7 @@ void Surf::read_restart(FILE *fp)
   }
 
   if (domain->dimension == 3) {
-    if (me == 0) fread(&nsurf,sizeof(bigint),1,fp);
+    if (me == 0) tmp = fread(&nsurf,sizeof(bigint),1,fp);
     MPI_Bcast(&nsurf,1,MPI_SPARTA_BIGINT,0,world);
     tris = (Tri *) memory->smalloc(nsurf*sizeof(Tri),"surf:tris");
     // NOTE: need different logic for different surf styles
@@ -3990,14 +3992,14 @@ void Surf::read_restart(FILE *fp)
 
     if (me == 0) {
       for (int i = 0; i < nsurf; i++) {
-        fread(&tris[i].id,sizeof(surfint),1,fp);
-        fread(&tris[i].type,sizeof(int),1,fp);
-        fread(&tris[i].mask,sizeof(int),1,fp);
-        fread(&tris[i].transparent,sizeof(int),1,fp);
+        tmp = fread(&tris[i].id,sizeof(surfint),1,fp);
+        tmp = fread(&tris[i].type,sizeof(int),1,fp);
+        tmp = fread(&tris[i].mask,sizeof(int),1,fp);
+        tmp = fread(&tris[i].transparent,sizeof(int),1,fp);
         tris[i].isc = tris[i].isr = -1;
-        fread(tris[i].p1,sizeof(double),3,fp);
-        fread(tris[i].p2,sizeof(double),3,fp);
-        fread(tris[i].p3,sizeof(double),3,fp);
+        tmp = fread(tris[i].p1,sizeof(double),3,fp);
+        tmp = fread(tris[i].p2,sizeof(double),3,fp);
+        tmp = fread(tris[i].p3,sizeof(double),3,fp);
         tris[i].norm[0] = tris[i].norm[1] = tris[i].norm[2] = 0.0;
       }
     }
@@ -4068,11 +4070,13 @@ void Surf::write_restart_custom(FILE *fp)
 
 void Surf::read_restart_custom(FILE *fp)
 {
+  int tmp;
+  
   // ncustom is 0 at time restart file is read
   // will be incremented as add_custom() for each nactive
 
   int nactive;
-  if (me == 0) fread(&nactive,sizeof(int),1,fp);
+  if (me == 0) tmp = fread(&nactive,sizeof(int),1,fp);
   MPI_Bcast(&nactive,1,MPI_INT,0,world);
   if (nactive == 0) return;
 
@@ -4083,14 +4087,14 @@ void Surf::read_restart_custom(FILE *fp)
   char *name;
 
   for (int i = 0; i < nactive; i++) {
-    if (me == 0) fread(&n,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&n,sizeof(int),1,fp);
     MPI_Bcast(&n,1,MPI_INT,0,world);
     name = new char[n];
-    if (me == 0) fread(name,sizeof(char),n,fp);
+    if (me == 0) tmp = fread(name,sizeof(char),n,fp);
     MPI_Bcast(name,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&type,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&type,sizeof(int),1,fp);
     MPI_Bcast(&type,n,MPI_CHAR,0,world);
-    if (me == 0) fread(&size,sizeof(int),1,fp);
+    if (me == 0) tmp = fread(&size,sizeof(int),1,fp);
     MPI_Bcast(&size,n,MPI_CHAR,0,world);
 
     // create the custom attribute

--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -3934,7 +3934,7 @@ void Surf::write_restart(FILE *fp)
 void Surf::read_restart(FILE *fp)
 {
   int tmp;
-  
+
   if (distributed || implicit)
     error->all(FLERR,
                "Restart files with distributed surfaces are not yet supported");
@@ -4071,7 +4071,7 @@ void Surf::write_restart_custom(FILE *fp)
 void Surf::read_restart_custom(FILE *fp)
 {
   int tmp;
-  
+
   // ncustom is 0 at time restart file is read
   // will be incremented as add_custom() for each nactive
 

--- a/src/surf_collide_cll.cpp
+++ b/src/surf_collide_cll.cpp
@@ -475,7 +475,7 @@ void SurfCollideCLL::wrapper(Particle::OnePart *p, double *norm,
 
 void SurfCollideCLL::flags_and_coeffs(int *flags, double *coeffs)
 {
-  if (tmode == CUSTOM) 
+  if (tmode == CUSTOM)
     error->all(FLERR,"Surf_collide cll with custom per-surf Twall "
                "does not support external caller");
 

--- a/src/surf_collide_diffuse.cpp
+++ b/src/surf_collide_diffuse.cpp
@@ -145,7 +145,7 @@ void SurfCollideDiffuse::init()
       error->all(FLERR,"Surf_collide diffuse variable is invalid style");
   } else if (tmode == CUSTOM) {
     int tindex = surf->find_custom(tstr);
-    if (tindex < 0) 
+    if (tindex < 0)
       error->all(FLERR,"Surf_collide diffuse could not find "
                  "custom per-surf vector");
     if (surf->etype[tindex] != DOUBLE || surf->esize[tindex] != 0)
@@ -362,7 +362,7 @@ void SurfCollideDiffuse::wrapper(Particle::OnePart *p, double *norm,
 
 void SurfCollideDiffuse::flags_and_coeffs(int *flags, double *coeffs)
 {
-  if (tmode == CUSTOM) 
+  if (tmode == CUSTOM)
     error->all(FLERR,"Surf_collide diffuse with custom per-surf Twall "
                "does not support external caller");
 

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -468,7 +468,7 @@ void SurfCollideImpulsive::wrapper(Particle::OnePart *p, double *norm,
 
 void SurfCollideImpulsive::flags_and_coeffs(int *flags, double *coeffs)
 {
-  if (tmode == CUSTOM) 
+  if (tmode == CUSTOM)
     error->all(FLERR,"Surf_collide impulsive with custom per-surf Twall "
                "does not support external caller");
 

--- a/src/surf_collide_td.cpp
+++ b/src/surf_collide_td.cpp
@@ -328,7 +328,7 @@ void SurfCollideTD::wrapper(Particle::OnePart *p, double *norm,
 
 void SurfCollideTD::flags_and_coeffs(int *flags, double *coeffs)
 {
-  if (tmode == CUSTOM) 
+  if (tmode == CUSTOM)
     error->all(FLERR,"Surf_collide td with custom per-surf Twall "
                "does not support external caller");
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -599,7 +599,7 @@ int Variable::next(int narg, char **arg)
       delete random;
 
       FILE *fp = fopen("tmp.sparta.variable.lock","r");
-      fscanf(fp,"%d",&nextindex);
+      int tmp = fscanf(fp,"%d",&nextindex);
       //printf("READ %d %d\n",universe->me,nextindex);
       fclose(fp);
       fp = fopen("tmp.sparta.variable.lock","w");


### PR DESCRIPTION
## Purpose

Add return values to various system I/O calls to eliminate compiler warnings with g+++ 11.3.  The return values are simply ignored.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


