### PR TITLE
Enable particle/reorder without collisions

### DIFF
--- a/doc/global.txt
+++ b/doc/global.txt
@@ -353,7 +353,10 @@ grid cell contiguously in memory. This operation is performed every
 {nsteps} as specified. A value of 0 means no reordering is ever done. 
 This option is only available when using the KOKKOS package and can 
 improve performance on certain hardware such as GPUs, but is typically 
-slower on CPUs except when running on thousands of nodes. 
+slower on CPUs except when running on thousands of nodes. Reordering
+requires sorting the particles, which is done automatically when
+collisions are enabled. If collisions are not enabled, then sorting
+will also be performed in addition to reordering. 
 
 The {mem/limit} keyword limits the amount of memory allocated for 
 several operations: load balancing, reordering of particles, and restart 

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -324,13 +324,15 @@ void UpdateKokkos::run(int nsteps)
     if (cellweightflag) particle->post_weight();
     timer->stamp(TIME_COMM);
 
-    if (collide) {
+    const int reorder_flag = (update->reorder_period &&
+        (update->ntimestep % update->reorder_period == 0));
+
+    if (collide || reorder_flag) {
       particle_kk->sort_kokkos();
       timer->stamp(TIME_SORT);
+    }
 
-      //CollideVSSKokkos* collide_kk = (CollideVSSKokkos*) collide;
-      //collide_kk->wrap_kokkos_sort();
-
+    if (collide) {
       collide->collisions();
       timer->stamp(TIME_COLLIDE);
     }


### PR DESCRIPTION
## Purpose

Previously `global particle/reorder` was only enabled when collisions were enabled, since it requires particle sorting. However benchmarking shows `particle/reorder` can give performance improvement on GPUs even when there are no collisions (e.g. `/bench/in.free`).

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes