### PR TITLE
Fix bug with Kokkos bitmasks

### DIFF
--- a/src/KOKKOS/grid_kokkos.cpp
+++ b/src/KOKKOS/grid_kokkos.cpp
@@ -282,15 +282,10 @@ void GridKokkos::wrap_kokkos()
     pcells = k_pcells.h_view.data();
   }
 
-  // plevels
+  // plevels doesn't need wrap but was modified on host
 
-  if (plevels != k_plevels.h_view.data()) {
-    memoryKK->wrap_kokkos(k_plevels,plevels,maxparent,"grid:plevels");
-    k_plevels.modify_host();
-    k_plevels.sync_device();
-    memory->sfree(plevels);
-    plevels = k_plevels.h_view.data();
-  }
+  k_plevels.modify_host();
+  k_plevels.sync_device();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/sparta_masks.h
+++ b/src/sparta_masks.h
@@ -24,27 +24,27 @@
 
 #define PARTICLE_MASK  0x00000001
 #define SPECIES_MASK   0x00000002
-#define CUSTOM_MASK    0x00004096
+#define CUSTOM_MASK    0x00000004
 
 // grid
 
-#define CELL_MASK      0x00000004
-#define CINFO_MASK     0x00000008
-#define PCELL_MASK     0x00000016
-#define SINFO_MASK     0x00000032
-#define PLEVEL_MASK    0x00000064
+#define CELL_MASK      0x00000008
+#define CINFO_MASK     0x00000010
+#define PCELL_MASK     0x00000020
+#define SINFO_MASK     0x00000040
+#define PLEVEL_MASK    0x00000080
 
 // collide
 
-#define VREMAX_MASK    0x00000128
-#define REMAIN_MASK    0x00000256
+#define VREMAX_MASK    0x00000100
+#define REMAIN_MASK    0x00000200
 
 // surf
 
-#define PT_MASK          0x00000512
-#define LINE_MASK        0x00001024
-#define TRI_MASK         0x00002048
-#define SURF_CUSTOM_MASK 0x00008192
+#define PT_MASK          0x00000400
+#define LINE_MASK        0x00000800
+#define TRI_MASK         0x00001000
+#define SURF_CUSTOM_MASK 0x00002000
 
 
 #endif


### PR DESCRIPTION
## Purpose

Fix bug with Kokkos bitmasks, where data wasn't always being transferred between GPU and CPU correctly. This does not affect CPUs or GPUs when UVM is enabled. It manifested as a crash in the problem input if grid adaptation was enabled with the error: `Particle being sent to self proc on step 1`.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes