### PR TITLE
Implement error function in variable command

### DIFF
--- a/doc/variable.html
+++ b/doc/variable.html
@@ -52,7 +52,7 @@
     math operators = (), -x, x+y, x-y, x*y, x/y, x^y, x%y,
                      x==y, x!=y, x<y, x<=y, x>y, x>=y, x&&y, x||y, !x
     math functions = sqrt(x), exp(x), ln(x), log(x), abs(x),
-                     sin(x), cos(x), tan(x), asin(x), acos(x), atan(x), atan2(y,x),
+                     sin(x), cos(x), tan(x), asin(x), acos(x), atan(x), atan2(y,x), erf(x),
                      random(x,y), normal(x,y), ceil(x), floor(x), round(x)
                      ramp(x,y), stagger(x,y), logfreq(x,y,z), stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
     special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
@@ -349,7 +349,7 @@ references, fix references, and references to other variables.
 <TR><TD >Constant</TD><TD > PI</TD></TR>
 <TR><TD >Stats keywords</TD><TD > step, np, vol, etc</TD></TR>
 <TR><TD >Math operators</TD><TD > (), -x, x+y, x-y, x*y, x/y, x^y, x%y, x==y, x!=y, x<y, x<=y, x>y, x>=y, x&&y, x||y, !x</TD></TR>
-<TR><TD >Math functions</TD><TD > sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x),      asin(x), acos(x), atan(x), atan2(y,x), random(x,y,z), normal(x,y,z),      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z),      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)</TD></TR>
+<TR><TD >Math functions</TD><TD > sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x),      asin(x), acos(x), atan(x), atan2(y,x), erf(x), random(x,y,z), normal(x,y,z),      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z),      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)</TD></TR>
 <TR><TD >Special functions</TD><TD > sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)</TD></TR>
 <TR><TD >Particle vectors</TD><TD > mass, type, mu, x, y, z, vx, vy, vz</TD></TR>
 <TR><TD >Grid vectors</TD><TD > xc, yc, zc</TD></TR>

--- a/doc/variable.txt
+++ b/doc/variable.txt
@@ -47,7 +47,7 @@ style = {delete} or {index} or {loop} or {world} or {universe} or {uloop} or {st
     math operators = (), -x, x+y, x-y, x*y, x/y, x^y, x%y,
                      x==y, x!=y, x<y, x<=y, x>y, x>=y, x&&y, x||y, !x
     math functions = sqrt(x), exp(x), ln(x), log(x), abs(x),
-                     sin(x), cos(x), tan(x), asin(x), acos(x), atan(x), atan2(y,x),
+                     sin(x), cos(x), tan(x), asin(x), acos(x), atan(x), atan2(y,x), erf(x),
                      random(x,y), normal(x,y), ceil(x), floor(x), round(x)
                      ramp(x,y), stagger(x,y), logfreq(x,y,z), stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
     special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
@@ -343,7 +343,7 @@ Constant: PI
 Stats keywords: step, np, vol, etc
 Math operators: (), -x, x+y, x-y, x*y, x/y, x^y, x%y, x==y, x!=y, x<y, x<=y, x>y, x>=y, x&&y, x||y, !x
 Math functions: sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x), \
-     asin(x), acos(x), atan(x), atan2(y,x), random(x,y,z), normal(x,y,z), \
+     asin(x), acos(x), atan(x), atan2(y,x), erf(x), random(x,y,z), normal(x,y,z), \
      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z), \
      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
 Special functions: sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)


### PR DESCRIPTION
## Purpose

This is a small change that I had downstream for ages. Maybe it is useful for someone else.

## Author(s)

Tim Teichmann (KIT)

## Backward Compatibility

Yes

## Implementation Notes

Trivial

Allows to use the error function in variable definitions, e.g.
`variable test equal "erf(step)"`

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines
