### PR TITLE
Add realloc_kokkos method, reduce Kokkos memory use

### DIFF
--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -582,6 +582,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
   particle_kk->modify(Device,PARTICLE_MASK);
 
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
+  d_nn_last_partner = decltype(d_nn_last_partner)();
 }
 
 KOKKOS_INLINE_FUNCTION

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -466,7 +466,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
 
   if (NEARCP) {
     if (int(d_nn_last_partner.extent(0)) < nglocal || int(d_nn_last_partner.extent(1)) < d_plist.extent(1))
-      d_nn_last_partner = DAT::t_int_2d(Kokkos::view_alloc("collide:nn_last_partner",Kokkos::WithoutInitializing),nglocal,d_plist.extent(1));
+      MemKK::realloc_kokkos(d_nn_last_partner,"collide:nn_last_partner",nglocal,d_plist.extent(1));
     //Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagCollideZeroNN>(0,nglocal),*this);
   }
 
@@ -500,7 +500,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
       Kokkos::resize(grid_kk->d_plist,nglocal,maxcellcount_extra);
       d_plist = grid_kk->d_plist;
       if (NEARCP)
-        d_nn_last_partner = DAT::t_int_2d(Kokkos::view_alloc("collide:nn_last_partner",Kokkos::WithoutInitializing),nglocal,maxcellcount_extra);
+        MemKK::realloc_kokkos(d_nn_last_partner,"collide:nn_last_partner",nglocal,maxcellcount_extra);
     }
 
     auto nlocal_extra = particle->nlocal*extra_factor;

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -497,6 +497,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
     maxcellcount = particle_kk->get_maxcellcount();
     auto maxcellcount_extra = maxcellcount*extra_factor;
     if (d_plist.extent(1) < maxcellcount_extra) {
+      d_plist = decltype(d_plist)();
       Kokkos::resize(grid_kk->d_plist,nglocal,maxcellcount_extra);
       d_plist = grid_kk->d_plist;
       if (NEARCP)
@@ -557,6 +558,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
       particle_kk->set_maxcellcount(maxcellcount);
       auto maxcellcount_extra = maxcellcount*extra_factor;
       if (d_plist.extent(1) < maxcellcount_extra) {
+        d_plist = decltype(d_plist)();
         Kokkos::resize(grid_kk->d_plist,nglocal,maxcellcount_extra);
         d_plist = grid_kk->d_plist;
       }
@@ -583,6 +585,7 @@ template < int NEARCP > void CollideVSSKokkos::collisions_one(COLLIDE_REDUCE &re
 
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
   d_nn_last_partner = decltype(d_nn_last_partner)();
+  d_plist = decltype(d_nn_last_partner)();
 }
 
 KOKKOS_INLINE_FUNCTION
@@ -827,6 +830,7 @@ void CollideVSSKokkos::collisions_one_ambipolar(COLLIDE_REDUCE &reduce)
 
     auto maxcellcount_extra = maxcellcount*extra_factor;
     if (d_plist.extent(1) < maxcellcount_extra) {
+      d_plist = decltype(d_plist)();
       Kokkos::resize(grid_kk->d_plist,nglocal,maxcellcount_extra);
       d_plist = grid_kk->d_plist;
     }
@@ -900,6 +904,7 @@ void CollideVSSKokkos::collisions_one_ambipolar(COLLIDE_REDUCE &reduce)
       particle_kk->set_maxcellcount(maxcellcount);
       auto maxcellcount_extra = maxcellcount*extra_factor;
       if (d_plist.extent(1) < maxcellcount_extra) {
+        d_plist = decltype(d_plist)();
         Kokkos::resize(grid_kk->d_plist,nglocal,maxcellcount_extra);
         d_plist = grid_kk->d_plist;
       }
@@ -932,6 +937,7 @@ void CollideVSSKokkos::collisions_one_ambipolar(COLLIDE_REDUCE &reduce)
   particle_kk->modify(Device,PARTICLE_MASK|CUSTOM_MASK);
 
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
+  d_plist = decltype(d_nn_last_partner)();
 }
 
 template < int ATOMIC_REDUCTION >

--- a/src/KOKKOS/comm_kokkos.cpp
+++ b/src/KOKKOS/comm_kokkos.cpp
@@ -64,7 +64,7 @@ CommKokkos::~CommKokkos()
      so Update can iterate on particle move
 ------------------------------------------------------------------------- */
 
-int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d d_plist_in)
+int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d &d_plist_in)
 {
   GridKokkos* grid_kk = (GridKokkos*) grid;
   ParticleKokkos* particle_kk = ((ParticleKokkos*)particle);
@@ -233,6 +233,7 @@ int CommKokkos::migrate_particles(int nmigrate, int *plist, DAT::t_int_1d d_plis
 
   particle_kk->modify(Device,PARTICLE_MASK);
   d_particles = t_particle_1d(); // destroy reference to reduce memory use
+  d_plist = decltype(d_plist)();
 
   particle->nlocal += nrecv;
   ncomm += nsend;

--- a/src/KOKKOS/comm_kokkos.h
+++ b/src/KOKKOS/comm_kokkos.h
@@ -34,7 +34,7 @@ class CommKokkos : public Comm {
 
   CommKokkos(class SPARTA *);
   ~CommKokkos();
-  int migrate_particles(int, int*, DAT::t_int_1d);
+  int migrate_particles(int, int*, DAT::t_int_1d &);
   void migrate_cells(int);
 
   template<int NEED_ATOMICS, int HAVE_CUSTOM>

--- a/src/KOKKOS/compute_sonine_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_sonine_grid_kokkos.cpp
@@ -156,6 +156,8 @@ void ComputeSonineGridKokkos::compute_per_grid_kokkos()
     Kokkos::Experimental::contribute(d_tally, dup_tally);
     dup_tally = decltype(dup_tally)(); // free duplicated memory
   }
+
+  d_plist = decltype(d_plist)();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/create_particles_kokkos.cpp
+++ b/src/KOKKOS/create_particles_kokkos.cpp
@@ -189,7 +189,6 @@ void CreateParticlesKokkos::create_local(bigint np)
   Kokkos::View<double*[3], DeviceType> d_x("cand_x", ncands);
   Kokkos::View<double*, DeviceType> d_vn("cand_vn", ncands);
   Kokkos::View<double*, DeviceType> d_vr("cand_vr", ncands);
-  Kokkos::View<double*[2], DeviceType> d_theta("cand_theta", ncands);
   Kokkos::View<double*, DeviceType> d_erot("cand_erot", ncands);
   Kokkos::View<double*, DeviceType> d_evib("cand_evib", ncands);
   Kokkos::View<int*, DeviceType> d_id("cand_id", ncands);
@@ -199,7 +198,6 @@ void CreateParticlesKokkos::create_local(bigint np)
   auto h_x = Kokkos::create_mirror_view(d_x);
   auto h_vn = Kokkos::create_mirror_view(d_vn);
   auto h_vr = Kokkos::create_mirror_view(d_vr);
-  auto h_theta = Kokkos::create_mirror_view(d_theta);
   auto h_erot = Kokkos::create_mirror_view(d_erot);
   auto h_evib = Kokkos::create_mirror_view(d_evib);
   auto h_id = Kokkos::create_mirror_view(d_id);
@@ -246,8 +244,6 @@ void CreateParticlesKokkos::create_local(bigint np)
       auto theta2 = MY_2PI * random->uniform();
       h_vn(cand) = vn;
       h_vr(cand) = vr;
-      h_theta(cand,0) = theta1;
-      h_theta(cand,1) = theta2;
 
       //these two functions also use random variables...
       h_erot(cand) = particle->erot(ispecies,temp_rot*tempscale,random);
@@ -275,7 +271,6 @@ void CreateParticlesKokkos::create_local(bigint np)
   Kokkos::deep_copy(d_x, h_x);
   Kokkos::deep_copy(d_vn, h_vn);
   Kokkos::deep_copy(d_vr, h_vr);
-  Kokkos::deep_copy(d_theta, h_theta);
   Kokkos::deep_copy(d_erot, h_erot);
   Kokkos::deep_copy(d_evib, h_evib);
   Kokkos::deep_copy(d_id, h_id);

--- a/src/KOKKOS/create_particles_kokkos.cpp
+++ b/src/KOKKOS/create_particles_kokkos.cpp
@@ -187,8 +187,6 @@ void CreateParticlesKokkos::create_local(bigint np)
   Kokkos::View<int*, DeviceType> d_keep("cand_keep", ncands);
   Kokkos::View<int*, DeviceType> d_isp("cand_isp", ncands);
   Kokkos::View<double*[3], DeviceType> d_x("cand_x", ncands);
-  Kokkos::View<double*, DeviceType> d_vn("cand_vn", ncands);
-  Kokkos::View<double*, DeviceType> d_vr("cand_vr", ncands);
   Kokkos::View<double*, DeviceType> d_erot("cand_erot", ncands);
   Kokkos::View<double*, DeviceType> d_evib("cand_evib", ncands);
   Kokkos::View<int*, DeviceType> d_id("cand_id", ncands);
@@ -196,8 +194,6 @@ void CreateParticlesKokkos::create_local(bigint np)
   auto h_keep = Kokkos::create_mirror_view(d_keep);
   auto h_isp = Kokkos::create_mirror_view(d_isp);
   auto h_x = Kokkos::create_mirror_view(d_x);
-  auto h_vn = Kokkos::create_mirror_view(d_vn);
-  auto h_vr = Kokkos::create_mirror_view(d_vr);
   auto h_erot = Kokkos::create_mirror_view(d_erot);
   auto h_evib = Kokkos::create_mirror_view(d_evib);
   auto h_id = Kokkos::create_mirror_view(d_id);
@@ -242,8 +238,6 @@ void CreateParticlesKokkos::create_local(bigint np)
 
       auto theta1 = MY_2PI * random->uniform();
       auto theta2 = MY_2PI * random->uniform();
-      h_vn(cand) = vn;
-      h_vr(cand) = vr;
 
       //these two functions also use random variables...
       h_erot(cand) = particle->erot(ispecies,temp_rot*tempscale,random);
@@ -269,8 +263,6 @@ void CreateParticlesKokkos::create_local(bigint np)
   Kokkos::deep_copy(d_keep, h_keep);
   Kokkos::deep_copy(d_isp, h_isp);
   Kokkos::deep_copy(d_x, h_x);
-  Kokkos::deep_copy(d_vn, h_vn);
-  Kokkos::deep_copy(d_vr, h_vr);
   Kokkos::deep_copy(d_erot, h_erot);
   Kokkos::deep_copy(d_evib, h_evib);
   Kokkos::deep_copy(d_id, h_id);

--- a/src/KOKKOS/create_particles_kokkos.cpp
+++ b/src/KOKKOS/create_particles_kokkos.cpp
@@ -185,7 +185,7 @@ void CreateParticlesKokkos::create_local(bigint np)
   Kokkos::deep_copy(h_cells2cands, d_cells2cands);
 
   Kokkos::View<int*, DeviceType> d_keep("cand_keep", ncands);
-  Kokkos::View<int*, DeviceType> d_isp("cand_x", ncands);
+  Kokkos::View<int*, DeviceType> d_isp("cand_isp", ncands);
   Kokkos::View<double*[3], DeviceType> d_x("cand_x", ncands);
   Kokkos::View<double*, DeviceType> d_vn("cand_vn", ncands);
   Kokkos::View<double*, DeviceType> d_vr("cand_vr", ncands);

--- a/src/KOKKOS/fix_temp_rescale_kokkos.cpp
+++ b/src/KOKKOS/fix_temp_rescale_kokkos.cpp
@@ -59,6 +59,8 @@ void FixTempRescaleKokkos::end_of_step_no_average(double t_target_in)
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixTempRescale_end_of_step_no_average>(0,nglocal),*this);
 
   copymode = 0;
+
+  d_plist = decltype(d_plist)();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -192,6 +194,7 @@ void FixTempRescaleKokkos::end_of_step_average(double t_target_in)
   Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixTempRescale_end_of_step_average2>(0,nglocal),*this);
 
   copymode = 0;
+  d_plist = decltype(d_plist)();
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/memory_kokkos.h
+++ b/src/KOKKOS/memory_kokkos.h
@@ -20,6 +20,8 @@
 
 namespace SPARTA_NS {
 
+typedef MemoryKokkos MemKK;
+
 class MemoryKokkos : public Memory {
  public:
   MemoryKokkos(class SPARTA *sparta) : Memory(sparta) {}
@@ -307,6 +309,28 @@ void destroy_kokkos(TYPE data, typename TYPE::value_type** &array)
   data = TYPE();
   sfree(array);
   array = NULL;
+}
+
+/* ----------------------------------------------------------------------
+   reallocate Kokkos views without initialization
+   deallocate first to reduce memory use
+------------------------------------------------------------------------- */
+
+template <typename TYPE, typename... Indices>
+static void realloc_kokkos(TYPE &data, const char *name, Indices... ns)
+{
+  data = TYPE();
+  data = TYPE(Kokkos::NoInit(std::string(name)), ns...);
+}
+
+/* ----------------------------------------------------------------------
+   get memory usage of Kokkos view in bytes
+------------------------------------------------------------------------- */
+
+template <typename TYPE>
+static double memory_usage(TYPE &data)
+{
+  return data.span() * sizeof(typename TYPE::value_type);
 }
 
 };

--- a/src/KOKKOS/particle_kokkos.cpp
+++ b/src/KOKKOS/particle_kokkos.cpp
@@ -267,8 +267,8 @@ void ParticleKokkos::sort_kokkos()
   if (reorder_flag) {
 
     if (reorder_scheme == COPYPARTICLELIST) {
-      // always realloc then dealloc d_sorted to reduce memory footprint
-      MemKK::realloc_kokkos(d_sorted,"particle:sorted",d_particles.extent(0));
+      if (d_particles.extent(0) > d_sorted.extent(0))
+        MemKK::realloc_kokkos(d_sorted,"particle:sorted",d_particles.extent(0));
 
       if (d_particles.extent(0) > d_sorted_id.extent(0))
         MemKK::realloc_kokkos(d_sorted_id,"particle:sorted_id",d_particles.extent(0));
@@ -290,7 +290,6 @@ void ParticleKokkos::sort_kokkos()
       //d_particles = k_particles.d_view;
       //d_sorted = tmp;
       Kokkos::deep_copy(d_particles,d_sorted);
-      d_sorted = t_particle_1d();
 
       this->modify(Device,PARTICLE_MASK);
     }

--- a/src/KOKKOS/particle_kokkos.h
+++ b/src/KOKKOS/particle_kokkos.h
@@ -168,8 +168,8 @@ class ParticleKokkos : public Particle {
   HAT::t_int_1d h_mlist;
   HAT::t_int_1d h_slist;
 
-  DAT::t_int_scalar d_fail_flag;
-  HAT::t_int_scalar h_fail_flag;
+  DAT::t_int_scalar d_resize;
+  HAT::t_int_scalar h_resize;
 
   // work memory for reduced memory reordering
   t_particle_1d d_pswap1;

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -170,4 +170,5 @@ void SurfCollideDiffuseKokkos::post_collide()
 {
   ParticleKokkos* particle_kk = (ParticleKokkos*) particle;
   if (ambi_flag || vibmode_flag) particle_kk->modify(Device,CUSTOM_MASK);
+  d_particles = decltype(d_particles)();
 }


### PR DESCRIPTION
## Purpose

In order to reduce Kokkos memory use, it is necessary to free the memory before realloc'ing. This PR adds a helper function to do this, copied from LAMMPS. Also try to reduce memory footprint of the Kokkos version by removing unused views, etc.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes