### PR TITLE
Track surface collisions

### DIFF
--- a/src/compute.cpp
+++ b/src/compute.cpp
@@ -51,14 +51,16 @@ Compute::Compute(SPARTA *sparta, int narg, char **arg) : Pointers(sparta)
   per_particle_flag = per_grid_flag = per_surf_flag = 0;
   post_process_grid_flag = post_process_isurf_grid_flag = 0;
   surf_tally_flag = boundary_tally_flag = 0;
-
+  per_tally_flag = 0;
+  
   timeflag = 0;
   ntime = maxtime = 0;
   tlist = NULL;
 
   invoked_scalar = invoked_vector = invoked_array = -1;
   invoked_per_particle = invoked_per_grid = invoked_per_surf = -1;
-
+  invoked_per_tally = 0;
+  
   kokkos_flag = 0;
   copy = copymode = 0;
 }

--- a/src/compute.h
+++ b/src/compute.h
@@ -33,13 +33,20 @@ class Compute : protected Pointers {
   double **array_grid;      // computed per-grid array
 
   // vec/array surf are length = # of explicit surf elements owned
-  // vec/array tally are length = # of surf elements tallied
+  // vec/array surf tally are length = # of surf elements tallied
 
   double *vector_surf;        // computed per-surf vector
   double **array_surf;        // computed per-surf array
   double *vector_surf_tally;  // computed per-surf tally vector
   double **array_surf_tally;  // computed per-surf tally array
 
+  // vec/array tally are length = # of tallies
+
+  double *vector_tally;      // computed per-tally vector
+  double **array_tally;      // computed per-tally array
+  
+  // data flags and sizes
+  
   int scalar_flag;          // 0/1 if compute_scalar() function exists
   int vector_flag;          // 0/1 if compute_vector() function exists
   int array_flag;           // 0/1 if compute_array() function exists
@@ -61,6 +68,11 @@ class Compute : protected Pointers {
   int surf_tally_flag;        // 1 if compute tallies surface bounce info
   int boundary_tally_flag;    // 1 if compute tallies boundary bounce info
 
+  int per_tally_flag;         // 1 if compute_per_tally() function exists
+  int size_per_tally_cols;    //  0 = vector, N = columns in per-tally array
+  
+  // timestep and invocation info
+  
   int timeflag;       // 1 if Compute stores list of timesteps it's called on
   int ntime;          // # of entries in time list
   int maxtime;        // max # of entries time list can hold
@@ -73,7 +85,10 @@ class Compute : protected Pointers {
   bigint invoked_per_particle; // ditto for compute_per_particle()
   bigint invoked_per_grid;     // ditto for compute_per_grid()
   bigint invoked_per_surf;     // ditto for compute_per_surf()
+  bigint invoked_per_tally;    // ditto for compute_per_tally()
 
+  // public methods
+  
   Compute(class SPARTA *, int, char **);
   Compute(class SPARTA* sparta) : Pointers(sparta) {}
   virtual ~Compute();
@@ -85,6 +100,7 @@ class Compute : protected Pointers {
   virtual void compute_per_particle() {}
   virtual void compute_per_grid() {}
   virtual void compute_per_surf() {}
+  virtual void compute_per_tally() {}
   virtual void clear() {}
   virtual void surf_tally(int, int, int, Particle::OnePart *,
                           Particle::OnePart *, Particle::OnePart *) {}

--- a/src/compute_collide_tally.cpp
+++ b/src/compute_collide_tally.cpp
@@ -1,0 +1,229 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "string.h"
+#include "compute_collide_tally.h"
+#include "particle.h"
+#include "mixture.h"
+#include "surf.h"
+#include "update.h"
+#include "domain.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+enum{IDPART,IDSURF,XC,YC,ZC,VXOLD,VYOLD,VZOLD,VXNEW,VYNEW,VZNEW};
+
+#define DELTA 4096
+
+/* ---------------------------------------------------------------------- */
+
+ComputeCollideTally::ComputeCollideTally(SPARTA *sparta, int narg, char **arg) :
+  Compute(sparta, narg, arg)
+{
+  if (narg < 5) error->all(FLERR,"Illegal compute collide/tally command");
+
+  int igroup = surf->find_group(arg[2]);
+  if (igroup < 0) error->all(FLERR,"Compute collide/tally group ID does not exist");
+  groupbit = surf->bitmask[igroup];
+
+  imix = particle->find_mixture(arg[3]);
+  if (imix < 0) error->all(FLERR,"Compute collide/tally mixture ID does not exist");
+
+  nvalue = narg - 4;
+  which = new int[nvalue];
+
+  // process input values
+
+  nvalue = 0;
+  int iarg = 4;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg],"id/part") == 0) which[nvalue++] = IDPART;
+    else if (strcmp(arg[iarg],"id/surf") == 0) which[nvalue++] = IDSURF;
+    else if (strcmp(arg[iarg],"xc") == 0) which[nvalue++] = XC;
+    else if (strcmp(arg[iarg],"yc") == 0) which[nvalue++] = YC;
+    else if (strcmp(arg[iarg],"zc") == 0) which[nvalue++] = ZC;
+    else if (strcmp(arg[iarg],"vxold") == 0) which[nvalue++] = VXOLD;
+    else if (strcmp(arg[iarg],"vyold") == 0) which[nvalue++] = VYOLD;
+    else if (strcmp(arg[iarg],"vzold") == 0) which[nvalue++] = VZOLD;
+    else if (strcmp(arg[iarg],"vxnew") == 0) which[nvalue++] = VXNEW;
+    else if (strcmp(arg[iarg],"vynew") == 0) which[nvalue++] = VYNEW;
+    else if (strcmp(arg[iarg],"vznew") == 0) which[nvalue++] = VZNEW;
+    else error->all(FLERR,"Invalid value for compute collide/tally");
+    iarg++;
+  }
+
+  // setup
+
+  per_tally_flag = 1;
+  size_per_tally_cols = nvalue;
+
+  surf_tally_flag = 1;         // triggers Update to invoke surf_tally() for each collision
+  timeflag = 1;                // tells Update which timesteps to invoke surf_tally()
+
+  ntally = maxtally = 0;
+  array_tally = NULL;
+  
+  dim = domain->dimension;
+}
+
+/* ---------------------------------------------------------------------- */
+
+ComputeCollideTally::~ComputeCollideTally()
+{
+  if (copy || copymode) return;
+
+  delete [] which;
+
+  memory->destroy(array_tally);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeCollideTally::init()
+{
+  if (!surf->exist)
+    error->all(FLERR,"Cannot use compute collide/tally when surfs do not exist");
+  if (surf->implicit)
+    error->all(FLERR,"Cannot use compute collide/tally with implicit surfs");
+}
+
+/* ----------------------------------------------------------------------
+   no operations here, since compute results are stored in tally array
+   just used by callers to indicate compute was used
+   enables prediction of next step when update needs to tally
+------------------------------------------------------------------------- */
+
+void ComputeCollideTally::compute_per_tally()
+{
+  invoked_per_tally = update->ntimestep;
+}
+
+/* ----------------------------------------------------------------------
+   called by Update before timesteps if will invoke surf_tally()
+---------------------------------------------------------------------- */
+
+void ComputeCollideTally::clear()
+{
+  lines = surf->lines;
+  tris = surf->tris;
+
+  ntally = 0;
+}
+
+/* ----------------------------------------------------------------------
+   tally values for a single particle in icell
+     colliding with surface element isurf, performing reaction (1 to N)
+   iorig = particle ip before collision
+   ip,jp = particles after collision
+   ip = NULL means no particles after collision
+   jp = NULL means one particle after collision
+   jp != NULL means two particles after collision
+------------------------------------------------------------------------- */
+
+void ComputeCollideTally::surf_tally(int isurf, int icell, int reaction,
+                                     Particle::OnePart *iorig,
+                                     Particle::OnePart *ip, Particle::OnePart *jp)
+{
+  // skip if isurf not in surface group
+
+  if (dim == 2) {
+    if (!(lines[isurf].mask & groupbit)) return;
+  } else {
+    if (!(tris[isurf].mask & groupbit)) return;
+  }
+
+  // skip if particle species not in mixture group
+
+  int origspecies = iorig->ispecies;
+  int igroup = particle->mixture[imix]->species2group[origspecies];
+  if (igroup < 0) return;
+
+  // grow tally array if necessary
+  
+  if (ntally == maxtally) grow_tally();
+
+  // tally all values associated with group into array
+  // particle iorig and ip have same position = collision point
+  
+  double *vec = array_tally[ntally++];
+  
+  for (int m = 0; m < nvalue; m++) {
+    switch (which[m]) {
+    case IDPART:
+      vec[m] = ip->id;
+      break;
+    case IDSURF:
+      if (dim == 2) vec[m] = lines[isurf].id;
+      else vec[m] = tris[isurf].id;
+      break;
+    case XC:
+      vec[m] = ip->x[0];
+      break;
+    case YC: 
+      vec[m] = ip->x[1];
+      break;
+    case ZC: 
+      vec[m] = ip->x[2];
+      break;
+    case VXOLD:
+      vec[m] = iorig->v[0];
+      break;
+    case VYOLD: 
+      vec[m] = iorig->v[1];
+      break;
+    case VZOLD: 
+      vec[m] = iorig->v[2];
+      break;
+    case VXNEW:
+      vec[m] = ip->v[0];
+      break;
+    case VYNEW: 
+      vec[m] = ip->v[1];
+      break;
+    case VZNEW: 
+      vec[m] = ip->v[2];
+      break;
+    }
+  }
+}
+
+/* ----------------------------------------------------------------------
+   return # of tallies
+------------------------------------------------------------------------- */
+
+int ComputeCollideTally::tallyinfo(surfint *&dummy)
+{
+  return ntally;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void ComputeCollideTally::grow_tally()
+{
+  maxtally += DELTA;
+  memory->grow(array_tally,maxtally,nvalue,"collide/tally:array_tally");
+}
+
+/* ----------------------------------------------------------------------
+   memory usage
+------------------------------------------------------------------------- */
+
+bigint ComputeCollideTally::memory_usage()
+{
+  bigint bytes = 0;
+  bytes += nvalue*maxtally * sizeof(double);    // array_tally
+  return bytes;
+}

--- a/src/compute_collide_tally.cpp
+++ b/src/compute_collide_tally.cpp
@@ -26,6 +26,8 @@ using namespace SPARTA_NS;
 
 enum{IDPART,IDSURF,XC,YC,ZC,VXOLD,VYOLD,VZOLD,VXNEW,VYNEW,VZNEW};
 
+enum{INT,DOUBLE,BIGINT,STRING};        // same as Dump
+
 #define DELTA 4096
 
 /* ---------------------------------------------------------------------- */
@@ -156,27 +158,27 @@ void ComputeCollideTally::surf_tally(int isurf, int icell, int reaction,
   if (ntally == maxtally) grow_tally();
 
   // tally all values associated with group into array
-  // particle iorig and ip have same position = collision point
+  // particle iorig,ip have same collision point but before/after velocities
   
   double *vec = array_tally[ntally++];
   
   for (int m = 0; m < nvalue; m++) {
     switch (which[m]) {
     case IDPART:
-      vec[m] = ip->id;
+      vec[m] = ubuf(ip->id).d;
       break;
     case IDSURF:
-      if (dim == 2) vec[m] = lines[isurf].id;
-      else vec[m] = tris[isurf].id;
+      if (dim == 2) vec[m] = ubuf(lines[isurf].id).d;
+      else vec[m] = ubuf(tris[isurf].id).d;
       break;
     case XC:
-      vec[m] = ip->x[0];
+      vec[m] = iorig->x[0];
       break;
     case YC: 
-      vec[m] = ip->x[1];
+      vec[m] = iorig->x[1];
       break;
     case ZC: 
-      vec[m] = ip->x[2];
+      vec[m] = iorig->x[2];
       break;
     case VXOLD:
       vec[m] = iorig->v[0];
@@ -207,6 +209,25 @@ void ComputeCollideTally::surf_tally(int isurf, int icell, int reaction,
 int ComputeCollideTally::tallyinfo(surfint *&dummy)
 {
   return ntally;
+}
+
+/* ----------------------------------------------------------------------
+   return datatype of tally quantity
+   icol = 0 for vector
+   icol = 1 to N for array column
+   datatype = INT,DOUBLE,BIGINT
+------------------------------------------------------------------------- */
+
+int ComputeCollideTally::datatype(int icol)
+{
+  if (which[icol-1] == IDPART) return INT;
+
+  if (which[icol-1] == IDSURF) {
+    if (sizeof(surfint) == sizeof(smallint)) return INT;
+    if (sizeof(surfint) == sizeof(bigint)) return BIGINT;
+  }
+
+  return DOUBLE;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/compute_collide_tally.h
+++ b/src/compute_collide_tally.h
@@ -36,6 +36,7 @@ class ComputeCollideTally : public Compute {
   void surf_tally(int, int, int, Particle::OnePart *,
                           Particle::OnePart *, Particle::OnePart *);
   int tallyinfo(surfint *&);
+  int datatype(int);
   bigint memory_usage();
 
  protected:

--- a/src/compute_collide_tally.h
+++ b/src/compute_collide_tally.h
@@ -1,0 +1,77 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef COMPUTE_CLASS
+
+ComputeStyle(collide/tally,ComputeCollideTally)
+
+#else
+
+#ifndef SPARTA_COMPUTE_COLLIDE_TALLY_H
+#define SPARTA_COMPUTE_COLLIDE_TALLY_H
+
+#include "compute.h"
+#include "surf.h"
+
+namespace SPARTA_NS {
+
+class ComputeCollideTally : public Compute {
+ public:
+  ComputeCollideTally(class SPARTA *, int, char **);
+  ~ComputeCollideTally();
+  void init();
+  void compute_per_tally();
+  void clear();
+  void surf_tally(int, int, int, Particle::OnePart *,
+                          Particle::OnePart *, Particle::OnePart *);
+  int tallyinfo(surfint *&);
+  bigint memory_usage();
+
+ protected:
+  int groupbit,imix,nvalue;
+  int *which;
+
+  int ntally;              // # of surfs I have tallied for
+  int maxtally;            // # of tallies currently allocated
+
+  int dim;                 // local copies
+  Surf::Line *lines;
+  Surf::Tri *tris;
+
+  virtual void grow_tally();
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+E: Illegal ... command
+
+Self-explanatory.  Check the input script syntax and compare to the
+documentation for the command.  You can use -echo screen as a
+command-line option when running SPARTA to see the offending line.
+
+E: Compute surf mixture ID does not exist
+
+Self-explanatory.
+
+E: Number of groups in compute surf mixture has changed
+
+This mixture property cannot be changed after this compute command is
+issued.
+
+*/

--- a/src/dump.h
+++ b/src/dump.h
@@ -101,6 +101,25 @@ class Dump : protected Pointers {
   virtual int count() = 0;
   virtual void pack() = 0;
   virtual void write_data(int, double *) = 0;
+
+    // union data struct for packing 32-bit and 64-bit ints into double bufs
+  // this avoids aliasing issues by having 2 pointers (double,int)
+  //   to same buf memory
+  // constructor for 32-bit int prevents compiler
+  //   from possibly calling the double constructor when passed an int
+  // copy to a double *buf:
+  //   buf[m++] = ubuf(foo).d, where foo is a 32-bit or 64-bit int
+  // copy from a double *buf:
+  //   foo = (int) ubuf(buf[m++]).i;, where (int) or (tagint) match foo
+  //   the cast prevents compiler warnings about possible truncation
+
+  union ubuf {
+    double d;
+    int64_t i;
+    ubuf(double arg) : d(arg) {}
+    ubuf(int64_t arg) : i(arg) {}
+    ubuf(int arg) : i(arg) {}
+  };
 };
 
 }

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -358,7 +358,7 @@ int DumpSurf::count()
   if (ncompute) {
     for (int i = 0; i < ncompute; i++)
       if (!(compute[i]->invoked_flag & INVOKED_PER_SURF)) {
-        compute[i]->compute_per_grid();
+        compute[i]->compute_per_surf();
         compute[i]->invoked_flag |= INVOKED_PER_SURF;
       }
   }

--- a/src/dump_tally.cpp
+++ b/src/dump_tally.cpp
@@ -1,0 +1,402 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.sandia.gov
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "mpi.h"
+#include "math.h"
+#include "stdlib.h"
+#include "string.h"
+#include "dump_tally.h"
+#include "update.h"
+#include "domain.h"
+#include "modify.h"
+#include "compute.h"
+#include "input.h"
+#include "memory.h"
+#include "error.h"
+
+using namespace SPARTA_NS;
+
+// customize by adding keyword
+
+enum{INT,DOUBLE,BIGINT,STRING};        // same as Dump
+
+#define INVOKED_PER_TALLY 64
+#define CHUNK 8
+
+/* ---------------------------------------------------------------------- */
+
+DumpTally::DumpTally(SPARTA *sparta, int narg, char **arg) :
+  Dump(sparta, narg, arg)
+{
+  if (narg == 5) error->all(FLERR,"No dump tally attributes specified");
+
+  clearstep = 1;
+  buffer_allow = 1;
+  buffer_flag = 1;
+
+  dimension = domain->dimension;
+
+  nevery = atoi(arg[2]);
+
+  // expand args if any have wildcard character "*"
+  // ok to include trailing optional args,
+  //   so long as they do not have "*" between square brackets
+  // nfield may be shrunk below if extra optional args exist
+
+  int expand = 0;
+  char **earg;
+  int nargnew = nfield = input->expand_args(narg-5,&arg[5],1,earg);
+
+  if (earg != &arg[5]) expand = 1;
+
+  // allocate field vectors
+
+  pack_choice = new FnPtrPack[nfield];
+  vtype = new int[nfield];
+  field2index = new int[nfield];
+  argindex = new int[nfield];
+
+  // custom computes which the dump accesses
+
+  ncompute = 0;
+  id_compute = NULL;
+  compute = NULL;
+
+  // process attributes
+  // ioptional = start of additional optional args in expanded args
+
+  int ioptional = parse_fields(nfield,earg);
+
+  if (ioptional < nfield)
+    error->all(FLERR,"Invalid attribute in dump tally command");
+
+  // noptional = # of optional args
+  // reset nfield to subtract off optional args
+  // reset ioptional to what it would be in original arg list
+
+  int noptional = nfield - ioptional;
+  nfield -= noptional;
+  size_one = nfield;
+  ioptional = narg - noptional;
+
+  // setup format strings
+
+  vformat = new char*[nfield];
+
+  format_default = new char[4*nfield+1];
+  format_default[0] = '\0';
+
+  for (int i = 0; i < nfield; i++) {
+    if (vtype[i] == INT) strcat(format_default,"%d ");
+    else if (vtype[i] == DOUBLE) strcat(format_default,"%g ");
+    else if (vtype[i] == BIGINT) strcat(format_default,BIGINT_FORMAT " ");
+    vformat[i] = NULL;
+  }
+
+  format_column_user = new char*[size_one];
+  for (int i = 0; i < size_one; i++) format_column_user[i] = NULL;
+
+  // setup column string
+
+  int n = 0;
+  for (int iarg = 0; iarg < nfield; iarg++) n += strlen(earg[iarg]) + 2;
+  columns = new char[n];
+  columns[0] = '\0';
+  for (int iarg = 0; iarg < nfield; iarg++) {
+    strcat(columns,earg[iarg]);
+    strcat(columns," ");
+  }
+
+  // if wildcard expansion occurred, free earg memory from expand_args()
+  // wait to do this until after column string is created
+
+  if (expand) {
+    for (int i = 0; i < nargnew; i++) delete [] earg[i];
+    memory->sfree(earg);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+DumpTally::~DumpTally()
+{
+  delete [] pack_choice;
+  delete [] vtype;
+  delete [] field2index;
+  delete [] argindex;
+
+  for (int i = 0; i < ncompute; i++) delete [] id_compute[i];
+  memory->sfree(id_compute);
+  delete [] compute;
+
+  for (int i = 0; i < nfield; i++) delete [] vformat[i];
+  delete [] vformat;
+
+  delete [] columns;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::init_style()
+{
+  // setup function ptrs
+
+  if (binary) header_choice = &DumpTally::header_binary;
+  else header_choice = &DumpTally::header_item;
+
+  if (binary) write_choice = &DumpTally::write_binary;
+  else if (buffer_flag == 1) write_choice = &DumpTally::write_string;
+  else write_choice = &DumpTally::write_text;
+
+  // find current ptr for each compute
+
+  int icompute;
+  for (int i = 0; i < ncompute; i++) {
+    icompute = modify->find_compute(id_compute[i]);
+    if (icompute < 0)
+      error->all(FLERR,"Could not find dump tally compute ID");
+    compute[i] = modify->compute[icompute];
+  }
+
+  // open single file, one time only
+
+  if (multifile == 0) openfile();
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::write_header(bigint ndump)
+{
+  if (multiproc) (this->*header_choice)(ndump);
+  else if (me == 0) (this->*header_choice)(ndump);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::header_binary(bigint ndump)
+{
+  fwrite(&update->ntimestep,sizeof(bigint),1,fp);
+  fwrite(&ndump,sizeof(bigint),1,fp);
+  fwrite(domain->bflag,6*sizeof(int),1,fp);
+  fwrite(&boxxlo,sizeof(double),1,fp);
+  fwrite(&boxxhi,sizeof(double),1,fp);
+  fwrite(&boxylo,sizeof(double),1,fp);
+  fwrite(&boxyhi,sizeof(double),1,fp);
+  fwrite(&boxzlo,sizeof(double),1,fp);
+  fwrite(&boxzhi,sizeof(double),1,fp);
+  fwrite(&nfield,sizeof(int),1,fp);
+  if (multiproc) fwrite(&nclusterprocs,sizeof(int),1,fp);
+  else fwrite(&nprocs,sizeof(int),1,fp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::header_item(bigint ndump)
+{
+  fprintf(fp,"ITEM: TIMESTEP\n");
+  fprintf(fp,BIGINT_FORMAT "\n",update->ntimestep);
+  fprintf(fp,"ITEM: NUMBER OF TALLIES\n");
+  fprintf(fp,BIGINT_FORMAT "\n",ndump);
+  fprintf(fp,"ITEM: BOX BOUNDS %s\n",boundstr);
+  fprintf(fp,"%g %g\n",boxxlo,boxxhi);
+  fprintf(fp,"%g %g\n",boxylo,boxyhi);
+  fprintf(fp,"%g %g\n",boxzlo,boxzhi);
+  fprintf(fp,"ITEM: TALLIES %s\n",columns);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int DumpTally::count()
+{
+  // invoke Computes for per-tally quantities
+  // tally count for each compute must be equal
+
+  int flag = 0;
+  
+  if (ncompute) {
+    for (int i = 0; i < ncompute; i++)
+      if (!(compute[i]->invoked_flag & INVOKED_PER_TALLY)) {
+        compute[i]->compute_per_tally();
+        compute[i]->invoked_flag |= INVOKED_PER_TALLY;
+
+        surfint *dummy;
+        int ntally_one = compute[i]->tallyinfo(dummy);
+        if (i == 0) ntally = ntally_one;
+        else if (ntally_one != ntally) flag = 1;
+      }
+  }
+
+  int flagall;
+  MPI_Allreduce(&flag,&flagall,1,MPI_INT,MPI_SUM,world);
+  if (flagall)
+    error->all(FLERR,"Tally count not the same for all computes in dump tally");
+
+  // return tally count on this processor
+
+  return ntally;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::pack()
+{
+  for (int n = 0; n < size_one; n++) (this->*pack_choice[n])(n);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::write_data(int n, double *mybuf)
+{
+  (this->*write_choice)(n,mybuf);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::write_binary(int n, double *mybuf)
+{
+  n *= size_one;
+  fwrite(&n,sizeof(int),1,fp);
+  fwrite(mybuf,sizeof(double),n,fp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::write_string(int n, double *mybuf)
+{
+  fwrite(mybuf,sizeof(char),n,fp);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpTally::write_text(int n, double *mybuf)
+{
+  int i,j;
+
+  int m = 0;
+  for (i = 0; i < n; i++) {
+    if (i == 0) printf("MYBUF %d %d %g %g %g\n",
+                       static_cast<int> (mybuf[0]),
+                       static_cast<int> (mybuf[1]),
+                       mybuf[2],mybuf[3],mybuf[4]);
+    for (j = 0; j < size_one; j++) {
+      if (vtype[j] == INT) fprintf(fp,vformat[j],static_cast<int> (mybuf[m]));
+      else if (vtype[j] == DOUBLE) fprintf(fp,vformat[j],mybuf[m]);
+      m++;
+    }
+    fprintf(fp,"\n");
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+int DumpTally::parse_fields(int narg, char **arg)
+{
+  // customize by adding to if statement
+
+  int i;
+  for (int iarg = 0; iarg < narg; iarg++) {
+    i = iarg;
+    argindex[i] = -1;
+
+    // compute value = c_ID
+    // if no trailing [], then index = 0, else index = int between []
+
+    if (strncmp(arg[iarg],"c_",2) == 0) {
+      pack_choice[i] = &DumpTally::pack_compute;
+      if (i <= 1) vtype[i] = INT;
+      else vtype[i] = DOUBLE;
+
+      int n = strlen(arg[iarg]);
+      char *suffix = new char[n];
+      strcpy(suffix,&arg[iarg][2]);
+
+      char *ptr = strchr(suffix,'[');
+      if (ptr) {
+        if (suffix[strlen(suffix)-1] != ']')
+          error->all(FLERR,"Invalid attribute in dump tally command");
+        argindex[i] = atoi(ptr+1);
+        *ptr = '\0';
+      } else argindex[i] = 0;
+
+      n = modify->find_compute(suffix);
+      if (n < 0) error->all(FLERR,"Could not find dump tally compute ID");
+      if (modify->compute[n]->per_tally_flag == 0)
+        error->all(FLERR,"Dump tally compute does not compute per-tally info");
+      if (argindex[i] == 0 && modify->compute[n]->size_per_tally_cols != 0)
+        error->all(FLERR,"Dump tally compute does not compute per-tally vector");
+      if (argindex[i] > 0 && modify->compute[n]->size_per_tally_cols == 0)
+        error->all(FLERR,
+                   "Dump tally compute does not calculate per-tally array");
+      if (argindex[i] > 0 &&
+          argindex[i] > modify->compute[n]->size_per_tally_cols)
+        error->all(FLERR,"Dump tally compute array is accessed out-of-range");
+
+      field2index[i] = add_compute(suffix);
+      delete [] suffix;
+
+    } else return iarg;
+  }
+
+  return narg;
+}
+
+/* ----------------------------------------------------------------------
+   add Compute to list of Compute objects used by dump
+   return index of where this Compute is in list
+   if already in list, do not add, just return index, else add to list
+------------------------------------------------------------------------- */
+
+int DumpTally::add_compute(char *id)
+{
+  int icompute;
+  for (icompute = 0; icompute < ncompute; icompute++)
+    if (strcmp(id,id_compute[icompute]) == 0) break;
+  if (icompute < ncompute) return icompute;
+
+  id_compute = (char **)
+    memory->srealloc(id_compute,(ncompute+1)*sizeof(char *),"dump:id_compute");
+  delete [] compute;
+  compute = new Compute*[ncompute+1];
+
+  int n = strlen(id) + 1;
+  id_compute[ncompute] = new char[n];
+  strcpy(id_compute[ncompute],id);
+  ncompute++;
+  return ncompute-1;
+}
+
+/* ----------------------------------------------------------------------
+   extraction of Compute results
+------------------------------------------------------------------------- */
+
+void DumpTally::pack_compute(int n)
+{
+  int index = argindex[n];
+  Compute *c = compute[field2index[n]];
+
+  if (index == 0) {
+    double *vector = c->vector_tally;
+    for (int i = 0; i < ntally; i++) {
+      buf[n] = vector[i];
+      n += size_one;
+    }
+  } else {
+    index--;
+    double **array = c->array_tally;
+    for (int i = 0; i < ntally; i++) {
+      buf[n] = array[i][index];
+      n += size_one;
+    }
+  }
+}

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -530,8 +530,8 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
               icompute = modify->find_compute(&arg[iarg][2]);
               *ptr1 = '[';
 
-              // check for global vector/array,
-              // per-particle array, per-grid array, per-surf array
+              // check for global vector/array
+              // or per-particle, per-grid, per-surf, per-tally array
 
               if (icompute >= 0) {
                 if (mode == 0 && modify->compute[icompute]->vector_flag) {
@@ -552,6 +552,10 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                            modify->compute[icompute]->size_per_surf_cols) {
                   nmax = modify->compute[icompute]->size_per_surf_cols;
                   expandflag = 1;
+                } else if (modify->compute[icompute]->per_tally_flag &&
+                           modify->compute[icompute]->size_per_tally_cols) {
+                  nmax = modify->compute[icompute]->size_per_tally_cols;
+                  expandflag = 1;
                 }
               }
             } else if (arg[iarg][0] == 'f') {
@@ -560,7 +564,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
               *ptr1 = '[';
 
               // check for global vector/array,
-              // per-particle array, per-grid array, per-surf array
+              // per-particle, per-grid, per-surf array
 
               if (ifix >= 0) {
                 if (mode == 0 && modify->fix[ifix]->vector_flag) {

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -133,7 +133,7 @@ void *sparta_extract_global(void *ptr, char *name)
    extract a pointer to an internal SPARTA compute-based entity
    id = compute ID
    style = 0 for global data, 1 for per particle data,
-     2 for per grid data, 3 for per surf data
+     2 for per grid data, 3 for per surf data, 4 for per tally data
    type
      for style global: 0 for scalar, 1 for vector, 2 for array
      for style = particle, grid, surf:
@@ -143,7 +143,7 @@ void *sparta_extract_global(void *ptr, char *name)
      compute's internal data structure for the entity
      caller should cast it to (double *) for a scalar or vector
      caller should cast it to (double **) for an array
-   for per particle or grid or surf data, returns a pointer to the
+   for per particle or grid or surf or tally data, returns a pointer to the
      compute's internal data structure for the entity
      caller should cast it to (double *) for a vector
      caller should cast it to (double **) for an array
@@ -237,6 +237,20 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
         compute->compute_per_surf();
       compute->post_process_surf();
       return (void *) compute->array_surf;
+    }
+  }
+
+  if (style == 4) {
+    if (!compute->per_tally_flag) return NULL;
+    if (type == 1) {
+      if (compute->invoked_per_tally != sparta->update->ntimestep)
+        compute->compute_per_tally();
+      return (void *) compute->vector_tally;
+    }
+    if (type > 1) {
+      if (compute->invoked_per_tally != sparta->update->ntimestep)
+        compute->compute_per_tally();
+      return (void *) compute->array_tally;
     }
   }
 

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -134,6 +134,8 @@ void *sparta_extract_global(void *ptr, char *name)
    id = compute ID
    style = 0 for global data, 1 for per particle data,
      2 for per grid data, 3 for per surf data, 4 for per tally data
+     NOTE: for per tally data, some columns of double **array
+           may be int/bigint ubuf data, up to caller to decode correctly
    type
      for style global: 0 for scalar, 1 for vector, 2 for array
      for style = particle, grid, surf:
@@ -253,7 +255,7 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
       return (void *) compute->array_tally;
     }
   }
-
+  
   return NULL;
 }
 

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -124,6 +124,7 @@ void Modify::init()
     compute[i]->invoked_per_particle = -1;
     compute[i]->invoked_per_grid = -1;
     compute[i]->invoked_per_surf = -1;
+    compute[i]->invoked_per_tally = -1;
   }
   addstep_compute_all(update->ntimestep);
 }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1720,6 +1720,7 @@ void Update::reset_timestep(bigint newstep)
     modify->compute[i]->invoked_per_particle = -1;
     modify->compute[i]->invoked_per_grid = -1;
     modify->compute[i]->invoked_per_surf = -1;
+    modify->compute[i]->invoked_per_tally = -1;
   }
 
   for (int i = 0; i < modify->ncompute; i++)


### PR DESCRIPTION
## Purpose

Add new compute collide/tally and dump tally commands which allow some or all collisions of particles with surface elements to be logged and output.  Info about the particle and surface IDs, collision point, and before/after velocities of the particle can be logged.  The list of tallied collisions can be dumped on particular timesteps or all timesteps if desired for post-analysis. 

## Author(s)

Steve with input from Wolfgang Macher 

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


