### PR TITLE
Add support for charge to particle-style variables

### DIFF
--- a/doc/variable.html
+++ b/doc/variable.html
@@ -56,7 +56,7 @@
                      random(x,y), normal(x,y), ceil(x), floor(x), round(x)
                      ramp(x,y), stagger(x,y), logfreq(x,y,z), stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
     special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
-    particle vectors = mass, type, mu, x, y, z, vx, vy, vz
+    particle vectors = mass, type, q, mu, x, y, z, vx, vy, vz
     grid vectors = xc, yc, zc
     compute references = c_ID, c_ID[i], c_ID[i][j]
     fix references = f_ID, f_ID[i], f_ID[i][j]
@@ -351,7 +351,7 @@ references, fix references, and references to other variables.
 <TR><TD >Math operators</TD><TD > (), -x, x+y, x-y, x*y, x/y, x^y, x%y, x==y, x!=y, x<y, x<=y, x>y, x>=y, x&&y, x||y, !x</TD></TR>
 <TR><TD >Math functions</TD><TD > sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x),      asin(x), acos(x), atan(x), atan2(y,x), erf(x), random(x,y,z), normal(x,y,z),      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z),      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)</TD></TR>
 <TR><TD >Special functions</TD><TD > sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)</TD></TR>
-<TR><TD >Particle vectors</TD><TD > mass, type, mu, x, y, z, vx, vy, vz</TD></TR>
+<TR><TD >Particle vectors</TD><TD > mass, type, q, mu, x, y, z, vx, vy, vz</TD></TR>
 <TR><TD >Grid vectors</TD><TD > xc, yc, zc</TD></TR>
 <TR><TD >Compute references</TD><TD > c_ID, c_ID[i], c_ID[i][j]</TD></TR>
 <TR><TD >Fix references</TD><TD > f_ID, f_ID[i], f_ID[i][j]</TD></TR>
@@ -615,10 +615,10 @@ is deleted, similar to how the <A HREF = "next.html">next</A> command operates.
 <P>Particle vectors generate one value per particle, so that a reference
 like "vx" means the x-component of each particles's velocity will be
 used when evaluating the variable.  Some values are per-species
-values, like mass and mu.  A reference like "mass" means the mass for
-the particle's species.
+values, like mass and q and mu.  "Mass" is the mass for the particle's
+species, "q" is the particle's charge, "mu" is its magnetic moment.
 </P>
-<P>The meaning of the different particle vectors is self-explanatory.
+<P>The meaning of the other particle vectors should be self-explanatory.
 </P>
 <P>Particle vectors can only be used in <I>particle</I> style variables,
 not in <I>equal</I> or <I>grid</I> style varaibles.

--- a/doc/variable.txt
+++ b/doc/variable.txt
@@ -51,7 +51,7 @@ style = {delete} or {index} or {loop} or {world} or {universe} or {uloop} or {st
                      random(x,y), normal(x,y), ceil(x), floor(x), round(x)
                      ramp(x,y), stagger(x,y), logfreq(x,y,z), stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
     special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
-    particle vectors = mass, type, mu, x, y, z, vx, vy, vz
+    particle vectors = mass, type, q, mu, x, y, z, vx, vy, vz
     grid vectors = xc, yc, zc
     compute references = c_ID, c_ID\[i\], c_ID\[i\]\[j\]
     fix references = f_ID, f_ID\[i\], f_ID\[i\]\[j\]
@@ -347,7 +347,7 @@ Math functions: sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x), 
      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z), \
      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
 Special functions: sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
-Particle vectors: mass, type, mu, x, y, z, vx, vy, vz
+Particle vectors: mass, type, q, mu, x, y, z, vx, vy, vz
 Grid vectors: xc, yc, zc
 Compute references: c_ID, c_ID\[i\], c_ID\[i\]\[j\]
 Fix references: f_ID, f_ID\[i\], f_ID\[i\]\[j\]
@@ -610,10 +610,10 @@ Particle Vectors :h4
 Particle vectors generate one value per particle, so that a reference
 like "vx" means the x-component of each particles's velocity will be
 used when evaluating the variable.  Some values are per-species
-values, like mass and mu.  A reference like "mass" means the mass for
-the particle's species.
+values, like mass and q and mu.  "Mass" is the mass for the particle's
+species, "q" is the particle's charge, "mu" is its magnetic moment.
 
-The meaning of the different particle vectors is self-explanatory.
+The meaning of the other particle vectors should be self-explanatory.
 
 Particle vectors can only be used in {particle} style variables,
 not in {equal} or {grid} style varaibles.

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3366,19 +3366,20 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
    check if word matches a particle vector
    return 1 if yes, else 0
    customize by adding a particle vector:
-     mass,type,x,y,z,vx,vy,vz,fx,fy,fz,mu
+     x,y,z,vx,vy,vz,type,mass,q,mu
 ------------------------------------------------------------------------- */
 
 int Variable::is_particle_vector(char *word)
 {
-  if (strcmp(word,"mass") == 0) return 1;
-  if (strcmp(word,"type") == 0) return 1;
   if (strcmp(word,"x") == 0) return 1;
   if (strcmp(word,"y") == 0) return 1;
   if (strcmp(word,"z") == 0) return 1;
   if (strcmp(word,"vx") == 0) return 1;
   if (strcmp(word,"vy") == 0) return 1;
   if (strcmp(word,"vz") == 0) return 1;
+  if (strcmp(word,"type") == 0) return 1;
+  if (strcmp(word,"mass") == 0) return 1;
+  if (strcmp(word,"q") == 0) return 1;
   if (strcmp(word,"mu") == 0) return 1;
   return 0;
 }
@@ -3388,7 +3389,7 @@ int Variable::is_particle_vector(char *word)
    push result onto tree
    word = particle vector
    customize by adding a particle vector:
-     mass,type,x,y,z,vx,vy,vz,fx,fy,fz
+     x,y,z,vx,vy,vz,type,mass,q,mu
 ------------------------------------------------------------------------- */
 
 void Variable::particle_vector(char *word, Tree **tree,
@@ -3406,15 +3407,7 @@ void Variable::particle_vector(char *word, Tree **tree,
   newtree->left = newtree->middle = newtree->right = NULL;
   treestack[ntreestack++] = newtree;
 
-  if (strcmp(word,"mass") == 0) {
-    newtree->type = SPECARRAY;
-    newtree->nstride = sizeof(Particle::Species);
-    newtree->carray = (char *) &species[0].mass;
-  } else if (strcmp(word,"type") == 0) {
-    newtree->type = PARTARRAYINT;
-    newtree->carray = (char *) &particles[0].ispecies;
-  }
-  else if (strcmp(word,"x") == 0)
+  if (strcmp(word,"x") == 0)
     newtree->carray = (char *) &particles[0].x[0];
   else if (strcmp(word,"y") == 0)
     newtree->carray = (char *) &particles[0].x[1];
@@ -3426,7 +3419,19 @@ void Variable::particle_vector(char *word, Tree **tree,
     newtree->carray = (char *) &particles[0].v[1];
   else if (strcmp(word,"vz") == 0)
     newtree->carray = (char *) &particles[0].v[2];
-  else if (strcmp(word,"mu") == 0) {
+
+  else if (strcmp(word,"type") == 0) {
+    newtree->type = PARTARRAYINT;
+    newtree->carray = (char *) &particles[0].ispecies;
+  } else if (strcmp(word,"mass") == 0) {
+    newtree->type = SPECARRAY;
+    newtree->nstride = sizeof(Particle::Species);
+    newtree->carray = (char *) &species[0].mass;
+  } else if (strcmp(word,"q") == 0) {
+    newtree->type = SPECARRAY;
+    newtree->nstride = sizeof(Particle::Species);
+    newtree->carray = (char *) &species[0].charge;
+  } else if (strcmp(word,"mu") == 0) {
     newtree->type = SPECARRAY;
     newtree->nstride = sizeof(Particle::Species);
     newtree->carray = (char *) &species[0].magmoment;


### PR DESCRIPTION
## Purpose

Allow particle-style variables to access the charge of each particle.

Useful for computing Lorentz forces of moving charged particles due to a magnetic field.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


