### PR TITLE
Normfactor computation consistent with surfaces for axisymmetric case

### DIFF
--- a/src/compute_boundary.cpp
+++ b/src/compute_boundary.cpp
@@ -101,6 +101,11 @@ void ComputeBoundary::init()
   if (domain->dimension == 2) {
     normflux[XLO] = normflux[XHI] = domain->yprd * nfactor;
     normflux[YLO] = normflux[YHI] = domain->xprd * nfactor;
+
+    if (domain->axisymmetric) {
+      normflux[YLO] *= 2 * M_PI * domain->yprd;
+      normflux[YHI] *= 2 * M_PI * domain->yprd;
+    }
   } else if (domain->dimension == 3) {
     normflux[XLO] = normflux[XHI] = domain->yprd*domain->zprd * nfactor;
     normflux[YLO] = normflux[YHI] = domain->xprd*domain->zprd * nfactor;


### PR DESCRIPTION
## Purpose

This small change adds additional factors to compute the surface area (that is used for flux scaling) of the box boundary in the axisymmetric case. This way this is consistent with computations done in `compute_surf.cpp` and `surf.cpp` (see `surf->axi_line_size`).  This uses the same scaling for YLO, although that surface/boundary has an area of 0 (due to being on the axis of rotation).

## Author(s)

Georgii Oblapenko, DLR

## Backward Compatibility

No issues with tests; no changes to existing input files needed. May cause inconsistency in output in computations that used the box boundary flux for the YHI boundary in an axisymmetric setup.

## Implementation Notes

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links
