### PR TITLE
Incident flux

### DIFF
--- a/doc/compute_surf.html
+++ b/doc/compute_surf.html
@@ -27,12 +27,14 @@
 
 <LI>one or more values can be appended 
 
-<LI>value = <I>n</I> or <I>nwt</I> or <I>nflux</I> or <I>mflux</I> or <I>fx</I> or <I>fy</I> or <I>fz</I> or <I>press</I> or <I>px</I> or <I>py</I> or <I>pz</I> or <I>shx</I> or <I>shy</I> or <I>shz</I> or <I>ke</I> 
+<LI>value = <I>n</I> or <I>nwt</I> or <I>nflux</I> or <I>nflux_incident</I> or <I>mflux</I> or <I>mflux_incident</I> or <I>fx</I> or <I>fy</I> or <I>fz</I> or <I>press</I> or <I>px</I> or <I>py</I> or <I>pz</I> or <I>shx</I> or <I>shy</I> or <I>shz</I> or <I>ke</I> 
 
 <PRE>  n = count of particles hitting surface element
   nwt = weighted count of particles hitting surface element
-  nflux = flux of particles on surface element
-  mflux = flux of mass on surface element
+  nflux = net flux of particles through surface element
+  nflux_incident = incident flux of particles on surface element
+  mflux = net flux of mass through surface element
+  mflux_incident = incident flux of mass on surface element
   fx,fy,fz = components of force on surface element
   press = magnitude of normal pressure on surface element
   px,py,pz = components of normal pressure on surface element
@@ -152,8 +154,9 @@ occurs.  The <I>nwt</I> quantity will only be different than <I>n</I> if
 particle weighting is enabled via the <A HREF = "global.html">global weight</A>
 command.
 </P>
-<P>The <I>nflux</I> value calculates the number flux imparted to the surface
-element by particles in the group.  This is computed as
+<P>The <I>nflux</I> and <I>nflux_incident</I> values calculate the net and incident
+number flux imparted to the surface element by particles in the group
+respectively. These are computed as
 </P>
 <PRE>Nflux = N / (A * dt / fnum) 
 </PRE>
@@ -167,8 +170,9 @@ included in the Nflux formula.  The Nflux quantity becomes effectively
 a particle flow rate (count per time).  See discussion of the <I>norm</I>
 keyword below.
 </P>
-<P>The <I>mflux</I> value calculates the mass flux imparted to the surface
-element by particles in the group.  This is computed as
+<P>The <I>mflux</I> and <I>mflux_incident</I> values calculate the net and incident
+mass flux imparted to the surface element by particles in the group
+respectively. These are computed as
 </P>
 <PRE>Mflux = Sum_i (mass_i) / (A * dt / fnum) 
 </PRE>

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -18,11 +18,13 @@ surf = style name of this compute command :l
 group-ID = group ID for which surface elements to perform calculation on :l
 mix-ID = mixture ID for particles to perform calculation on :l
 one or more values can be appended :l
-value = {n} or {nwt} or {nflux} or {mflux} or {fx} or {fy} or {fz} or {press} or {px} or {py} or {pz} or {shx} or {shy} or {shz} or {ke} :l
+value = {n} or {nwt} or {nflux} or {nflux_incident} or {mflux} or {mflux_incident} or {fx} or {fy} or {fz} or {press} or {px} or {py} or {pz} or {shx} or {shy} or {shz} or {ke} :l
   n = count of particles hitting surface element
   nwt = weighted count of particles hitting surface element
-  nflux = flux of particles on surface element
-  mflux = flux of mass on surface element
+  nflux = net flux of particles through surface element
+  nflux_incident = incident flux of particles on surface element
+  mflux = net flux of mass through surface element
+  mflux_incident = incident flux of mass on surface element
   fx,fy,fz = components of force on surface element
   press = magnitude of normal pressure on surface element
   px,py,pz = components of normal pressure on surface element
@@ -138,8 +140,9 @@ occurs.  The {nwt} quantity will only be different than {n} if
 particle weighting is enabled via the "global weight"_global.html
 command.
 
-The {nflux} value calculates the number flux imparted to the surface
-element by particles in the group.  This is computed as
+The {nflux} and {nflux_incident} values calculate the net and incident
+number flux imparted to the surface element by particles in the group
+respectively.  These are computed as
 
 Nflux = N / (A * dt / fnum) :pre
 
@@ -153,8 +156,9 @@ included in the Nflux formula.  The Nflux quantity becomes effectively
 a particle flow rate (count per time).  See discussion of the {norm}
 keyword below.
 
-The {mflux} value calculates the mass flux imparted to the surface
-element by particles in the group.  This is computed as
+The {mflux} and {mflux_incident} values calculate the net and incident
+mass flux imparted to the surface element by particles in the group
+respectively.  These are computed as
 
 Mflux = Sum_i (mass_i) / (A * dt / fnum) :pre
 

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -142,7 +142,9 @@ command.
 
 The {nflux} and {nflux_incident} values calculate the net and incident
 number flux imparted to the surface element by particles in the group
-respectively.  These are computed as
+respectively. Incident flux sums over all the impacting particles,
+while net flux subtracts out reflected particles and includes effects
+from surface chemistry such as particle deletion. These are computed as
 
 Nflux = N / (A * dt / fnum) :pre
 

--- a/src/compute_surf.cpp
+++ b/src/compute_surf.cpp
@@ -27,7 +27,7 @@
 
 using namespace SPARTA_NS;
 
-enum{NUM,NUMWT,NFLUX,MFLUX,FX,FY,FZ,PRESS,XPRESS,YPRESS,ZPRESS,
+enum{NUM,NUMWT,NFLUX,NFLUXIN,MFLUX,MFLUXIN,FX,FY,FZ,PRESS,XPRESS,YPRESS,ZPRESS,
      XSHEAR,YSHEAR,ZSHEAR,KE,EROT,EVIB,ETOT};
 
 #define DELTA 4096
@@ -58,7 +58,9 @@ ComputeSurf::ComputeSurf(SPARTA *sparta, int narg, char **arg) :
     if (strcmp(arg[iarg],"n") == 0) which[nvalue++] = NUM;
     else if (strcmp(arg[iarg],"nwt") == 0) which[nvalue++] = NUMWT;
     else if (strcmp(arg[iarg],"nflux") == 0) which[nvalue++] = NFLUX;
+    else if (strcmp(arg[iarg],"nflux_incident") == 0) which[nvalue++] = NFLUXIN;
     else if (strcmp(arg[iarg],"mflux") == 0) which[nvalue++] = MFLUX;
+    else if (strcmp(arg[iarg],"mflux_incident") == 0) which[nvalue++] = MFLUXIN;
     else if (strcmp(arg[iarg],"fx") == 0) which[nvalue++] = FX;
     else if (strcmp(arg[iarg],"fy") == 0) which[nvalue++] = FY;
     else if (strcmp(arg[iarg],"fz") == 0) which[nvalue++] = FZ;
@@ -328,12 +330,20 @@ void ComputeSurf::surf_tally(int isurf, int icell, int reaction,
       }
       k++;
       break;
+    case NFLUXIN:
+      vec[k] += weight * fluxscale;
+      k++;
+      break;
     case MFLUX:
       vec[k] += origmass * fluxscale;
       if (!transparent) {
         if (ip) vec[k] -= imass * fluxscale;
         if (jp) vec[k] -= jmass * fluxscale;
       }
+      k++;
+      break;
+    case MFLUXIN:
+      vec[k] += origmass * fluxscale;
       k++;
       break;
     case FX:


### PR DESCRIPTION
## Purpose

Introduce `nflux_incident` and `mflux_incident` to the `compute_surf` command. These calculate the incident fluxes on the surface, whereas the original `nflux` and `mflux` commands calculate the respective net fluxes (superposition of incident and reflected fluxes). This is also reflected in the updated doc pages.

Closes #361 

## Author(s)

Tim Teichmann (KIT, ITEP)

## Backward Compatibility

yes, new commands are optional and old commands are unchanged.

## Implementation Notes

See discussion in #361 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines


