### PR TITLE
Fix random and proc style balance_grid input parse

### DIFF
--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -102,12 +102,12 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
   } else if (strcmp(arg[0],"random") == 0) {
     if (narg < 1) error->all(FLERR,"Illegal balance_grid command");
     bstyle = RANDOM;
-    iarg = 0;
+    iarg = 1;
 
   } else if (strcmp(arg[0],"proc") == 0) {
     if (narg < 1) error->all(FLERR,"Illegal balance_grid command");
     bstyle = PROC;
-    iarg = 0;
+    iarg = 1;
 
   } else if (strcmp(arg[0],"rcb") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal balance_grid command");

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -63,6 +63,7 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
   if (strcmp(arg[0],"none") == 0) {
     if (narg < 1) error->all(FLERR,"Illegal balance_grid command");
     bstyle = NONE;
+    iarg = 1;
 
   } else if (strcmp(arg[0],"stride") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal balance_grid command");
@@ -74,7 +75,7 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
     else if (strcmp(arg[1],"zxy") == 0) order = ZXY;
     else if (strcmp(arg[1],"zyx") == 0) order = ZYX;
     else error->all(FLERR,"Illegal balance_grid command");
-    iarg = 1;
+    iarg = 2;
 
   } else if (strcmp(arg[0],"clump") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal balance_grid command");


### PR DESCRIPTION
## Purpose

Fixes an issue with parsing the `balance_grid` command with `proc` or `random` style load-balancing options.

## Author(s)

Georgii Oblapenko, DLR

## Backward Compatibility

No issues with backward compatibility unless someone was relying on some internal tests breaking with balance_grid random or proc.

## Implementation Notes

Previous attempts to run with `balance_grid proc` or `balance_grid random` led to the following error: `ERROR: Illegal balance_grid command (../balance_grid.cpp:151)`, as the number of parsed string arguments was being erroneously set to 0.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links


