### PR TITLE
Normfactor computation consistent with surfaces for axisymm case

### DIFF
--- a/src/compute_boundary.cpp
+++ b/src/compute_boundary.cpp
@@ -24,8 +24,10 @@
 #include "math_extra.h"
 #include "memory.h"
 #include "error.h"
+#include "math_const.h"
 
 using namespace SPARTA_NS;
+using namespace MathConst;
 
 enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
 enum{PERIODIC,OUTFLOW,REFLECT,SURFACE,AXISYM};  // same as Domain
@@ -100,7 +102,15 @@ void ComputeBoundary::init()
   double nfactor = update->dt/update->fnum;
   if (domain->dimension == 2) {
     normflux[XLO] = normflux[XHI] = domain->yprd * nfactor;
-    normflux[YLO] = normflux[YHI] = domain->xprd * nfactor;
+
+    if (!domain->axisymmetric) {
+      normflux[YLO] = normflux[YHI] = domain->xprd * nfactor;
+    }
+    else {
+      // normflux[YLO] is actually 0 in axisymmetric case
+      // but is used in tally normalization even though numerator will be 0
+      normflux[YLO] = normflux[YHI] = 2 * MY_PI * domain->xprd * domain->yprd * nfactor;
+    }
   } else if (domain->dimension == 3) {
     normflux[XLO] = normflux[XHI] = domain->yprd*domain->zprd * nfactor;
     normflux[YLO] = normflux[YHI] = domain->xprd*domain->zprd * nfactor;

--- a/src/compute_boundary.cpp
+++ b/src/compute_boundary.cpp
@@ -103,12 +103,11 @@ void ComputeBoundary::init()
   if (domain->dimension == 2) {
     normflux[XLO] = normflux[XHI] = domain->yprd * nfactor;
 
-    if (!domain->axisymmetric) {
+    if (!domain->axisymmetric)
       normflux[YLO] = normflux[YHI] = domain->xprd * nfactor;
-    }
     else {
       // normflux[YLO] is actually 0 in axisymmetric case
-      // but is used in tally normalization even though numerator will be 0
+      //  but is used in tally normalization even though numerator will be 0
       normflux[YLO] = normflux[YHI] = 2 * MY_PI * domain->xprd * domain->yprd * nfactor;
     }
   } else if (domain->dimension == 3) {


### PR DESCRIPTION
## Purpose

This small change adds additional factors to compute the surface area (that is used for flux scaling) of the box boundary in the axisymmetric case. This way this is consistent with computations done in `compute_surf.cpp` and `surf.cpp` (see `surf->axi_line_size`). This uses the same scaling for YLO, although that surface/boundary has an area of 0 (due to being on the axis of rotation).

## Author(s)

Georgii Oblapenko, DLR

## Backward Compatibility

No issues with tests; no changes to existing input files needed. May cause inconsistency in output in computations that used the box boundary flux for the YHI boundary in an axisymmetric setup.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links



