### PR TITLE
grid dimensions parsing fix

### DIFF
--- a/tools/paraview/grid2paraview.py
+++ b/tools/paraview/grid2paraview.py
@@ -1031,9 +1031,9 @@ def read_grid_description_file(sif, grid_desc):
       grid_desc["slice"].append(p)
     elif s.lower()[:10] == "create_box" and len(s.split()) == 7:
       grid_desc["create_box"] = {}
-      if s.split()[1] < s.split()[2] and \
-         s.split()[3] < s.split()[4] and \
-         s.split()[5] < s.split()[6]:
+      if float(s.split()[1]) < float(s.split()[2]) and \
+         float(s.split()[3]) < float(s.split()[4]) and \
+         float(s.split()[5]) < float(s.split()[6]):
          grid_desc["create_box"]["xlo"] = float(s.split()[1])
          grid_desc["create_box"]["xhi"] = float(s.split()[2])
          grid_desc["create_box"]["ylo"] = float(s.split()[3])


### PR DESCRIPTION
## Purpose

Fixes an bug in the parsing of grid dimension in the Paraview conversion script. It was comparing strings instead of the actual float values, which would sometimes lead to errors depending on the grid sizing (see https://github.com/sparta/sparta/issues/377)

## Author(s)

Georgii Oblapenko

## Backward Compatibility

No changes in backward compatibility.

## Implementation Notes

Added float conversion in the grid dimensions check.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links



