### PR TITLE
Fixed reaction energy checks in tce/qk react style

### DIFF
--- a/src/react_tce_qk.cpp
+++ b/src/react_tce_qk.cpp
@@ -123,7 +123,7 @@ int ReactTCEQK::attempt_tce(Particle::OnePart *ip, Particle::OnePart *jp,
   if (pre_ave_rotdof > 0.1) ecc += pre_erot*r->coeff[0]/pre_ave_rotdof;
 
   double e_excess = ecc - r->coeff[1];
-  if (e_excess > 0.0) return 0;
+  if (e_excess <= 0.0) return 0;
 
   // compute probability of reaction
 
@@ -188,7 +188,7 @@ int ReactTCEQK::attempt_qk(Particle::OnePart *ip, Particle::OnePart *jp,
   if (pre_ave_rotdof > 0.1) ecc += pre_erot*r->coeff[0]/pre_ave_rotdof;
 
   double e_excess = ecc - r->coeff[1];
-  if (e_excess > 0.0) return 0;
+  if (e_excess <= 0.0) return 0;
 
   // compute probability of reaction
 


### PR DESCRIPTION
## Purpose

This fixes https://github.com/sparta/sparta/issues/424 (at least partially, the implementation of the hybrid tce/qk style seems inconsistent to me). But the basic check for sufficient collision energy works as intended now.

## Author(s)

Georgii Oblapenko, DLR

## Backward Compatibility

Tests pass, no changes to input files needed.

## Implementation Notes


## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links
