### PR TITLE
Do not emit particles in cells that are outside of the flow volume

### DIFF
--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -250,9 +250,11 @@ void FixEmitSurf::create_task(int icell)
   double *vscale = particle->mixture[imix]->vscale;
 
   // no tasks if no surfs in cell
+
   if (cells[icell].nsurf == 0) return;
 
   // no tasks if cell is outside of flow volume
+
   if (cinfo[icell].volume == 0.0) return;
 
   // loop over surfs in cell

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -250,8 +250,10 @@ void FixEmitSurf::create_task(int icell)
   double *vscale = particle->mixture[imix]->vscale;
 
   // no tasks if no surfs in cell
-
   if (cells[icell].nsurf == 0) return;
+
+  // no tasks if cell is outside of flow volume
+  if (cinfo[icell].volume == 0.0) return;
 
   // loop over surfs in cell
   // use Cut2d/Cut3d to find overlap area and geoemtry of overlap


### PR DESCRIPTION
## Purpose

This fixes the emission of particles in cells that are outside of the flow volume. This fixes a problem for some case setups that feature internal flows (i.e. inside the geometry, e.g. in a pipe), where particles would be emitted twice for an inflow surface.

I suspect that this will also fix the bug mentioned in #429.

## Author(s)

Tim Teichmann (KIT, ITEP)

## Backward Compatibility

I have had this patch downstream for several years and have not found any issues.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

