### PR TITLE
Fix bug in optimized move on multiple MPI ranks

### DIFF
--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -944,7 +944,6 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, cons
 	    d_ncomm_one()++;
 	  else
 	    reduce.ncomm_one++;
-	  }
         }
 
         return;

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -935,6 +935,16 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, cons
             indx = Kokkos::atomic_fetch_add(&d_nmigrate(),1);
           }
           k_mlist.d_view[indx] = i;
+
+          particle_i.flag = PDONE;
+
+	  if (ATOMIC_REDUCTION == 1)
+	    Kokkos::atomic_increment(&d_ncomm_one());
+	  else if (ATOMIC_REDUCTION == 0)
+	    d_ncomm_one()++;
+	  else
+	    reduce.ncomm_one++;
+	  }
         }
 
         return;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -537,8 +537,11 @@ template < int DIM, int SURF, int OPT > void Update::move()
             x[1] = xnew[1];
             x[2] = xnew[2];
 
-            if (cells[icell].proc != me)
+            if (cells[icell].proc != me) {
               mlist[nmigrate++] = i;
+              particles[i].flag = PDONE;
+              ncomm_one++;
+            }
 
             continue;
           }


### PR DESCRIPTION
## Purpose

The optimized move on multiple MPI ranks was incorrect.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes