### PR TITLE
Remove register keyword (deprecated in C++11)

### DIFF
--- a/src/FFT/pack2d.h
+++ b/src/FFT/pack2d.h
@@ -54,8 +54,8 @@ struct pack_plan_2d {
 static void pack_2d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_2d *plan)
 
 {
-  register int in,out,fast,slow;
-  register int nfast,nslow,nstride;
+  int in,out,fast,slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -76,8 +76,8 @@ static void pack_2d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_2d *plan)
 void unpack_2d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register int in,out,fast,slow;
-  register int nfast,nslow,nstride;
+  int in,out,fast,slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -98,8 +98,8 @@ void unpack_2d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 void unpack_2d_permute_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register int in,out,fast,slow;
-  register int nfast,nslow,nstride;
+  int in,out,fast,slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -120,8 +120,8 @@ void unpack_2d_permute_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void unpack_2d_permute_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register int in,out,fast,slow;
-  register int nfast,nslow,nstride;
+  int in,out,fast,slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -144,8 +144,8 @@ void unpack_2d_permute_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void unpack_2d_permute_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register int in,out,iqty,instart,fast,slow;
-  register int nfast,nslow,nstride,nqty;
+  int in,out,iqty,instart,fast,slow;
+  int nfast,nslow,nstride,nqty;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -177,9 +177,9 @@ void unpack_2d_permute_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void pack_2d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*begin,*end;
-  register int slow;
-  register int nfast,nslow,nstride;
+  double *in,*out,*begin,*end;
+  int slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -201,9 +201,9 @@ void pack_2d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_2d *plan)
 void unpack_2d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*begin,*end;
-  register int slow;
-  register int nfast,nslow,nstride;
+  double *in,*out,*begin,*end;
+  int slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -225,9 +225,9 @@ void unpack_2d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 void unpack_2d_permute_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*begin,*end;
-  register int slow;
-  register int nfast,nslow,nstride;
+  double *in,*out,*begin,*end;
+  int slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -249,9 +249,9 @@ void unpack_2d_permute_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void unpack_2d_permute_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*begin,*end;
-  register int slow;
-  register int nfast,nslow,nstride;
+  double *in,*out,*begin,*end;
+  int slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -275,9 +275,9 @@ void unpack_2d_permute_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void unpack_2d_permute_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*instart,*begin,*end;
-  register int iqty,slow;
-  register int nfast,nslow,nstride,nqty;
+  double *in,*out,*instart,*begin,*end;
+  int iqty,slow;
+  int nfast,nslow,nstride,nqty;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -312,9 +312,9 @@ void unpack_2d_permute_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void pack_2d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out;
-  register int slow,size;
-  register int nfast,nslow,nstride;
+  double *in,*out;
+  int slow,size;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -335,9 +335,9 @@ void pack_2d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_2d *plan)
 void unpack_2d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out;
-  register int slow,size;
-  register int nfast,nslow,nstride;
+  double *in,*out;
+  int slow,size;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -358,9 +358,9 @@ void unpack_2d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 void unpack_2d_permute_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*begin,*end;
-  register int slow;
-  register int nfast,nslow,nstride;
+  double *in,*out,*begin,*end;
+  int slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -382,9 +382,9 @@ void unpack_2d_permute_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void unpack_2d_permute_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*begin,*end;
-  register int slow;
-  register int nfast,nslow,nstride;
+  double *in,*out,*begin,*end;
+  int slow;
+  int nfast,nslow,nstride;
 
   nfast = plan->nfast;
   nslow = plan->nslow;
@@ -408,9 +408,9 @@ void unpack_2d_permute_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *p
 void unpack_2d_permute_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_2d *plan)
 
 {
-  register double *in,*out,*instart,*begin,*end;
-  register int iqty,slow;
-  register int nfast,nslow,nstride,nqty;
+  double *in,*out,*instart,*begin,*end;
+  int iqty,slow;
+  int nfast,nslow,nstride,nqty;
 
   nfast = plan->nfast;
   nslow = plan->nslow;

--- a/src/FFT/pack3d.h
+++ b/src/FFT/pack3d.h
@@ -55,8 +55,8 @@ struct pack_plan_3d {
 
 static void pack_3d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_3d *plan)
 {
-  register int in,out,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  int in,out,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -81,8 +81,8 @@ static void pack_3d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_3d *plan)
 
 static void unpack_3d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 {
-  register int in,out,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  int in,out,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -107,8 +107,8 @@ static void unpack_3d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan
 
 static void unpack_3d_permute1_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 {
-  register int in,out,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  int in,out,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -133,8 +133,8 @@ static void unpack_3d_permute1_1(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 
 static void unpack_3d_permute1_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 {
-  register int in,out,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  int in,out,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -162,8 +162,8 @@ static void unpack_3d_permute1_2(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute1_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register int in,out,iqty,instart,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane,nqty;
+  int in,out,iqty,instart,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane,nqty;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -192,8 +192,8 @@ static void unpack_3d_permute1_n(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register int in,out,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane;
+  int in,out,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -218,8 +218,8 @@ static void unpack_3d_permute2_1(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register int in,out,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane;
+  int in,out,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -246,8 +246,8 @@ static void unpack_3d_permute2_2(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register int in,out,iqty,instart,fast,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,nqty;
+  int in,out,iqty,instart,fast,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,nqty;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -283,9 +283,9 @@ static void unpack_3d_permute2_n(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void pack_3d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -312,9 +312,9 @@ static void pack_3d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_3d *plan)
 static void unpack_3d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -341,9 +341,9 @@ static void unpack_3d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan
 static void unpack_3d_permute1_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -370,9 +370,9 @@ static void unpack_3d_permute1_1(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute1_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -401,9 +401,9 @@ static void unpack_3d_permute1_2(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute1_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*instart,*begin,*end;
-  register int iqty,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane,nqty;
+  PACK_DATA *in,*out,*instart,*begin,*end;
+  int iqty,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane,nqty;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -433,9 +433,9 @@ static void unpack_3d_permute1_n(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -461,9 +461,9 @@ static void unpack_3d_permute2_1(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -491,9 +491,9 @@ static void unpack_3d_permute2_2(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*instart,*begin,*end;
-  register int iqty,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,nqty;
+  PACK_DATA *in,*out,*instart,*begin,*end;
+  int iqty,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,nqty;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -532,9 +532,9 @@ static void unpack_3d_permute2_n(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void pack_3d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out;
-  register int mid,slow,size;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane,upto;
+  PACK_DATA *in,*out;
+  int mid,slow,size;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane,upto;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -561,9 +561,9 @@ static void pack_3d(PACK_DATA *data, PACK_DATA *buf, struct pack_plan_3d *plan)
 static void unpack_3d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out;
-  register int mid,slow,size;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane,upto;
+  PACK_DATA *in,*out;
+  int mid,slow,size;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane,upto;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -590,9 +590,9 @@ static void unpack_3d(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan
 static void unpack_3d_permute1_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -619,9 +619,9 @@ static void unpack_3d_permute1_1(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute1_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -650,9 +650,9 @@ static void unpack_3d_permute1_2(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute1_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*instart,*begin,*end;
-  register int iqty,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,plane,nqty;
+  PACK_DATA *in,*out,*instart,*begin,*end;
+  int iqty,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,plane,nqty;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -682,9 +682,9 @@ static void unpack_3d_permute1_n(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_1(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -710,9 +710,9 @@ static void unpack_3d_permute2_1(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_2(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*begin,*end;
-  register int mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane;
+  PACK_DATA *in,*out,*begin,*end;
+  int mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane;
 
   nfast = plan->nfast;
   nmid = plan->nmid;
@@ -740,9 +740,9 @@ static void unpack_3d_permute2_2(PACK_DATA *buf, PACK_DATA *data, struct pack_pl
 static void unpack_3d_permute2_n(PACK_DATA *buf, PACK_DATA *data, struct pack_plan_3d *plan)
 
 {
-  register PACK_DATA *in,*out,*instart,*begin,*end;
-  register int iqty,mid,slow;
-  register int nfast,nmid,nslow,nstride_line,nstride_plane,nqty;
+  PACK_DATA *in,*out,*instart,*begin,*end;
+  int iqty,mid,slow;
+  int nfast,nmid,nslow,nstride_line,nstride_plane,nqty;
 
   nfast = plan->nfast;
   nmid = plan->nmid;


### PR DESCRIPTION
## Purpose

Remove the `register` keyword which is deprecated since C++11. Apparently it has little to no use, see https://stackoverflow.com/questions/20618008/replacement-for-deprecated-register-keyword-c-11. 

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes