### PR TITLE
Fix Kokkos performance regression

### DIFF
--- a/doc/Section_accelerate.txt
+++ b/doc/Section_accelerate.txt
@@ -484,6 +484,13 @@ one or more nodes, each with two GPUs.
 mpirun -np 2 spa_kokkos_cuda -k on g 2 -sf kk -in in.collide          # 1 node,   2 MPI tasks/node, 2 GPUs/node
 mpirun -np 32 -ppn 2 spa_kokkos_cuda -k on g 2 -sf kk -in in.collide  # 16 nodes, 2 MPI tasks/node, 2 GPUs/node (32 GPUs total) :pre
 
+NOTE: Use the "-pk kokkos" "command-line
+switch"_Section_start.html#start_7 to change the default "package
+kokkos"_package.html options. See its doc page for details and default
+settings. For example:
+
+mpirun -np 2 spa_kokkos_cuda -k on g 2 -sf kk -pk kokkos gpu/aware off -in in.collide      # set gpu/aware MPI support off :pre
+
 NOTE: Using OpenMP threading and CUDA together is currently not
 possible with the SPARTA KOKKOS package.
 

--- a/doc/Section_accelerate.txt
+++ b/doc/Section_accelerate.txt
@@ -143,7 +143,7 @@ prepare and test a regular SPARTA simulation |
 enable specific accelerator support via '-k on' "command-line switch"_Section_start.html#start_6, |
   -k on g 1 |
 set any needed options for the package via "-pk" "command-line switch"_Section_start.html#start_6 or "package"_package.html command, |
-  only if defaults need to be changed, -pk kokkos reduction atomic |
+  only if defaults need to be changed, -pk kokkos react/retry yes |
 use accelerated styles in your input via "-sf" "command-line switch"_Section_start.html#start_6 or "suffix"_suffix.html command | lmp_kokkos_cuda -in in.script -sf kk
 :tb(c=2,s=|)
 
@@ -483,17 +483,6 @@ one or more nodes, each with two GPUs.
 
 mpirun -np 2 spa_kokkos_cuda -k on g 2 -sf kk -in in.collide          # 1 node,   2 MPI tasks/node, 2 GPUs/node
 mpirun -np 32 -ppn 2 spa_kokkos_cuda -k on g 2 -sf kk -in in.collide  # 16 nodes, 2 MPI tasks/node, 2 GPUs/node (32 GPUs total) :pre
-
-NOTE: The default for the "package kokkos"_package.html command is to
-use "parallel" reduction of statistics along with threaded
-communication.  However, using "atomic" reduction is typically faster
-for GPUs.  Use the "-pk kokkos" "command-line
-switch"_Section_start.html#start_7 to change the default "package
-kokkos"_package.html options. See its doc page for details and default
-settings. Experimenting with its options can provide a speed-up for
-specific calculations. For example:
-
-mpirun -np 2 spa_kokkos_cuda -k on g 2 -sf kk -pk kokkos reduction atomic -in in.collide      # set reduction = atomic :pre
 
 NOTE: Using OpenMP threading and CUDA together is currently not
 possible with the SPARTA KOKKOS package.

--- a/doc/global.txt
+++ b/doc/global.txt
@@ -13,7 +13,7 @@ global command :h3
 global keyword values ... :pre
 
 one or more keyword/value pairs :ulb,l
-keyword = {fnum} or {nrho} or {vstream} or {temp} or {gravity} or {surfs} or {surfgrid} or {surfmax} or {splitmax} or {surftally} or {gridcut} or {comm/sort} or {comm/style} or {weight} or {particle/reorder} or {mem/limit} :l
+keyword = {fnum} or {nrho} or {vstream} or {temp} or {field} or {surfs} or {surfgrid} or {surfmax} or {splitmax} or {surftally} or {gridcut} or {comm/sort} or {comm/style} or {weight} or {particle/reorder} or {mem/limit} :l
   {fnum} value = ratio
     ratio = Fnum ratio of physical particles to simulation particles
   {nrho} value = density

--- a/doc/package.txt
+++ b/doc/package.txt
@@ -16,13 +16,10 @@ style = {kokkos} :ulb,l
 args = arguments specific to the style :l
   {kokkos} args = keyword value ...
     zero or more keyword/value pairs may be appended
-    keywords = {comm} or {reduction}
+    keywords = {comm} or {react/extra} or {react/retry} or {gpu/aware}
       {comm} value = {threaded} or {serial}
         threaded = perform pack/unpack using KOKKOS (e.g. on GPU or using OpenMP) (default for GPUs)
         serial = perform communication pack/unpack in non-KOKKOS mode (default for CPUs)
-      {reduction} = {parallel/reduce} or {atomic}
-        parallel/reduce = use parallel reduction for statistics (default for CPUs)
-        atomic = use atomic reduction for statistics (default for GPUs)
       {react/extra} = {factor}
         factor = increase memory used for collisions by this factor (default)
       {react/retry} = {yes} or {no}
@@ -36,7 +33,7 @@ args = arguments specific to the style :l
 [Examples:]
 
 package kokkos comm serial
-package kokkos comm threaded reduction atomic
+package kokkos comm threaded react/retry yes
 package kokkos gpu/aware no :pre
 
 [Description:]
@@ -82,12 +79,6 @@ KOKKOS package.
 
 All of the settings are optional keyword/value pairs.  Each has a
 default value as listed below.
-
-The {reduction} keyword sets the type of reduction used to gather
-statistics. The {parallel/reduce} option uses a parallel reduction and
-is typically the preferred method when running on CPUs and Xeon Phis.
-The {atomic} option uses thread atomics and is typically faster when
-running on GPUs.
 
 Chemical reactions (gas or surface) can increase the number of
 particles in the simulation, which requires extra memory storage. It
@@ -145,9 +136,9 @@ setting"_Section_start.html#start_6
 [Default:]
 
 For the KOKKOS package, the option defaults are react/extra = 1.1,
-react/retry = no, and gpu/aware yes. For CPUs: comm = serial,
-reduction = parallel/reduce, and for GPUs: comm = threaded, reduction =
-atomic. These settings are made automatically by the required "-k on"
-"command-line switch"_Section_start.html#start_6. You can change them
-by using the package kokkos command in your input script or via the
-"-pk kokkos" "command-line switch"_Section_start.html#start_6. 
+react/retry = no, and gpu/aware yes. For CPUs: comm = serial, and for
+GPUs: comm = threaded.  These settings are made automatically by the
+required "-k on" "command-line switch"_Section_start.html#start_6. You
+can change them by using the package kokkos command in your input script
+or via the "-pk kokkos" "command-line
+switch"_Section_start.html#start_6. 

--- a/examples/cylinder/in.cylinder
+++ b/examples/cylinder/in.cylinder
@@ -92,7 +92,7 @@ global		    nrho ${nden}
 global              fnum ${Fnum}
 
 timestep            ${tstep}
-global              gridcut 1.E-1 particle/reorder 100
+global              gridcut 1.E-1 particle/reorder 100 comm/sort yes
 
 ###################################
 # Grid generation

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -69,31 +69,37 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
 
       int set_flag = 0;
       char *str;
-      if ((str = getenv("SLURM_LOCALID"))) {
+      if (str = getenv("SLURM_LOCALID")) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
         set_flag = 1;
       }
-      if ((str = getenv("MPT_LRANK"))) {
+      if (str = getenv("FLUX_TASK_LOCAL_ID")) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
         set_flag = 1;
       }
-      if ((str = getenv("MV2_COMM_WORLD_LOCAL_RANK"))) {
+      if (str = getenv("MPT_LRANK")) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
         set_flag = 1;
       }
-      if ((str = getenv("OMPI_COMM_WORLD_LOCAL_RANK"))) {
+      if (str = getenv("MV2_COMM_WORLD_LOCAL_RANK")) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;
         set_flag = 1;
       }
-      if ((str = getenv("PMI_LOCAL_RANK"))) {
+      if (str = getenv("OMPI_COMM_WORLD_LOCAL_RANK")) {
+        int local_rank = atoi(str);
+        device = local_rank % ngpus;
+        if (device >= skip_gpu) device++;
+        set_flag = 1;
+      }
+      if (str = getenv("PMI_LOCAL_RANK")) {
         int local_rank = atoi(str);
         device = local_rank % ngpus;
         if (device >= skip_gpu) device++;

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -193,14 +193,6 @@ void KokkosSPARTA::accelerator(int narg, char **arg)
         comm_serial = 0;
       } else error->all(FLERR,"Illegal package kokkos command");
       iarg += 2;
-    } else if (strcmp(arg[iarg],"reduction") == 0) {
-      if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
-      if (strcmp(arg[iarg+1],"atomic") == 0) {
-        atomic_reduction = 1;
-      } else if (strcmp(arg[iarg+1],"parallel/reduce") == 0) {
-        atomic_reduction = 0;
-      } else error->all(FLERR,"Illegal package kokkos command");
-      iarg += 2;
     } else if (strcmp(arg[iarg],"react/retry") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal package kokkos command");
       if (strcmp(arg[iarg+1],"yes") == 0) {

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -139,10 +139,10 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
 
       if (sr_type == 0) {
         reaction = sr_kk_global_copy[m].obj.
-          react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
+          react_kokkos<ATOMIC_REDUCTION>(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       } else if (sr_type == 1) {
         reaction = sr_kk_prob_copy[m].obj.
-          react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
+          react_kokkos<ATOMIC_REDUCTION>(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       }
 
       if (reaction) {

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.h
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.h
@@ -111,13 +111,17 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
      resets particle(s) to post-collision outward velocity
   ------------------------------------------------------------------------- */
 
+  template<int REACT, int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, double &,
                                     int isurf, const double *norm, int isr, int &reaction,
                                     const DAT::t_int_scalar &d_retry, const DAT::t_int_scalar &d_nlocal) const
   {
-    Kokkos::atomic_increment(&d_nsingle());
-
+    if (ATOMIC_REDUCTION == 0)
+      d_nsingle()++;
+    else
+      Kokkos::atomic_increment(&d_nsingle());
+ 
     // if surface chemistry defined, attempt reaction
     // reaction = 1 to N for which reaction took place, 0 for none
     // velreset = 1 if reaction reset post-collision velocity, else 0
@@ -127,7 +131,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
     reaction = 0;
     int velreset = 0;
 
-    if (isr >= 0) {
+    if (REACT) {
       if (ambi_flag || vibmode_flag) memcpy(&iorig,ip,sizeof(Particle::OnePart));
 
       int sr_type = sr_type_list[isr];
@@ -141,7 +145,12 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
           react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       }
 
-      if (reaction) Kokkos::atomic_increment(&d_nreact_one());
+      if (reaction) {
+        if (ATOMIC_REDUCTION == 0)
+          d_nreact_one()++;
+        else
+          Kokkos::atomic_increment(&d_nreact_one());
+      }
     }
 
     // diffuse reflection for each particle
@@ -161,7 +170,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
       if (vibmode_flag)
         fix_vibmode_kk_copy.obj.update_custom_kokkos(i,twall_local,twall_local,twall_local,vstream);
     }
-    if (jp) {
+    if (REACT && jp) {
       if (!velreset) diffuse(jp,norm,twall_local);
       int j = jp - d_particles.data();
       if (ambi_flag)
@@ -174,7 +183,7 @@ class SurfCollideDiffuseKokkos : public SurfCollideDiffuse {
     // they may reset j to -1, e.g. fix ambipolar
     //   in which case newly created j is deleted
 
-    if (reaction && ambi_flag) {
+    if (REACT && reaction && ambi_flag) {
       int i = -1;
       if (ip) i = ip - d_particles.data();
       int j = -1;

--- a/src/KOKKOS/surf_collide_piston_kokkos.h
+++ b/src/KOKKOS/surf_collide_piston_kokkos.h
@@ -120,10 +120,10 @@ class SurfCollidePistonKokkos : public SurfCollidePiston {
 
       if (sr_type == 0) {
         reaction = sr_kk_global_copy[m].obj.
-          react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
+          react_kokkos<ATOMIC_REDUCTION>(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       } else if (sr_type == 1) {
         reaction = sr_kk_prob_copy[m].obj.
-          react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
+          react_kokkos<ATOMIC_REDUCTION>(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       }
 
       if (reaction) {

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -120,10 +120,10 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
 
       if (sr_type == 0) {
         reaction = sr_kk_global_copy[m].obj.
-          react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
+          react_kokkos<ATOMIC_REDUCTION>(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       } else if (sr_type == 1) {
         reaction = sr_kk_prob_copy[m].obj.
-          react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
+          react_kokkos<ATOMIC_REDUCTION>(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       }
 
       if (reaction) {

--- a/src/KOKKOS/surf_collide_specular_kokkos.h
+++ b/src/KOKKOS/surf_collide_specular_kokkos.h
@@ -92,12 +92,16 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
      resets particle(s) to post-collision outward velocity
   ------------------------------------------------------------------------- */
 
+  template<int REACT, int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, double &,
                                     int isurf, const double *norm, int isr, int &reaction,
                                     const DAT::t_int_scalar &d_retry, const DAT::t_int_scalar &d_nlocal) const
   {
-    Kokkos::atomic_increment(&d_nsingle());
+    if (ATOMIC_REDUCTION == 0)
+      d_nsingle()++;
+    else
+      Kokkos::atomic_increment(&d_nsingle());
 
     // if surface chemistry defined, attempt reaction
     // reaction = 1 to N for which reaction took place, 0 for none
@@ -108,7 +112,7 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
     reaction = 0;
     int velreset = 0;
 
-    if (isr >= 0) {
+    if (REACT) {
       if (ambi_flag || vibmode_flag) memcpy(&iorig,ip,sizeof(Particle::OnePart));
 
       int sr_type = sr_type_list[isr];
@@ -122,7 +126,12 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
           react_kokkos(ip,isurf,norm,jp,velreset,d_retry,d_nlocal);
       }
 
-      if (reaction) Kokkos::atomic_increment(&d_nreact_one());
+      if (reaction) {
+        if (ATOMIC_REDUCTION == 0)
+          d_nreact_one()++;
+        else
+          Kokkos::atomic_increment(&d_nreact_one());
+      }
     }
 
     // specular or noslip reflection for each particle
@@ -155,7 +164,7 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
       //}
     }
 
-    if (jp) {
+    if (REACT && jp) {
       if (!velreset) {
         if (noslip_flag) {
 
@@ -181,7 +190,7 @@ class SurfCollideSpecularKokkos : public SurfCollideSpecular {
     // they may reset j to -1, e.g. fix ambipolar
     //   in which case newly created j is deleted
 
-    if (reaction && ambi_flag) {
+    if (REACT && reaction && ambi_flag) {
       int i = -1;
       if (ip) i = ip - d_particles.data();
       int j = -1;

--- a/src/KOKKOS/surf_collide_transparent_kokkos.h
+++ b/src/KOKKOS/surf_collide_transparent_kokkos.h
@@ -52,12 +52,16 @@ class SurfCollideTransparentKokkos : public SurfCollideTransparent {
      return jp = NULL for no new particle
   ------------------------------------------------------------------------- */
 
+  template<int REACT, int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *, double &,
                                     int, const double *, int, int &,
                                     const DAT::t_int_scalar &, const DAT::t_int_scalar &) const
   {
-    Kokkos::atomic_increment(&d_nsingle());
+    if (ATOMIC_REDUCTION == 0)
+      d_nsingle()++;
+    else
+      Kokkos::atomic_increment(&d_nsingle());
 
     return NULL;
   }

--- a/src/KOKKOS/surf_collide_vanish_kokkos.h
+++ b/src/KOKKOS/surf_collide_vanish_kokkos.h
@@ -51,12 +51,16 @@ class SurfCollideVanishKokkos : public SurfCollideVanish {
      return reaction = 0 = no reaction took place
   ------------------------------------------------------------------------- */
 
+  template<int REACT, int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
   Particle::OnePart* collide_kokkos(Particle::OnePart *&ip, double &,
                                     int, const double *, int, int &,
                                     const DAT::t_int_scalar &, const DAT::t_int_scalar &) const
   {
-    Kokkos::atomic_increment(&d_nsingle());
+    if (ATOMIC_REDUCTION == 0)
+      d_nsingle()++;
+    else
+      Kokkos::atomic_increment(&d_nsingle());
 
     ip = NULL;
     return NULL;

--- a/src/KOKKOS/surf_react_prob_kokkos.h
+++ b/src/KOKKOS/surf_react_prob_kokkos.h
@@ -87,6 +87,7 @@ class SurfReactProbKokkos : public SurfReactProb {
      if dissociation, add particle and return ptr JP
   ------------------------------------------------------------------------- */
 
+  template<int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
   int react_kokkos(Particle::OnePart *&ip, int, const double *,
                    Particle::OnePart *&jp, int &,
@@ -112,8 +113,13 @@ class SurfReactProbKokkos : public SurfReactProb {
       react_prob += d_coeffs(j,0);
 
       if (react_prob > random_prob) {
-        Kokkos::atomic_increment(&d_nsingle());
-        Kokkos::atomic_increment(&d_tally_single(j));
+        if (ATOMIC_REDUCTION == 0) {
+          d_nsingle()++;
+          d_tally_single(j)++;
+        } else {
+          Kokkos::atomic_increment(&d_nsingle());
+          Kokkos::atomic_increment(&d_tally_single(j));
+        }
         switch (d_type(j)) {
         case DISSOCIATION:
           {
@@ -122,7 +128,14 @@ class SurfReactProbKokkos : public SurfReactProb {
             int id = MAXSMALLINT*rand_gen.drand();
             memcpy(x,ip->x,3*sizeof(double));
             memcpy(v,ip->v,3*sizeof(double));
-            int index = Kokkos::atomic_fetch_add(&d_nlocal(),1);
+
+            int index;
+            if (ATOMIC_REDUCTION == 0) {
+              index = d_nlocal();
+              d_nlocal()++;
+            } else
+              index = Kokkos::atomic_fetch_add(&d_nlocal(),1);
+
             int reallocflag = ParticleKokkos::add_particle_kokkos(d_particles,index,id,d_products(j,1),ip->icell,x,v,0.0,0.0);
             if (reallocflag) {
               d_retry() = 1;

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -1906,6 +1906,7 @@ int UpdateKokkos::split2d(int icell, double *x) const
 
     if (hitflag && side != INSIDE && param < minparam) {
       cflag = 1;
+      minparam = param;
       minsurfindex = m;
     }
   }

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -211,7 +211,6 @@ void UpdateKokkos::init()
       error->all(FLERR,
                  "External field in y not allowed for axisymmetric model");
   } else if (fstyle == PFIELD) {
-  } else if (fstyle == PFIELD) {
     ifieldfix = modify->find_fix(fieldID);
     if (ifieldfix < 0) error->all(FLERR,"External field fix ID not found");
     if (!modify->fix[ifieldfix]->per_particle_field)

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -177,25 +177,28 @@ void UpdateKokkos::init()
   // choose the appropriate move method
 
   if (domain->dimension == 3) {
-    if (surf->exist)
-      moveptr = &UpdateKokkos::move<3,1,0>;
-    else {
-      if (optmove_flag) moveptr = &UpdateKokkos::move<3,0,1>;
-      else moveptr = &UpdateKokkos::move<3,0,0>;
+    if (surf->exist) {
+      if (surf->nsr) moveptr = &UpdateKokkos::move<3,1,1,0>;
+      else moveptr = &UpdateKokkos::move<3,1,0,0>;
+    } else {
+      if (optmove_flag) moveptr = &UpdateKokkos::move<3,0,0,1>;
+      else moveptr = &UpdateKokkos::move<3,0,0,0>;
     }
   } else if (domain->axisymmetric) {
-    if (surf->exist)
-      moveptr = &UpdateKokkos::move<1,1,0>;
-    else {
-      if (optmove_flag) moveptr = &UpdateKokkos::move<1,0,1>;
-      else moveptr = &UpdateKokkos::move<1,0,0>;
+    if (surf->exist) {
+      if (surf->nsr) moveptr = &UpdateKokkos::move<1,1,1,0>;
+      else moveptr = &UpdateKokkos::move<1,1,0,0>;
+    } else {
+      if (optmove_flag) moveptr = &UpdateKokkos::move<1,0,0,1>;
+      else moveptr = &UpdateKokkos::move<1,0,0,0>;
     }
   } else if (domain->dimension == 2) {
-    if (surf->exist)
-      moveptr = &UpdateKokkos::move<2,1,0>;
-    else {
-      if (optmove_flag) moveptr = &UpdateKokkos::move<2,0,1>;
-      else moveptr = &UpdateKokkos::move<2,0,0>;
+    if (surf->exist) {
+      if (surf->nsr) moveptr = &UpdateKokkos::move<2,1,1,0>;
+      else moveptr = &UpdateKokkos::move<2,1,0,0>;
+    } else {
+      if (optmove_flag) moveptr = &UpdateKokkos::move<2,0,0,1>;
+      else moveptr = &UpdateKokkos::move<2,0,0,0>;
     }
   }
 
@@ -207,6 +210,7 @@ void UpdateKokkos::init()
     if (domain->axisymmetric && field[1] != 0.0)
       error->all(FLERR,
                  "External field in y not allowed for axisymmetric model");
+  } else if (fstyle == PFIELD) {
   } else if (fstyle == PFIELD) {
     ifieldfix = modify->find_fix(fieldID);
     if (ifieldfix < 0) error->all(FLERR,"External field fix ID not found");
@@ -413,7 +417,7 @@ void UpdateKokkos::run(int nsteps)
    use multiple iterations of move/comm if necessary
 ------------------------------------------------------------------------- */
 
-template < int DIM, int SURF, int OPT > void UpdateKokkos::move()
+template < int DIM, int SURF, int REACT, int OPT > void UpdateKokkos::move()
 {
   int pstart,pstop,entryexit,any_entryexit;
   int continue_loop_flag = 0;
@@ -580,11 +584,6 @@ template < int DIM, int SURF, int OPT > void UpdateKokkos::move()
 
     UPDATE_REDUCE reduce;
 
-    /* ATOMIC_REDUCTION: 1 = use atomics
-                         0 = don't need atomics
-                        -1 = use parallel_reduce
-    */
-
     // Reactions may create or delete more particles than existing views can hold.
     //  Cannot grow a Kokkos view in a parallel loop, so
     //  if the capacity of the view is exceeded, break out of parallel loop,
@@ -605,13 +604,24 @@ template < int DIM, int SURF, int OPT > void UpdateKokkos::move()
       Kokkos::deep_copy(d_scalars,h_scalars);
 
       copymode = 1;
-      if (!sparta->kokkos->need_atomics)
-        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,OPT,0> >(pstart,pstop),*this);
-      else if (sparta->kokkos->atomic_reduction)
-        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,OPT,1> >(pstart,pstop),*this);
-      else
-        Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,OPT,-1> >(pstart,pstop),*this,reduce);
+
+    /* ATOMIC_REDUCTION: 1 = use atomics
+                         0 = don't need atomics
+                        -1 = use parallel_reduce
+    */
+
+#ifdef SPARTA_KOKKOS_GPU
+      Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,1> >(pstart,pstop),*this);
+#else
+      if constexpr(std::is_same<DeviceType,Kokkos::Serial) {
+        Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,-1> >(pstart,pstop),*this,reduce);
+      else {
+        if (!sparta->kokkos->need_atomics)
+          Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,0> >(pstart,pstop),*this);
+        else
+          Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,-1> >(pstart,pstop),*this,reduce);
       copymode = 0;
+#endif
 
       Kokkos::deep_copy(h_scalars,d_scalars);
 
@@ -785,18 +795,18 @@ template < int DIM, int SURF, int OPT > void UpdateKokkos::move()
 
 /* ---------------------------------------------------------------------- */
 
-template<int DIM, int SURF, int OPT, int ATOMIC_REDUCTION>
+template<int DIM, int SURF, int REACT, int OPT, int ATOMIC_REDUCTION>
 KOKKOS_INLINE_FUNCTION
-void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, const int &i) const {
+void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>, const int &i) const {
   UPDATE_REDUCE reduce;
-  this->template operator()<DIM,SURF,OPT,ATOMIC_REDUCTION>(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>(), i, reduce);
+  this->template operator()<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>(TagUpdateMove<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>(), i, reduce);
 }
 
 /*-----------------------------------------------------------------------------*/
 
-template<int DIM, int SURF, int OPT, int ATOMIC_REDUCTION>
+template<int DIM, int SURF, int REACT, int OPT, int ATOMIC_REDUCTION>
 KOKKOS_INLINE_FUNCTION
-void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, const int &i, UPDATE_REDUCE &reduce) const {
+void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>, const int &i, UPDATE_REDUCE &reduce) const {
   if (d_error_flag() || d_retry()) return;
 
   // int m;
@@ -1342,38 +1352,38 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, cons
           if (DIM == 3) {
             if (sc_type == 0) {
               jpart = sc_kk_specular_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 1) {
               jpart = sc_kk_diffuse_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 2) {
               jpart = sc_kk_vanish_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 3) {
               jpart = sc_kk_piston_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 4) {
               jpart = sc_kk_transparent_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,tri->norm,tri->isr,reaction,d_retry,d_nlocal);
             }
           }
 
           if (DIM != 3) {
             if (sc_type == 0) {
               jpart = sc_kk_specular_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 1) {
               jpart = sc_kk_diffuse_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 2) {
               jpart = sc_kk_vanish_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 3) {
               jpart = sc_kk_piston_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
             } else if (sc_type == 4) {
               jpart = sc_kk_transparent_copy[m].obj.
-                collide_kokkos(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
+                collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,minsurf,line->norm,line->isr,reaction,d_retry,d_nlocal);
             }
           }
 
@@ -1608,19 +1618,19 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, cons
 
         if (sc_type == 0)
           jpart = sc_kk_specular_copy[m].obj.
-            collide_kokkos(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
+            collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
         else if (sc_type == 1)
           jpart = sc_kk_diffuse_copy[m].obj.
-            collide_kokkos(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
+            collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
         else if (sc_type == 2)
           jpart = sc_kk_vanish_copy[m].obj.
-            collide_kokkos(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
+            collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
         else if (sc_type == 3)
           jpart = sc_kk_piston_copy[m].obj.
-            collide_kokkos(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
+            collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
         else if (sc_type == 4)
           jpart = sc_kk_transparent_copy[m].obj.
-            collide_kokkos(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
+            collide_kokkos<REACT,ATOMIC_REDUCTION>(ipart,dtremain,-(outface+1),domain_kk_copy.obj.norm[outface],domain_kk_copy.obj.surf_react[outface],reaction,d_retry,d_nlocal);
 
         if (ipart) {
           double *x = ipart->x;
@@ -1889,7 +1899,6 @@ int UpdateKokkos::split2d(int icell, double *x) const
 
     if (hitflag && side != INSIDE && param < minparam) {
       cflag = 1;
-      minparam = param;
       minsurfindex = m;
     }
   }

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -613,15 +613,17 @@ template < int DIM, int SURF, int REACT, int OPT > void UpdateKokkos::move()
 #ifdef SPARTA_KOKKOS_GPU
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,1> >(pstart,pstop),*this);
 #else
-      if constexpr(std::is_same<DeviceType,Kokkos::Serial) {
+      if constexpr(std::is_same<DeviceType,Kokkos::Serial>::value)
         Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,-1> >(pstart,pstop),*this,reduce);
       else {
         if (!sparta->kokkos->need_atomics)
           Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,0> >(pstart,pstop),*this);
         else
           Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,-1> >(pstart,pstop),*this,reduce);
-      copymode = 0;
+      }
 #endif
+
+      copymode = 0;
 
       Kokkos::deep_copy(h_scalars,d_scalars);
 

--- a/src/KOKKOS/update_kokkos.h
+++ b/src/KOKKOS/update_kokkos.h
@@ -215,7 +215,7 @@ class UpdateKokkos : public Update {
 
   typedef void (UpdateKokkos::*FnPtr)();
   FnPtr moveptr;             // ptr to move method
-  template < int, int, int, int> void move();
+  template <int, int, int, int> void move();
 
   //typedef void (UpdateKokkos::*FnPtr2)(int, int, double, double *, double *) const;
   //FnPtr2 moveperturb;        // ptr to moveperturb method

--- a/src/KOKKOS/update_kokkos.h
+++ b/src/KOKKOS/update_kokkos.h
@@ -69,7 +69,7 @@ struct s_UPDATE_REDUCE {
 };
 typedef struct s_UPDATE_REDUCE UPDATE_REDUCE;
 
-template<int DIM, int SURF, int OPT, int ATOMIC_REDUCTION>
+template<int DIM, int SURF, int REACT, int OPT, int ATOMIC_REDUCTION>
 struct TagUpdateMove{};
 
 class UpdateKokkos : public Update {
@@ -88,13 +88,13 @@ class UpdateKokkos : public Update {
   void setup();
   void run(int);
 
-  template<int DIM, int SURF, int OPT, int ATOMIC_REDUCTION>
+  template<int DIM, int SURF, int REACT, int OPT, int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, const int&) const;
+  void operator()(TagUpdateMove<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>, const int&) const;
 
-  template<int DIM, int SURF, int OPT, int ATOMIC_REDUCTION>
+  template<int DIM, int SURF, int REACT, int OPT, int ATOMIC_REDUCTION>
   KOKKOS_INLINE_FUNCTION
-  void operator()(TagUpdateMove<DIM,SURF,OPT,ATOMIC_REDUCTION>, const int&, UPDATE_REDUCE&) const;
+  void operator()(TagUpdateMove<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>, const int&, UPDATE_REDUCE&) const;
 
  private:
 
@@ -215,7 +215,7 @@ class UpdateKokkos : public Update {
 
   typedef void (UpdateKokkos::*FnPtr)();
   FnPtr moveptr;             // ptr to move method
-  template < int, int, int > void move();
+  template < int, int, int, int> void move();
 
   //typedef void (UpdateKokkos::*FnPtr2)(int, int, double, double *, double *) const;
   //FnPtr2 moveperturb;        // ptr to moveperturb method


### PR DESCRIPTION
## Purpose

Fix slowdown on NVIDIA GPUs from #396, reported by Matt Bettencourt (NVIDIA)

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

The Kokkos package `reduction` option was removed and the previous defaults will always be used now. This helps speed up compile time for `update_kokkos.cpp` which has many templates.