### PR TITLE
Extend dump surf command with the option to dump the area of surface elements to file

### DIFF
--- a/doc/dump.html
+++ b/doc/dump.html
@@ -79,6 +79,7 @@
       v1x,v1y,v1z = coords of 1st vertex in surface element
       v1x,v1y,v1z = coords of 2nd vertex in surface element
       v1x,v1y,v1z = coords of 3rd vertex in surface element
+      area = surface element area (3d, axisymmetric) or length (2d)
       s_ID = custom per-surf vector with ID
       s_ID[N] = Nth column of custom per-surf array with ID
       c_ID = per-surf vector calculated by a compute with ID
@@ -422,6 +423,10 @@ outward normal of the triangle.
 attributes write the coordinates of the vertices of the end or corner
 points of the surface element.  The <I>v1z</I>, <I>v2z</I>, <I>v3x</I>, <I>v3y</I>, and
 <I>v3z</I> attributes cannot be used for a 2d simulation.
+</P>
+<P>
+The <I>area</I> attribute writes the surface element area (3d and
+axisymmetric) or length (2d).
 </P>
 <P>The <I>s_ID</I> and <I>s_ID[N]</I> attributes allow custom per-surf vectors or
 arrays defined by a <A HREF = "fix.html">fix</A> or <A HREF = "surf_react.html">surf_react</A>

--- a/doc/dump.txt
+++ b/doc/dump.txt
@@ -68,6 +68,7 @@ args = list of arguments for a particular style :l
       v1x,v1y,v1z = coords of 1st vertex in surface element
       v1x,v1y,v1z = coords of 2nd vertex in surface element
       v1x,v1y,v1z = coords of 3rd vertex in surface element
+      area = surface element area (3d, axisymmetric) or length (2d)
       s_ID = custom per-surf vector with ID
       s_ID\[N\] = Nth column of custom per-surf array with ID
       c_ID = per-surf vector calculated by a compute with ID
@@ -410,6 +411,9 @@ The {v1x}, {v1y}, {v1z}, {v2x}, {v2y}, {v2z}, {v3x}, {v3y}, {v3z}
 attributes write the coordinates of the vertices of the end or corner
 points of the surface element.  The {v1z}, {v2z}, {v3x}, {v3y}, and
 {v3z} attributes cannot be used for a 2d simulation.
+
+The {area} attribute writes the surface element area (3d and
+axisymmetric) or length (2d).
 
 The {s_ID} and {s_ID\[N\]} attributes allow custom per-surf vectors or
 arrays defined by a "fix"_fix.html or "surf_react"_surf_react.html

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -50,6 +50,7 @@ DumpSurf::DumpSurf(SPARTA *sparta, int narg, char **arg) :
   buffer_flag = 1;
 
   dimension = domain->dimension;
+  axisymmetric = domain->axisymmetric;
 
   int igroup = surf->find_group(arg[2]);
   if (igroup < 0) error->all(FLERR,"Dump surf group ID does not exist");
@@ -476,6 +477,9 @@ int DumpSurf::parse_fields(int narg, char **arg)
       if (dimension == 2)
         error->all(FLERR,"Invalid dump surf field for 2d simulation");
       pack_choice[i] = &DumpSurf::pack_v3z;
+      vtype[i] = DOUBLE;
+    } else if (strcmp(arg[iarg],"area") == 0) {
+      pack_choice[i] = &DumpSurf::pack_area;
       vtype[i] = DOUBLE;
 
    // custom surf vector or array
@@ -1042,5 +1046,36 @@ void DumpSurf::pack_v3z(int n)
   for (int i = 0; i < nchoose; i++) {
     buf[n] = tris[cglobal[i]].p3[2];
     n += size_one;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpSurf::pack_area(int n)
+{
+  if (dimension == 2) {
+    Surf::Line *lines;
+    if (distributed && !implicit) lines = surf->mylines;
+    else lines = surf->lines;
+    if (axisymmetric) {
+      for (int i = 0; i < nchoose; i++) {
+        buf[n] = surf->axi_line_size(&lines[cglobal[i]]);
+        n += size_one;
+      }
+    } else {
+      for (int i = 0; i < nchoose; i++) {
+        buf[n] = surf->line_size(&lines[cglobal[i]]);
+        n += size_one;
+      }
+    }
+  } else if (dimension == 3) {
+    double tmp;
+    Surf::Tri *tris;
+    if (distributed && !implicit) tris = surf->mytris;
+    else tris = surf->tris;
+    for (int i = 0; i < nchoose; i++) {
+      buf[n] = surf->tri_size(&tris[cglobal[i]],tmp);
+      n += size_one;
+    }
   }
 }

--- a/src/dump_surf.h
+++ b/src/dump_surf.h
@@ -60,6 +60,7 @@ class DumpSurf : public Dump {
   int *custom;               // list of indices for the Custom attributes
 
   int dimension;
+  int axisymmetric;
   int nown;                  // # of surf elements owned by this proc
   int nchoose;               // # of surf elements output by this proc
   int *cglobal;              // indices of global elements for nchoose
@@ -116,6 +117,7 @@ class DumpSurf : public Dump {
   void pack_v3x(int);
   void pack_v3y(int);
   void pack_v3z(int);
+  void pack_area(int);
 };
 
 }


### PR DESCRIPTION
## Purpose

Extend the `dump surf` command with the option to dump the area of the surface elements (triangles in 3d, rotation area in axisymmetric and line length in 2d).

## Author(s)

Tim Teichmann, KIT

## Backward Compatibility

Yes, fully optional.

## Implementation Notes

See code

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

I have tested this with explicit and explicit distributed surfaces (jagged.3d / jagged.3d.distributed examples) but not with implicit surfaces. However, I see no reason why this should break due to the similarities with the other dump commands for e.g. v1x etc.


