### PR TITLE
Fix formatting of write_grid doc page

### DIFF
--- a/doc/write_grid.html
+++ b/doc/write_grid.html
@@ -36,13 +36,13 @@ topology.
 </P>
 <PRE>Description line 
 </PRE>
-<P>N cells
+<PRE>N cells
 M levels
 n1 n2 n3 level-1
 n1 n2 n3 level-2
 ...
-n1 n2 n3 level-M
-</P>
+n1 n2 n3 level-M 
+</PRE>
 <PRE>Cells 
 </PRE>
 <PRE>id1

--- a/doc/write_grid.txt
+++ b/doc/write_grid.txt
@@ -38,7 +38,7 @@ M levels
 n1 n2 n3 level-1
 n1 n2 n3 level-2
 ...
-n1 n2 n3 level-M
+n1 n2 n3 level-M :pre
 
 Cells :pre
 


### PR DESCRIPTION
## Purpose

Write_grid doc page was missing a formatting command for the file format explanation.

## Author(s)

Steve

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


