### PR TITLE
 Fix indexing bug in Surf::collate_array_implicit

### DIFF
--- a/src/surf.cpp
+++ b/src/surf.cpp
@@ -3335,7 +3335,7 @@ void Surf::collate_array_implicit(int nrow, int ncol, surfint *tally2surf,
   m = 0;
   for (i = 0; i < nout; i++) {
     cellID = out_rvous[m++];      // NOTE: should use ubuf
-    icell = hash[cellID] - 1;     // subtract one for child cell index
+    icell = hash[cellID];
     for (j = 0; j < ncol; j++)
       out[icell][j] += out_rvous[m++];
   }


### PR DESCRIPTION
## Purpose


Fix indexing bug in `Surf::collate_array_implicit`, was manifest by a segfault in `fix_ave_grid`, likely affects `fix_ave_surf` as well

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes just a bugfix