### PR TITLE
cmake: Add FFT_KOKKOS checks

### DIFF
--- a/BUILD_CMAKE.md
+++ b/BUILD_CMAKE.md
@@ -59,7 +59,9 @@ cmake -C /path/to/<NAME>.cmake /path/to/sparta/cmake
 * BUILD_MPI
   * Whether to enable the SPARTA MPI TPL.
 * FFT
-  * Which SPARTA FFT TPL to enable: FFTW3, or MKL.
+  * Which SPARTA FFT TPL to enable: FFTW3, MKL, or KISS.
+* FFT_KOKKOS
+  * Which SPARTA Kokkos FFT TPL to enable: CUFFT, HIPFFT, FFTW3, MKL, or KISS.
 
 Note: To point to a TPL installation, export <TPL>_ROOT=/path/to/tpl/install
 before running cmake.

--- a/cmake/common/print/sparta_options.cmake
+++ b/cmake/common/print/sparta_options.cmake
@@ -21,6 +21,10 @@ if(FFT)
   message(STATUS "  ${FFT}")
 endif()
 
+if(FFT_KOKKOS)
+  message(STATUS "  ${FFT_KOKKOS}")
+endif()
+
 message(STATUS "")
 
 message(STATUS "Enabled extra options")

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -53,18 +53,11 @@ endif()
 list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_MPI})
 # ################### END PROCESS MPI TPL/PKG ####################
 
-# ################### BEGIN PROCESS PKGS ####################
+# ################### BEGIN PROCESS FFT_KOKKOS TPL ####################
 if(FFT_KOKKOS STREQUAL "KISS")
   set(PKG_KOKKOS
   ON
   CACHE BOOL "Enable or disable sparta kokkos package. Default: OFF.")
-endif()
-
-if(PKG_KOKKOS)
-  # Sparta's Kokkos package requires dependencies from the PKG_FFT target.
-  set(PKG_FFT
-      ON
-      CACHE STRING "" FORCE)
 endif()
 
 if(FFT AND FFT_KOKKOS)
@@ -100,6 +93,15 @@ endif()
 if(FFT AND PKG_FFT)
   message(WARNING "Both FFT: ${FFT} and PKG_FFT: ${PKG_FFT} are selected. "
                   "Defaulting to PKG_FFT.")
+endif()
+# ################### END PROCESS FFT_KOKKOS TPL ####################
+
+# ################### BEGIN PROCESS PKGS ####################
+if(PKG_KOKKOS)
+  # Sparta's Kokkos package requires dependencies from the PKG_FFT target.
+  set(PKG_FFT
+      ON
+      CACHE STRING "" FORCE)
 endif()
 
 if(PKG_FFT)

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -54,11 +54,47 @@ list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_MPI})
 # ################### END PROCESS MPI TPL/PKG ####################
 
 # ################### BEGIN PROCESS PKGS ####################
+if(FFT_KOKKOS STREQUAL "KISS")
+  set(PKG_KOKKOS
+  ON
+  CACHE BOOL "Enable or disable sparta kokkos package. Default: OFF.")
+endif()
+
 if(PKG_KOKKOS)
   # Sparta's Kokkos package requires dependencies from the PKG_FFT target.
   set(PKG_FFT
       ON
       CACHE STRING "" FORCE)
+endif()
+
+if(FFT AND FFT_KOKKOS)
+  message(FATAL_ERROR  "Both FFT: ${FFT} and FFT_KOKKOS: ${FFT_KOKKOS} are selected. ")
+endif()
+
+if(FFT_KOKKOS STREQUAL "CUFFT" AND NOT Kokkos_ENABLE_CUDA)
+  message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_CUDA: ON.")
+endif()
+
+if(FFT_KOKKOS STREQUAL "HIPFFT" AND NOT Kokkos_ENABLE_HIP)
+  message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_HIP: ON.")
+endif()
+
+if(FFT_KOKKOS STREQUAL "FFTW3")
+  if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_ROCM)
+    message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} cannot run with a kokkos GPU backend.")
+  endif()
+endif()
+
+if(FFT_KOKKOS STREQUAL "MKL")
+  if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_ROCM)
+    message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} cannot run with a kokkos GPU backend.")
+  endif()
+endif()
+
+if(FFT_KOKKOS STREQUAL "FFTW3" OR FFT_KOKKOS STREQUAL "MKL")
+  if((NOT Kokkos_ENABLE_SERIAL) AND (NOT Kokkos_ENABLE_OPENMP))
+    message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires either Kokkos_ENABLE_OPENMP or Kokkos_ENABLE_SERIAL")
+  endif()
 endif()
 
 if(FFT AND PKG_FFT)

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -54,6 +54,13 @@ list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_MPI})
 # ################### END PROCESS MPI TPL/PKG ####################
 
 # ################### BEGIN PROCESS PKGS ####################
+if(PKG_KOKKOS)
+  # Sparta's Kokkos package requires dependencies from the PKG_FFT target.
+  set(PKG_FFT
+      ON
+      CACHE STRING "" FORCE)
+endif()
+
 if(FFT AND PKG_FFT)
   message(WARNING "Both FFT: ${FFT} and PKG_FFT: ${PKG_FFT} are selected. "
                   "Defaulting to PKG_FFT.")

--- a/cmake/common/set/sparta_options.cmake
+++ b/cmake/common/set/sparta_options.cmake
@@ -42,9 +42,8 @@ sparta_option(BUILD_JPEG "Enable or disable JPEG TPL. Default: OFF." OFF
 sparta_option(BUILD_PNG "Enable or disable PNG TPL. Default: OFF." OFF
               SPARTA_BUILD_TPL_LIST)
 
-option(FFT "Select a FFT TPL from FFTW3 and MKL. Default: OFF." OFF)
-option(FFT_KOKKOS "Select a FFT TPL for Kokkos from FFTW3_KOKKOS,
-MKL_KOKKOS, CUFFT_KOKKOS, and HIPFFT_KOKKOS. Default: OFF." OFF)
+option(FFT "Select a FFT TPL from FFTW3, MKL, or KISS. Default: OFF." OFF)
+option(FFT_KOKKOS "Select a FFT TPL for Kokkos from CUFFT, HIPFFT, FFTW3, MKL, or KISS. Default: OFF." OFF)
 # ######### END   SPARTA TPL DEPENDENCIES ##########
 
 # ######### BEGIN SPARTA EXTRA OPTIONS ##########


### PR DESCRIPTION
## Purpose

Add FFT_KOKKOS CMake checks. Fix sparta kokkos package build. Print selected FFT_KOKKOS option.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

Related to help desk ticket 3754.


