### PR TITLE
Fix bug with late use of global gridcut command

### DIFF
--- a/src/grid.h
+++ b/src/grid.h
@@ -361,6 +361,8 @@ class Grid : protected Pointers {
   class Cut2d *cut2d;
   class Cut3d *cut3d;
 
+  int unset_flag;          // flag for unset/reset neighbor methods
+
   // Particle class values used for packing/unpacking particles in grid comm
 
   int ncustom_particle;


### PR DESCRIPTION
## Purpose

Using the global gridcut command after the grid is defined can induce bugs (false errors) when surfaces are mapped to grid cells.  This PR should fix the issue.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


