### PR TITLE
Update CMake and docs for Kokkos FFTs

### DIFF
--- a/cmake/common/print/sparta_options.cmake
+++ b/cmake/common/print/sparta_options.cmake
@@ -17,11 +17,11 @@ foreach(opt IN LISTS SPARTA_BUILD_TPL_LIST)
   endif()
 endforeach()
 
-if(FFT)
+if(PKG_FFT AND FFT)
   message(STATUS "  ${FFT}")
 endif()
 
-if(FFT_KOKKOS)
+if(PKG_FFT AND FFT_KOKKOS)
   message(STATUS "  ${FFT_KOKKOS}")
 endif()
 

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -53,83 +53,105 @@ endif()
 list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_MPI})
 # ################### END PROCESS MPI TPL/PKG ####################
 
-# ################### BEGIN PROCESS FFT_KOKKOS TPL ####################
-if(FFT_KOKKOS STREQUAL "KISS")
-  set(PKG_KOKKOS
-  ON
-  CACHE BOOL "Enable or disable sparta kokkos package. Default: OFF.")
+# ################### BEGIN PROCESS FFT TPL/PKG ####################
+
+if((NOT PKG_FFT) AND (NOT (FFT_KOKKOS STREQUAL "OFF")))
+  message(FATAL_ERROR  "Setting FFT_KOKKOS library requires PKG_FFT: ON.")
 endif()
 
-if(FFT AND FFT_KOKKOS)
-  message(FATAL_ERROR  "Both FFT: ${FFT} and FFT_KOKKOS: ${FFT_KOKKOS} are selected. ")
-endif()
-
-if(FFT_KOKKOS STREQUAL "CUFFT" AND NOT Kokkos_ENABLE_CUDA)
-  message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_CUDA: ON.")
-endif()
-
-if(FFT_KOKKOS STREQUAL "HIPFFT" AND NOT Kokkos_ENABLE_HIP)
-  message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_HIP: ON.")
-endif()
-
-if(FFT_KOKKOS STREQUAL "FFTW3")
-  if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_ROCM)
-    message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} cannot run with a kokkos GPU backend.")
-  endif()
-endif()
-
-if(FFT_KOKKOS STREQUAL "MKL")
-  if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_ROCM)
-    message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} cannot run with a kokkos GPU backend.")
-  endif()
-endif()
-
-if(FFT_KOKKOS STREQUAL "FFTW3" OR FFT_KOKKOS STREQUAL "MKL")
-  if((NOT Kokkos_ENABLE_SERIAL) AND (NOT Kokkos_ENABLE_OPENMP))
-    message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires either Kokkos_ENABLE_OPENMP or Kokkos_ENABLE_SERIAL")
-  endif()
-endif()
-
-if(FFT AND PKG_FFT)
-  message(WARNING "Both FFT: ${FFT} and PKG_FFT: ${PKG_FFT} are selected. "
-                  "Defaulting to PKG_FFT.")
-endif()
-# ################### END PROCESS FFT_KOKKOS TPL ####################
-
-# ################### BEGIN PROCESS PKGS ####################
-if(PKG_KOKKOS)
-  # Sparta's Kokkos package requires dependencies from the PKG_FFT target.
-  set(PKG_FFT
-      ON
-      CACHE STRING "" FORCE)
+if((NOT PKG_FFT) AND (NOT (FFT STREQUAL "OFF")))
+  message(FATAL_ERROR  "Setting FFT library requires PKG_FFT: ON.")
 endif()
 
 if(PKG_FFT)
-  set(FFT
-      OFF
-      CACHE STRING "" FORCE)
+
+  if(FFT STREQUAL "OFF")
+    set(FFT "KISS" CACHE STRING "Select a FFT TPL for CPU from FFTW3, MKL, or KISS. Default: KISS." FORCE)
+  endif()
+
   set(TARGET_SPARTA_PKG_FFT pkg_fft)
   list(APPEND TARGET_SPARTA_PKGS ${TARGET_SPARTA_PKG_FFT})
-  set(SPARTA_DEFAULT_CXX_COMPILE_FLAGS -DFFT_NONE
-                                       ${SPARTA_DEFAULT_CXX_COMPILE_FLAGS})
-endif()
 
-if(FFT AND NOT PKG_FFT)
-  find_package(${FFT} REQUIRED)
-  set(TARGET_SPARTA_BUILD_FFT ${FFT}::${FFT})
+  string(TOUPPER ${FFT_KOKKOS} FFT_KOKKOS)
+
   set(SPARTA_DEFAULT_CXX_COMPILE_FLAGS -DFFT_${FFT}
                                        ${SPARTA_DEFAULT_CXX_COMPILE_FLAGS})
-  list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_FFT})
 
-  set(PKG_FFT
-      ON
-      CACHE STRING "" FORCE)
-  set(TARGET_SPARTA_PKG_FFT pkg_fft)
-  list(APPEND TARGET_SPARTA_PKGS ${TARGET_SPARTA_PKG_FFT})
+  if(NOT FFT STREQUAL "KISS")
+    find_package(${FFT} REQUIRED)
+
+    set(TARGET_SPARTA_BUILD_FFT ${FFT}::${FFT})
+    list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_FFT})
+
+    set(TARGET_SPARTA_PKG_FFT pkg_fft)
+    list(APPEND TARGET_SPARTA_PKGS ${TARGET_SPARTA_PKG_FFT})
+  endif()
+
   if(SPARTA_ENABLE_TESTING)
     set(SPARTA_ENABLED_TEST_SUITES ${SPARTA_ENABLED_TEST_SUITES} "fft")
   endif()
+
+  if(PKG_KOKKOS)
+    if(FFT_KOKKOS STREQUAL "OFF")
+      set(FFT_KOKKOS "KISS" CACHE STRING "Select a FFT TPL for Kokkos from CUFFT, HIPFFT, FFTW3, MKL, or KISS. Default: KISS." FORCE)
+    endif()
+
+    string(TOUPPER ${FFT_KOKKOS} FFT_KOKKOS)
+
+    if(FFT_KOKKOS STREQUAL "CUFFT" AND NOT Kokkos_ENABLE_CUDA)
+      message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_CUDA: ON.")
+    endif()
+
+    if(FFT_KOKKOS STREQUAL "HIPFFT" AND NOT Kokkos_ENABLE_HIP)
+      message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_HIP: ON.")
+    endif()
+
+    if(FFT_KOKKOS STREQUAL "FFTW3" OR FFT_KOKKOS STREQUAL "MKL")
+      if((NOT Kokkos_ENABLE_SERIAL) AND (NOT Kokkos_ENABLE_OPENMP))
+        message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires either Kokkos_ENABLE_OPENMP or Kokkos_ENABLE_SERIAL")
+      endif()
+
+      if(Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP OR Kokkos_ENABLE_ROCM)
+        message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} cannot run with a kokkos GPU backend.")
+      endif()
+    endif()
+
+    if(Kokkos_ENABLE_CUDA)
+      if(NOT ((FFT_KOKKOS STREQUAL "KISS") OR (FFT_KOKKOS STREQUAL "CUFFT")))
+        message(FATAL_ERROR "The CUDA backend of Kokkos requires either KISS FFT or CUFFT.")
+      elseif(FFT_KOKKOS STREQUAL "KISS")
+        message(WARNING "Using KISS FFT with the CUDA backend of Kokkos may be sub-optimal.")
+      elseif(FFT_KOKKOS STREQUAL "CUFFT")
+        find_library(CUFFT_LIBRARY cufft)
+        if (CUFFT_LIBRARY STREQUAL "CUFFT_LIBRARY-NOTFOUND")
+          message(FATAL_ERROR "Required cuFFT library not found. Check your environment or set CUFFT_LIBRARY to its location")
+        endif()
+        link_libraries(${CUFFT_LIBRARY})
+      endif()
+    elseif(Kokkos_ENABLE_HIP)
+      if(NOT ((FFT_KOKKOS STREQUAL "KISS") OR (FFT_KOKKOS STREQUAL "HIPFFT")))
+        message(FATAL_ERROR "The HIP backend of Kokkos requires either KISS FFT or HIPFFT.")
+      elseif(FFT_KOKKOS STREQUAL "KISS")
+        message(WARNING "Using KISS FFT with the HIP backend of Kokkos may be sub-optimal.")
+      elseif(FFT_KOKKOS STREQUAL "HIPFFT")
+        include(DetectHIPInstallation)
+        find_package(hipfft REQUIRED)
+        link_libraries(hip::hipfft)
+      endif()
+    endif()
+
+    if(FFT_KOKKOS STREQUAL "FFTW3" OR FFT_KOKKOS STREQUAL "MKL")
+      find_package(${FFT_KOKKOS} REQUIRED)
+    endif()
+
+    set(SPARTA_DEFAULT_CXX_COMPILE_FLAGS -DFFT_KOKKOS_${FFT_KOKKOS}
+                                         ${SPARTA_DEFAULT_CXX_COMPILE_FLAGS})
+
+  endif()
+
 endif()
+
+# ################### BEGIN PROCESS PKGS ####################
 
 if(PKG_KOKKOS)
   set(TARGET_SPARTA_PKG_KOKKOS pkg_kokkos)

--- a/cmake/common/set/sparta_options.cmake
+++ b/cmake/common/set/sparta_options.cmake
@@ -42,8 +42,8 @@ sparta_option(BUILD_JPEG "Enable or disable JPEG TPL. Default: OFF." OFF
 sparta_option(BUILD_PNG "Enable or disable PNG TPL. Default: OFF." OFF
               SPARTA_BUILD_TPL_LIST)
 
-option(FFT "Select a FFT TPL from FFTW3, MKL, or KISS. Default: OFF." OFF)
-option(FFT_KOKKOS "Select a FFT TPL for Kokkos from CUFFT, HIPFFT, FFTW3, MKL, or KISS. Default: OFF." OFF)
+set(FFT "OFF" CACHE STRING "Select a FFT TPL from FFTW3, MKL, or KISS. Default: KISS.")
+set(FFT_KOKKOS "OFF" CACHE STRING "Select a FFT TPL for Kokkos from CUFFT, HIPFFT, FFTW3, MKL, or KISS. Default: KISS.")
 # ######### END   SPARTA TPL DEPENDENCIES ##########
 
 # ######### BEGIN SPARTA EXTRA OPTIONS ##########

--- a/doc/Section_packages.txt
+++ b/doc/Section_packages.txt
@@ -63,12 +63,18 @@ FFT package :link(FFT),h4
 
 [Contents:]
 
-Apply Fast Fourier Transforms (FFTs) to simulation data. The FFT library is specified in the Makefile.machine using
-the FFT_INC, FFT_PATH, and FFT_LIB variables. Supported external FFT libraries that can be specified include
-FFTW3 and MKL. If no FFT library is specified in the Makefile, SPARTA will
-use the internal KISS FFT library that is included with SPARTA. See the see discussion
-in doc/Section_start.html#2_2 (step 6).
+Apply Fast Fourier Transforms (FFTs) to simulation data. The FFT library is
+specified in the Makefile.machine using the FFT_INC, FFT_PATH, and FFT_LIB
+variables. Supported external FFT libraries that can be specified include FFTW3
+and MKL. If no FFT library is specified in the Makefile, SPARTA will use the
+internal KISS FFT library that is included with SPARTA.
 
+Similarly an external FFT library can be specified for the KOKKOS package.
+Options are CUFFT, HIPFFT, FFTW3, and MKL. If no FFT library is specified in
+the Makefile, SPARTA will use the internal Kokkos version of the KISS FFT
+library that is included with SPARTA.
+
+See the see discussion in doc/Section_start.html#2_2 (step 6).
 
 [Install or un-install with make:]
 

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -222,7 +222,7 @@ Using one of the -DPACK_ARRAY, -DPACK_POINTER, and -DPACK_MEMCPY
 options can make for faster parallel FFTs on some platforms.  The
 -DPACK_ARRAY setting is the default.  See the "compute
 fft/grid"_compute_fft_grid.html command for info about FFTs.  See Step
-6 below for info about building SPPARKS with an FFT library.
+6 below for info about building SPARTA with an FFT library.
 
 [Step 5]
 
@@ -289,11 +289,23 @@ package in your build, you can also leave the 3 variables blank.
 
 Otherwise, select which kinds of FFTs to use as part of the FFT_INC
 setting by a switch of the form -DFFT_XXX. 
-Recommended values for XXX
-are: MKL or FFTW3.  NONE is supported as a legacy option.
-Selecting -DFFT_FFTW will use the FFTW3 library and -DFFT_NONE will
-use the KISS library described above.
-described above.
+Available values for XXX
+are: MKL or FFTW3.
+Selecting -DFFT_FFTW will use the FFTW3 library.
+
+Similarly a separate FFT library can be specified for KOKKOS package.
+By default, SPARTA will use a Kokkos version of the open-source "KISS
+FFT library"_http://kissfft.sf.net, which is included in the SPARTA
+distribution. Note that using the KISS FFT library on GPUs may give
+suboptimal performance. Other options can be specified using the form
+-DFFT_KOKKOS_XXX. Available values for XXX when using Kokkos are: CUFFT,
+HIPFFT, MKL or FFTW3. When using the Kokkos CUDA backend, either CUFFT
+or KISS must be used. When using the Kokkos HIP backend, either HIPFFT
+or KISS must be used. When using the Kokkos OpenMP or Serial backend,
+either MKL, FFTW3, or KISS must be used. The CUFFT option specifies the
+"cuFFT library"_https://developer.nvidia.com/cufft from NVIDIA. The
+HIPFFT option specifies the "rocFFT
+library"_https://rocm.docs.amd.com/projects/rocFFT/en/latest/ from AMD.
 
 You may also need to set the FFT_INC, FFT_PATH, and FFT_LIB variables,
 so the compiler and linker can find the needed FFT header and library
@@ -522,7 +534,7 @@ Using one of the -DPACK_ARRAY, -DPACK_POINTER, and -DPACK_MEMCPY
 options can make for faster parallel FFTs on some platforms.  The
 -DPACK_ARRAY setting is the default.  See the "compute
 fft/grid"_compute_fft_grid.html command for info about FFTs.  See STEP
-??? below for info about building SPPARKS with an FFT library.
+7 below for info about building SPARTA with an FFT library.
 
 [Step 5]
 
@@ -592,9 +604,30 @@ Note that this documentation link is for CMake version 3.12.
 
 [Step 7]
 
-You may select between 3 thiry party libraries (TPL) for FFT which SPARTA uses when
-configured with cmake -DFFT={FFTW3,MKL}. SPARTA also provides a FFT
-package which can be selected with cmake -DPKG_FFT=ON.
+When the SPARTA FFT package is enabled with cmake -DPKG_FFT=ON, you may select
+between 3 thiry party libraries (TPLs) for 1d FFTs, which SPARTA uses when
+configured with cmake -DFFT={FFTW3,MKL,KISS}.
+
+By default SPARTA will use the open-source "KISS FFT
+library"_http://kissfft.sf.net, which is included in the SPARTA distribution.
+This library is portable to all platforms and for typical SPARTA simulations is
+almost as fast as FFTW or vendor optimized libraries.
+
+Similarly when using the KOKKOS package, you may select between 5 TPLs for FFT
+which SPARTA uses when configured with cmake
+-DFFT_KOKKOS={CUFFT,HIPFFT,FFTW3,MKL,KISS}. This requires enabling the SPARTA
+FFT package which can be selected with cmake -DPKG_FFT=ON.
+
+By default, SPARTA will use a Kokkos version of the open-source "KISS FFT
+library"_http://kissfft.sf.net, which is included in the SPARTA distribution.
+Note that using the KISS FFT library on GPUs may give suboptimal performance.
+Other options for -DFFT_KOKKOS are CUFFT, HIPFFT, MKL or FFTW3. When using the
+Kokkos CUDA backend, either CUFFT or KISS must be used. When using the Kokkos
+HIP backend, either HIPFFT or KISS must be used. When using the Kokkos OpenMP
+or Serial backend, either MKL, FFTW3, or KISS must be used. The CUFFT option
+specifies the "cuFFT library"_https://developer.nvidia.com/cufft from NVIDIA.
+The HIPFFT option specifies the "rocFFT
+library"_https://rocm.docs.amd.com/projects/rocFFT/en/latest/ from AMD.
 
 You may need to install the FFT TPL you're interested in using. If you're on a
 cluster or supercomputer, use module before running cmake so that cmake finds

--- a/doc/dump.txt
+++ b/doc/dump.txt
@@ -411,7 +411,7 @@ attributes and command that define them.  For example, the
 "read_grid"_read_grid.html and "surf_react
 implicit"_surf_react_implicit.html commands can define per-grid
 attributes.  (The surf/react implicit command has not yet been
-released in public SPPARKS).
+released in public SPARTA).
 
 If {g_name} is used as a attribute, the custom attribute must be a
 vector, and it is output.  If {g_name\[N\]} is used, the custom

--- a/doc/fix_ave_grid.txt
+++ b/doc/fix_ave_grid.txt
@@ -155,7 +155,7 @@ attributes and command that define them.  For example, the
 "read_grid"_read_grid.html and "surf_react
 implicit"_surf_react_implicit.html commands can define per-grid
 attributes.  (The surf/react implicit command has not yet been
-released in public SPPARKS).
+released in public SPARTA).
 
 If {g_name} is used as a value, the custom attribute must be a vector.
 If {g_name\[N\]} is used, the custom attribute must be an array, and N

--- a/src/KOKKOS/compute_grid_kokkos.cpp
+++ b/src/KOKKOS/compute_grid_kokkos.cpp
@@ -14,6 +14,7 @@
 
 #include "string.h"
 #include "compute_grid_kokkos.h"
+#include "comm.h"
 #include "particle_kokkos.h"
 #include "mixture.h"
 #include "grid_kokkos.h"


### PR DESCRIPTION
## Purpose

Update CMake and docs for Kokkos FFTs, builds on #451 and #453

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes

## Implementation Notes

Also fixed a compile issue with Kokkos KISS FFT.