### PR TITLE
Fixed broken links in doc

### DIFF
--- a/doc/Section_commands.html
+++ b/doc/Section_commands.html
@@ -290,7 +290,7 @@ simulation parameters, output options, etc.
 </P>
 <P><A HREF = "clear.html">clear</A>, <A HREF = "echo.html">echo</A>, <A HREF = "if.html">if</A>,
 <A HREF = "include.html">include</A>, <A HREF = "jump.html">jump</A>, <A HREF = "label.html">label</A>,
-<A HREF = "log.html">log</A>, <A HREF = "next.html">next</A>, <A HREF = "partition,html">partition</A>,
+<A HREF = "log.html">log</A>, <A HREF = "next.html">next</A>, <A HREF = "partition.html">partition</A>,
 <A HREF = "print.html">print</A>, <A HREF = "quit.html">quit</A>, <A HREF = "shell.html">shell</A>,
 <A HREF = "variable.html">variable</A>
 </P>

--- a/doc/Section_commands.txt
+++ b/doc/Section_commands.txt
@@ -288,7 +288,7 @@ Miscellaneous:
 
 "clear"_clear.html, "echo"_echo.html, "if"_if.html,
 "include"_include.html, "jump"_jump.html, "label"_label.html,
-"log"_log.html, "next"_next.html, "partition"_partition,html,
+"log"_log.html, "next"_next.html, "partition"_partition.html,
 "print"_print.html, "quit"_quit.html, "shell"_shell.html,
 "variable"_variable.html
 

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -1661,7 +1661,7 @@ attributes in various ways:
 <LI><A HREF = "custom.html">custom</A> - set the values of a per-grid attribute and optionally create it
 <LI><A HREF = "dump.html">dump grid</A> - output per-grid attributes to a dump file
 <LI><A HREF = "fix_ave_grid.html">fix ave/grid</A> - time-average a per-grid attribute
-<LI><A HREF = "read_grid,html">read_grid</A> - define and initialize per-grid attributes
+<LI><A HREF = "read_grid.html">read_grid</A> - define and initialize per-grid attributes
 <LI>surf_react implicit - use per-grid vectors and an array to store chemical state (not yet released in public SPARTA)
 <LI><A HREF = "variable.html">variable</A> - use a per-grid attribute in a grid-style variable formula
 <LI><A HREF = "write_grid.html">write_grid</A> - write per-grid attributes to a grid data file 

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -1651,7 +1651,7 @@ attributes in various ways:
 "custom"_custom.html - set the values of a per-grid attribute and optionally create it
 "dump grid"_dump.html - output per-grid attributes to a dump file
 "fix ave/grid"_fix_ave_grid.html - time-average a per-grid attribute
-"read_grid"_read_grid,html - define and initialize per-grid attributes
+"read_grid"_read_grid.html - define and initialize per-grid attributes
 surf_react implicit - use per-grid vectors and an array to store chemical state (not yet released in public SPARTA)
 "variable"_variable.html - use a per-grid attribute in a grid-style variable formula
 "write_grid"_write_grid.html - write per-grid attributes to a grid data file :ul

--- a/doc/read_restart.html
+++ b/doc/read_restart.html
@@ -152,7 +152,7 @@ simulation, as specified by the associated commands:
 information about these simulation entities and their associated
 commands is NOT stored:
 </P>
-<UL><LI><A HREF = "seed,html">random number seed</A>
+<UL><LI><A HREF = "seed.html">random number seed</A>
 <LI><A HREF = "compute.html">computes</A>
 <LI><A HREF = "fix.html">fixes</A>
 <LI><A HREF = "collide.html">collision model</A>

--- a/doc/read_restart.txt
+++ b/doc/read_restart.txt
@@ -145,7 +145,7 @@ No other information is stored in the restart file.  Specifically,
 information about these simulation entities and their associated
 commands is NOT stored:
 
-"random number seed"_seed,html
+"random number seed"_seed.html
 "computes"_compute.html
 "fixes"_fix.html
 "collision model"_collide.html


### PR DESCRIPTION
## Purpose

Fixed broken links in doc where comma was there instead of period, i.e. ",html" vs ".html"

## Author(s)

Andrew YK Hong

## Backward Compatibility

No conflicts

## Implementation Notes

Only doc changes

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

None


