### PR TITLE
Fix couple of formatting issues in doc pages

### DIFF
--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -168,7 +168,9 @@ it gives quick access to documentation for all SPARTA commands.
 <BR>
   6.16 <A HREF = "Section_howto.html#howto_16">Visualizing SPARTA output with ParaView</A> 
 <BR>
-  6.17 <A HREF = "Section_howto.html#howto_17">Variable timestep simulations</A> 
+  6.17 <A HREF = "Section_howto.html#howto_17">Custom per-particle, per-grid, per-surf attributes</A> 
+<BR>
+  6.18 <A HREF = "Section_howto.html#howto_18">Variable timestep simulations</A> 
 <BR></UL>
 <LI><A HREF = "Section_example.html">Example problems</A> 
 
@@ -224,6 +226,8 @@ it gives quick access to documentation for all SPARTA commands.
 <BR></UL>
 
 </OL>
+
+
 
 
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -121,7 +121,8 @@ it gives quick access to documentation for all SPARTA commands.
   6.14 "Implicit surface ablation"_howto_14 :b
   6.15 "Transparent surface elements"_howto_15 :b
   6.16 "Visualizing SPARTA output with ParaView"_howto_16 :b
-  6.17 "Variable timestep simulations"_howto_17 :ule,b
+  6.17 "Custom per-particle, per-grid, per-surf attributes"_howto_17 :b
+  6.18 "Variable timestep simulations"_howto_18 :ule,b
 "Example problems"_Section_example.html :l
 "Performance & scalability"_Section_perf.html :l
 "Additional tools"_Section_tools.html :l
@@ -191,6 +192,7 @@ it gives quick access to documentation for all SPARTA commands.
 :link(howto_15,Section_howto.html#howto_15)
 :link(howto_16,Section_howto.html#howto_16)
 :link(howto_17,Section_howto.html#howto_17)
+:link(howto_18,Section_howto.html#howto_18)
 
 :link(mod_1,Section_modify.html#mod_1)
 :link(mod_2,Section_modify.html#mod_2)

--- a/doc/fix_field_grid.html
+++ b/doc/fix_field_grid.html
@@ -15,10 +15,10 @@
 </P>
 <PRE>fix ID field/grid axvar ayvar azvar 
 </PRE>
-<P>ID is documented in <A HREF = "fix.html">fix</A> command
-field/grid = style name of this fix command
-axvar,ayvar,azvar = names of grid-style variables for acceleration components:ul
-</P>
+<UL><LI>ID is documented in <A HREF = "fix.html">fix</A> command
+<LI>field/grid = style name of this fix command
+<LI>axvar,ayvar,azvar = names of grid-style variables for acceleration components 
+</UL>
 <P><B>Examples:</B>
 </P>
 <PRE>fix 1 field/grid gradBx gradBy NULL 

--- a/doc/fix_field_grid.txt
+++ b/doc/fix_field_grid.txt
@@ -14,7 +14,7 @@ fix ID field/grid axvar ayvar azvar :pre
 
 ID is documented in "fix"_fix.html command
 field/grid = style name of this fix command
-axvar,ayvar,azvar = names of grid-style variables for acceleration components:ul
+axvar,ayvar,azvar = names of grid-style variables for acceleration components :ul
 
 [Examples:]
 


### PR DESCRIPTION
## Purpose

Fix a couple of formatting and TOC issues with doc pages.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


