### PR TITLE
Fix a compiler warning

### DIFF
--- a/src/create_isurf.cpp
+++ b/src/create_isurf.cpp
@@ -260,10 +260,8 @@ void CreateISurf::set_corners()
   MPI_Allreduce(&ofull,&allofull,1,MPI_INT,MPI_SUM,world);
   if (allofull) {
     char str[128];
-    sprintf(str,
-            "Create_isurf could not determine whether some corner \
-             values are inside or outside with respect to the surface",
-            allofull);
+    sprintf(str,"Create_isurf could not determine whether %d corner \
+             values are inside or outside surface",allofull);
     error->all(FLERR,str);
   }
 


### PR DESCRIPTION
## Purpose

An error message in the create_isurf command was not using an integer value calculated for output with the message.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


