### PR TITLE
Use parallel_for instead of parallel_reduce for performance with Kokk…

### DIFF
--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -613,7 +613,7 @@ template < int DIM, int SURF, int REACT, int OPT > void UpdateKokkos::move()
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,1> >(pstart,pstop),*this);
 #elif defined KOKKOS_ENABLE_SERIAL
       if constexpr(std::is_same<DeviceType,Kokkos::Serial>::value)
-        Kokkos::parallel_reduce(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,0> >(pstart,pstop),*this,reduce);
+        Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,0> >(pstart,pstop),*this);
       else {
         if (!sparta->kokkos->need_atomics)
           Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagUpdateMove<DIM,SURF,REACT,OPT,0> >(pstart,pstop),*this);
@@ -954,12 +954,12 @@ void UpdateKokkos::operator()(TagUpdateMove<DIM,SURF,REACT,OPT,ATOMIC_REDUCTION>
 
           particle_i.flag = PDONE;
 
-	  if (ATOMIC_REDUCTION == 1)
-	    Kokkos::atomic_increment(&d_ncomm_one());
-	  else if (ATOMIC_REDUCTION == 0)
-	    d_ncomm_one()++;
-	  else
-	    reduce.ncomm_one++;
+          if (ATOMIC_REDUCTION == 1)
+            Kokkos::atomic_increment(&d_ncomm_one());
+          else if (ATOMIC_REDUCTION == 0)
+            d_ncomm_one()++;
+          else
+            reduce.ncomm_one++;
         }
 
         return;


### PR DESCRIPTION
…os Serial backend

## Purpose

Change a `parallel_reduce` that should have been a `parallel_for` which could be hurting performance (no correctness issues in either case).

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes