### PR TITLE
Fix bug in restart when using `global mem/limit`

### DIFF
--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -586,11 +586,13 @@ void ReadRestart::header(int incompatible)
       int value = read_int();
       if (!mem_limit_flag) update->mem_limit_grid_flag = value;
       if (!mem_limit_file) mem_limit_file = value;
+      mem_limit_flag = update->have_mem_limit();
     } else if (flag == MEMLIMIT) {
       // ignore value if already set
       int value = read_int();
       if (!mem_limit_flag) update->global_mem_limit = value;
       if (!mem_limit_file) mem_limit_file = value;
+      mem_limit_flag = update->have_mem_limit();
     } else if (flag == NPARTICLE) {
       nparticle_file = read_bigint();
     } else if (flag == NUNSPLIT) {

--- a/src/read_restart.cpp
+++ b/src/read_restart.cpp
@@ -67,8 +67,8 @@ void ReadRestart::command(int narg, char **arg)
   if (domain->box_exist)
     error->all(FLERR,"Cannot read_restart after simulation box is defined");
 
-  mem_limit_flag = update->global_mem_limit > 0 ||
-       (update->mem_limit_grid_flag && !grid->nlocal);
+  mem_limit_flag = update->have_mem_limit();
+  mem_limit_file = 0;
 
   MPI_Comm_rank(world,&me);
   MPI_Comm_size(world,&nprocs);
@@ -583,12 +583,14 @@ void ReadRestart::header(int incompatible)
       update->reorder_period = read_int();
     } else if (flag == MEMLIMIT_GRID) {
       // ignore value if already set
-      if (mem_limit_flag) read_int();
-      else update->mem_limit_grid_flag = read_int();
+      int value = read_int();
+      if (!mem_limit_flag) update->mem_limit_grid_flag = value;
+      if (!mem_limit_file) mem_limit_file = value;
     } else if (flag == MEMLIMIT) {
       // ignore value if already set
-      if (mem_limit_flag) read_int();
-      else update->global_mem_limit = read_int();
+      int value = read_int();
+      if (!mem_limit_flag) update->global_mem_limit = value;
+      if (!mem_limit_file) mem_limit_file = value;
     } else if (flag == NPARTICLE) {
       nparticle_file = read_bigint();
     } else if (flag == NUNSPLIT) {
@@ -1106,7 +1108,13 @@ void ReadRestart::read_gp_multi_file_less_procs_memlimit(char *file)
       if (flag != PERPROC_GRID)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
 
-      tmp = fread(&n_big,sizeof(bigint),1,fp);
+      if (mem_limit_file) {
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
+      } else {
+        int n;
+        tmp = fread(&n,sizeof(int),1,fp);
+	n_big = n;
+      }
 
       int grid_nlocal;
       tmp = fread(&grid_nlocal,sizeof(int),1,fp);
@@ -1260,7 +1268,13 @@ void ReadRestart::read_gp_multi_file_more_procs_memlimit(char *file)
       if (flag != PERPROC_GRID)
         error->one(FLERR,"Invalid flag in peratom section of restart file");
 
-      tmp = fread(&n_big,sizeof(bigint),1,fp);
+      if (mem_limit_file) {
+        tmp = fread(&n_big,sizeof(bigint),1,fp);
+      } else {
+        int n;
+        tmp = fread(&n,sizeof(int),1,fp);
+        n_big = n;
+      }
 
       int grid_nlocal;
       tmp = fread(&grid_nlocal,sizeof(int),1,fp);

--- a/src/read_restart.h
+++ b/src/read_restart.h
@@ -33,7 +33,8 @@ class ReadRestart : protected Pointers {
   void command(int, char **);
 
  private:
-  int me,nprocs,nprocs_file,multiproc_file,mem_limit_flag;
+  int me,nprocs,nprocs_file,multiproc_file;
+  int mem_limit_flag,mem_limit_file;
   int nfix_restart_global,nfix_restart_peratom;
   FILE *fp;
 

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -402,7 +402,7 @@ void WriteRestart::write_less_memory(char *file)
   }
 
   // proc 0 writes header info
-  // also simulation box, particle species, parent grid cells, surf info
+  // also simulation box, particle species, grid params, surf info
 
   bigint btmp = particle->nlocal;
   MPI_Allreduce(&btmp,&particle->nglobal,1,MPI_SPARTA_BIGINT,MPI_SUM,world);
@@ -447,7 +447,8 @@ void WriteRestart::write_less_memory(char *file)
 
   // header info is complete
   // if multiproc output:
-  //   close header file, open multiname file on each writing proc,
+  //   close header file
+  //   open new multiname file on each writing proc
   //   write PROCSPERFILE into new file
 
   if (multiproc) {
@@ -531,7 +532,6 @@ void WriteRestart::write_less_memory(char *file)
           write_char_vec(recv_size,buf);
       }
     }
-    fclose(fp);
 
   } else {
     bigint total_write_part = 0;

--- a/src/write_restart.cpp
+++ b/src/write_restart.cpp
@@ -85,8 +85,7 @@ void WriteRestart::command(int narg, char **arg)
   if (strchr(arg[0],'%')) multiproc = nprocs;
   else multiproc = 0;
 
-  int mem_limit_flag = update->global_mem_limit > 0 ||
-           (update->mem_limit_grid_flag && !grid->nlocal);
+  int mem_limit_flag = update->have_mem_limit();
   if (mem_limit_flag && !multiproc)
     error->all(FLERR,"Cannot (yet) use global mem/limit without "
                "% in restart file name");
@@ -186,10 +185,7 @@ void WriteRestart::multiproc_options(int multiproc_caller,
 
 void WriteRestart::write(char *file)
 {
-  if (update->mem_limit_grid_flag)
-    update->set_mem_limit_grid();
-  if (update->global_mem_limit > 0 ||
-      (update->mem_limit_grid_flag && !grid->nlocal))
+  if (update->have_mem_limit())
     return write_less_memory(file);
 
   // open single restart file or base file for multiproc case


### PR DESCRIPTION
## Purpose

Fix bug in restart when using `global mem/limit`. This was caused by #428 which changed a 64-bit integer to a 32-bit integer for non-memory-limited restart files. The read restart code now takes this into account.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes