### PR TITLE
Add custom per-surf options to fix emit/surf

### DIFF
--- a/doc/fix_emit_surf.html
+++ b/doc/fix_emit_surf.html
@@ -37,7 +37,7 @@
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
   <I>custom</I> values = attribute s_name
-    attribute = <I>nrho</I> or <I>vstream</I> or <I>speed</I> or <I>temp</I>
+    attribute = <I>nrho</I> or <I>vstream</I> or <I>speed</I> or <I>temp</I> or <I>fractions</I>
     s_name = custom per-surf vector or array with name 
 </PRE>
 
@@ -266,27 +266,48 @@ custom per-surf attributes.
 <UL><LI>nrho = number density = per-surf vector
 <LI>vstream = 3-component streaming velocity = per-surf array with 3 columns
 <LI>speed = length of streaming velocity vector in normal direction = per-surf vector
-<LI>temp = temperature = per-surf vector 
+<LI>temp = temperature = per-surf vector
+<LI>fractions = species fractions = per-surf array 
 </UL>
 <P>The <I>s_name</I> value of the <I>custom</I> keyword is the name of the custom
 per-surf vector or array.  It must store floating-point values and be
-a vector or 3-column array, as indicated in the list above.
+a vector or array, as indicated in the list above.
 </P>
 <P>When the fix emit/surf command calculates the number of particles (and
 their attributes) to be emitted from each surface element, by default
 it uses the mixture properties of the specified <I>mix-ID</I> for number
-density, streaming velocity, and temperature, i.e. the same values for
-all surface elements.  If the <I>custom</I> keyword is used for one or more
-of these properties, the values of the associated custom per-surf
-vector(s) or array(s) override the default mixture properties.
+density, streaming velocity, temperature, and relative species
+fractions.  The same values are used for all surface elements.  If the
+<I>custom</I> keyword is used for one or more of these properties, the
+values of the associated custom per-surf vector(s) or array(s)
+override the default mixture properties.
 </P>
-<P>Note that <I>custom</I> attribute <I>vstream</I> can only be used if the
-<I>normal</I> keyword is set to <I>no</I>, which is the default.  The <I>custom</I>
-attribute <I>speed</I> should be used instead if the <I>normal</I> keyword is
-set to <I>yes</I>.  In this case the custom per-surf vector should store
-the "speed" of the emission in the direction normal to each surface
-element.  I.e. the length of the streaming velocity vector, as
-described above for the <I>normal</I> keyword.
+<P>The <I>custom</I> attribute <I>vstream</I> can only be used if the <I>normal</I>
+keyword is set to <I>no</I>, which is the default.  In this case it must
+refer to a 3-column per-surf custom array which stores the 3 streaming
+velocity components for each surface element.  If the <I>normal</I> keyword
+is set to <I>yes</I>, then the <I>custom</I> atrribute <I>speed</I> should be used
+instead.  It must refer to a custom per-surf vector which stores the
+"speed" of the emission in the direction normal to each surface
+element.  I.e. it is the scalar length of the streaming velocity
+vector, as described above for the <I>normal</I> keyword.
+</P>
+<P>The <I>custom</I> attribute <I>fractions</I> must refer to a per-surf custom
+array with N columns, where N is the number of species in the mixture.
+For each surface element, the N values will be used to set the
+relative fractions of emitted particles for that element, using the
+logic for the <I>perspecies yes/no</I> keyword described above.
+</P>
+<P>For each surface element, the N per-species fractional values must sum
+to 1.0.  However, one or more of the numeric values can be < zero, say
+M of them.  In this case, each of the M values will be reset to (1 -
+sum)/M, where sum is the sum of the N-M values which are >= zero.
+</P>
+<P>Note that the order of species within the N columns of the custom
+per-surf array, if the same as the order of species within the mix-ID
+mixture.  This is determined by the <A HREF = "mixture.html">mixture</A> command.
+It is the order the gas species names were listed when the mixture
+command was specified (one or more times).
 </P>
 <HR>
 

--- a/doc/fix_emit_surf.html
+++ b/doc/fix_emit_surf.html
@@ -251,6 +251,8 @@ were exiting the simulation domain.  That is necessary to produce the
 correct subsonic conditions that the particle insertions due to this
 command are trying to achieve.
 </P>
+<HR>
+
 <P>The <I>custom</I> keyword can be used to tailor the emission of particles
 from individual surface elements.  This is done by using custom
 per-surf vectors or arrays defined by other commands.  E.g. the
@@ -261,13 +263,17 @@ initialization by use of <A HREF = "variable.html">surf-style variables</A>.  Se
 <A HREF = "Section_howto.html#howto_17">Section Howto 6.17</A> for a discussion of
 custom per-surf attributes.
 </P>
-<P>The <I>attribute</I> value of the <I>custom</I> keyword can be any of the following:
+<P>IMPORTANT NOTE: The <I>custom</I> keyword cannot be used together with
+either the <I>n</I> or <I>subsonic</I> keywords.
 </P>
-<UL><LI>nrho = number density = per-surf vector
-<LI>vstream = 3-component streaming velocity = per-surf array with 3 columns
-<LI>speed = length of streaming velocity vector in normal direction = per-surf vector
-<LI>temp = temperature = per-surf vector
-<LI>fractions = species fractions = per-surf array 
+<P>The <I>attribute</I> value of the <I>custom</I> keyword can be any of the
+following:
+</P>
+<UL><LI>nrho = number density (# per length^3 units) = per-surf vector
+<LI>vstream = 3-component streaming velocity (velocity units) = per-surf array with 3 columns
+<LI>speed = length of streaming velocity vector in normal direction (velocity units) = per-surf vector
+<LI>temp = temperature (temperature units) = per-surf vector
+<LI>fractions = species fractions (unitless) = per-surf array 
 </UL>
 <P>The <I>s_name</I> value of the <I>custom</I> keyword is the name of the custom
 per-surf vector or array.  It must store floating-point values and be
@@ -291,6 +297,11 @@ instead.  It must refer to a custom per-surf vector which stores the
 "speed" of the emission in the direction normal to each surface
 element.  I.e. it is the scalar length of the streaming velocity
 vector, as described above for the <I>normal</I> keyword.
+</P>
+<P>The <I>custom</I> attribute <I>temp</I> sets a temperature for each surface
+element.  This temperature is used as the thermal temeperature for
+each inserted particle which means it affects its thermal velocity
+components as well as its rotational and vibrational energies.
 </P>
 <P>The <I>custom</I> attribute <I>fractions</I> must refer to a per-surf custom
 array with N columns, where N is the number of species in the mixture.

--- a/doc/fix_emit_surf.html
+++ b/doc/fix_emit_surf.html
@@ -25,7 +25,7 @@
 
 <LI>zero or more keyword/value pairs may be appended 
 
-<LI>keyword = <I>n</I> or <I>normal</I> or <I>nevery</I> or <I>perspecies</I> or <I>region</I> or <I>subsonic</I> 
+<LI>keyword = <I>n</I> or <I>normal</I> or <I>nevery</I> or <I>perspecies</I> or <I>region</I> or <I>subsonic</I> or <I>custom</I> 
 
 <PRE>  <I>n</I> value = Np = number of particles to create
                    Np can be a variable (see below)
@@ -35,7 +35,10 @@
   <I>region</I> value = region-ID
   <I>subsonic</I> values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
-    Tsub = temperature setting at inflow boundary, can be NULL (temperature units) 
+    Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
+  <I>custom</I> values = attribute s_name
+    attribute = <I>nrho</I> or <I>vstream</I> or <I>speed</I> or <I>temp</I>
+    s_name = custom per-surf vector or array with name 
 </PRE>
 
 </UL>
@@ -46,11 +49,17 @@ fix in emit/face mymix myPatch region circle normal yes
 fix in emit/surf air all subsonic 0.1 300
 fix in emit/surf air all subsonic 0.05 NULL 
 </PRE>
+<PRE>read_surf sdata.circle custom myrho float 0 custom mystream float 3
+fix in emit/surf air all custom nrho s_myrho custom vstream s_mystream 
+</PRE>
 <P><B>Description:</B>
 </P>
 <P>Emit particles from a group of surface elements, continuously during a
 simulation.  If invoked every timestep, this fix creates a continuous
-outflux of particles from the surface elements in the group.
+outflux of particles from the surface elements in the group.  This
+command can only be used with explicit surfaces, not implicit.  See
+<A HREF = "Section_howto.html#howto_13">Section Howto 6.13</A> for a discussion of
+explicit and implicit surface elements.
 </P>
 <P>The properties of the added particles are determined by the mixture
 with ID <I>mix-ID</I>.  This sets the number and species of added
@@ -72,11 +81,9 @@ given by equation 4.22 of <A HREF = "#Bird94">(Bird94)</A>.  The number of parti
 within a grid cell is based on this flux and additional global, flow,
 and surface element properties:
 </P>
-<UL><LI>global property: <I>fnum</I> ratio as specified by the
-<LI><A HREF = "global.html"">global</A> command flow properties: number density,
-<LI>streaming velocity, and thermal temperature surface element
-<LI>properties: portion of surface element area that overlaps with the
-<LI>grid cell and its orientation relative to the streaming velocity 
+<UL><LI>global property: <I>fnum</I> ratio as specified by the <A HREF = "global.html"">global</A> command flow
+<LI>properties: number density, streaming velocity, and thermal temperature
+<LI>surface element properties: portion of surface element area that overlaps with the grid cell and its orientation relative to the streaming velocity 
 </UL>
 <P>The flow properties are defined for the specified mixture via the
 <A HREF = "mixture.html">mixture</A> command.
@@ -243,6 +250,43 @@ commands, so that particles hitting the surface disappear as if they
 were exiting the simulation domain.  That is necessary to produce the
 correct subsonic conditions that the particle insertions due to this
 command are trying to achieve.
+</P>
+<P>The <I>custom</I> keyword can be used to tailor the emission of particles
+from individual surface elements.  This is done by using custom
+per-surf vectors or arrays defined by other commands.  E.g. the
+<A HREF = "read_surf.html">read_surf</A> command which can read per-surf attributes
+included in the surface data file.  Or the custom command which allows
+for definition of custom per-surf vectors or arrays and their
+initialization by use of <A HREF = "variable.html">surf-style variables</A>.  See
+<A HREF = "Section_howto.html#howto_17">Section Howto 6.17</A> for a discussion of
+custom per-surf attributes.
+</P>
+<P>The <I>attribute</I> value of the <I>custom</I> keyword can be any of the following:
+</P>
+<UL><LI>nrho = number density = per-surf vector
+<LI>vstream = 3-component streaming velocity = per-surf array with 3 columns
+<LI>speed = length of streaming velocity vector in normal direction = per-surf vector
+<LI>temp = temperature = per-surf vector 
+</UL>
+<P>The <I>s_name</I> value of the <I>custom</I> keyword is the name of the custom
+per-surf vector or array.  It must store floating-point values and be
+a vector or 3-column array, as indicated in the list above.
+</P>
+<P>When the fix emit/surf command calculates the number of particles (and
+their attributes) to be emitted from each surface element, by default
+it uses the mixture properties of the specified <I>mix-ID</I> for number
+density, streaming velocity, and temperature, i.e. the same values for
+all surface elements.  If the <I>custom</I> keyword is used for one or more
+of these properties, the values of the associated custom per-surf
+vector(s) or array(s) override the default mixture properties.
+</P>
+<P>Note that <I>custom</I> attribute <I>vstream</I> can only be used if the
+<I>normal</I> keyword is set to <I>no</I>, which is the default.  The <I>custom</I>
+attribute <I>speed</I> should be used instead if the <I>normal</I> keyword is
+set to <I>yes</I>.  In this case the custom per-surf vector should store
+the "speed" of the emission in the direction normal to each surface
+element.  I.e. the length of the streaming velocity vector, as
+described above for the <I>normal</I> keyword.
 </P>
 <HR>
 

--- a/doc/fix_emit_surf.txt
+++ b/doc/fix_emit_surf.txt
@@ -28,9 +28,8 @@ keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} 
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
   {custom} values = attribute s_name
-    attribute = {nrho} or {vstream} or {speed} or {temp}
+    attribute = {nrho} or {vstream} or {speed} or {temp} or {fractions}
     s_name = custom per-surf vector or array with name :pre
-  
 :ule
 
 [Examples:]
@@ -257,27 +256,48 @@ The {attribute} value of the {custom} keyword can be any of the following:
 nrho = number density = per-surf vector
 vstream = 3-component streaming velocity = per-surf array with 3 columns
 speed = length of streaming velocity vector in normal direction = per-surf vector
-temp = temperature = per-surf vector :ul
+temp = temperature = per-surf vector
+fractions = species fractions = per-surf array :ul
 
 The {s_name} value of the {custom} keyword is the name of the custom
 per-surf vector or array.  It must store floating-point values and be
-a vector or 3-column array, as indicated in the list above.
+a vector or array, as indicated in the list above.
 
 When the fix emit/surf command calculates the number of particles (and
 their attributes) to be emitted from each surface element, by default
 it uses the mixture properties of the specified {mix-ID} for number
-density, streaming velocity, and temperature, i.e. the same values for
-all surface elements.  If the {custom} keyword is used for one or more
-of these properties, the values of the associated custom per-surf
-vector(s) or array(s) override the default mixture properties.
+density, streaming velocity, temperature, and relative species
+fractions.  The same values are used for all surface elements.  If the
+{custom} keyword is used for one or more of these properties, the
+values of the associated custom per-surf vector(s) or array(s)
+override the default mixture properties.
 
-Note that {custom} attribute {vstream} can only be used if the
-{normal} keyword is set to {no}, which is the default.  The {custom}
-attribute {speed} should be used instead if the {normal} keyword is
-set to {yes}.  In this case the custom per-surf vector should store
-the "speed" of the emission in the direction normal to each surface
-element.  I.e. the length of the streaming velocity vector, as
-described above for the {normal} keyword.
+The {custom} attribute {vstream} can only be used if the {normal}
+keyword is set to {no}, which is the default.  In this case it must
+refer to a 3-column per-surf custom array which stores the 3 streaming
+velocity components for each surface element.  If the {normal} keyword
+is set to {yes}, then the {custom} atrribute {speed} should be used
+instead.  It must refer to a custom per-surf vector which stores the
+"speed" of the emission in the direction normal to each surface
+element.  I.e. it is the scalar length of the streaming velocity
+vector, as described above for the {normal} keyword.
+
+The {custom} attribute {fractions} must refer to a per-surf custom
+array with N columns, where N is the number of species in the mixture.
+For each surface element, the N values will be used to set the
+relative fractions of emitted particles for that element, using the
+logic for the {perspecies yes/no} keyword described above.
+
+For each surface element, the N per-species fractional values must sum
+to 1.0.  However, one or more of the numeric values can be < zero, say
+M of them.  In this case, each of the M values will be reset to (1 -
+sum)/M, where sum is the sum of the N-M values which are >= zero.
+
+Note that the order of species within the N columns of the custom
+per-surf array, if the same as the order of species within the mix-ID
+mixture.  This is determined by the "mixture"_mixture.html command.
+It is the order the gas species names were listed when the mixture
+command was specified (one or more times).
 
 :line
 

--- a/doc/fix_emit_surf.txt
+++ b/doc/fix_emit_surf.txt
@@ -241,6 +241,8 @@ were exiting the simulation domain.  That is necessary to produce the
 correct subsonic conditions that the particle insertions due to this
 command are trying to achieve.
 
+:line
+
 The {custom} keyword can be used to tailor the emission of particles
 from individual surface elements.  This is done by using custom
 per-surf vectors or arrays defined by other commands.  E.g. the
@@ -251,13 +253,17 @@ initialization by use of "surf-style variables"_variable.html.  See
 "Section Howto 6.17"_Section_howto.html#howto_17 for a discussion of
 custom per-surf attributes.
 
-The {attribute} value of the {custom} keyword can be any of the following:
+IMPORTANT NOTE: The {custom} keyword cannot be used together with
+either the {n} or {subsonic} keywords.
 
-nrho = number density = per-surf vector
-vstream = 3-component streaming velocity = per-surf array with 3 columns
-speed = length of streaming velocity vector in normal direction = per-surf vector
-temp = temperature = per-surf vector
-fractions = species fractions = per-surf array :ul
+The {attribute} value of the {custom} keyword can be any of the
+following:
+
+nrho = number density (# per length^3 units) = per-surf vector
+vstream = 3-component streaming velocity (velocity units) = per-surf array with 3 columns
+speed = length of streaming velocity vector in normal direction (velocity units) = per-surf vector
+temp = temperature (temperature units) = per-surf vector
+fractions = species fractions (unitless) = per-surf array :ul
 
 The {s_name} value of the {custom} keyword is the name of the custom
 per-surf vector or array.  It must store floating-point values and be
@@ -281,6 +287,11 @@ instead.  It must refer to a custom per-surf vector which stores the
 "speed" of the emission in the direction normal to each surface
 element.  I.e. it is the scalar length of the streaming velocity
 vector, as described above for the {normal} keyword.
+
+The {custom} attribute {temp} sets a temperature for each surface
+element.  This temperature is used as the thermal temeperature for
+each inserted particle which means it affects its thermal velocity
+components as well as its rotational and vibrational energies.
 
 The {custom} attribute {fractions} must refer to a per-surf custom
 array with N columns, where N is the number of species in the mixture.

--- a/doc/fix_emit_surf.txt
+++ b/doc/fix_emit_surf.txt
@@ -17,7 +17,7 @@ emit/surf = style name of this fix command :l
 mix-ID = ID of mixture to use when creating particles :l
 group-ID = ID of surface group that emits particles :l
 zero or more keyword/value pairs may be appended :l
-keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} :l
+keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} or {custom} :l
   {n} value = Np = number of particles to create
                    Np can be a variable (see below)
   {normal} value = yes or no = emit normal to surface elements or with streaming velocity
@@ -26,8 +26,11 @@ keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} 
   {region} value = region-ID
   {subsonic} values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
-    Tsub = temperature setting at inflow boundary, can be NULL (temperature units) :pre
-
+    Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
+  {custom} values = attribute s_name
+    attribute = {nrho} or {vstream} or {speed} or {temp}
+    s_name = custom per-surf vector or array with name :pre
+  
 :ule
 
 [Examples:]
@@ -37,11 +40,17 @@ fix in emit/face mymix myPatch region circle normal yes
 fix in emit/surf air all subsonic 0.1 300
 fix in emit/surf air all subsonic 0.05 NULL :pre
 
+read_surf sdata.circle custom myrho float 0 custom mystream float 3
+fix in emit/surf air all custom nrho s_myrho custom vstream s_mystream :pre
+
 [Description:]
 
 Emit particles from a group of surface elements, continuously during a
 simulation.  If invoked every timestep, this fix creates a continuous
-outflux of particles from the surface elements in the group.
+outflux of particles from the surface elements in the group.  This
+command can only be used with explicit surfaces, not implicit.  See
+"Section Howto 6.13"_Section_howto.html#howto_13 for a discussion of
+explicit and implicit surface elements.
 
 The properties of the added particles are determined by the mixture
 with ID {mix-ID}.  This sets the number and species of added
@@ -63,11 +72,9 @@ given by equation 4.22 of "(Bird94)"_#Bird94.  The number of particles
 within a grid cell is based on this flux and additional global, flow,
 and surface element properties:
 
-global property: {fnum} ratio as specified by the
-"global"_global.html" command flow properties: number density,
-streaming velocity, and thermal temperature surface element
-properties: portion of surface element area that overlaps with the
-grid cell and its orientation relative to the streaming velocity :ul
+global property: {fnum} ratio as specified by the "global"_global.html" command flow
+properties: number density, streaming velocity, and thermal temperature
+surface element properties: portion of surface element area that overlaps with the grid cell and its orientation relative to the streaming velocity :ul
 
 The flow properties are defined for the specified mixture via the
 "mixture"_mixture.html command.
@@ -234,6 +241,43 @@ commands, so that particles hitting the surface disappear as if they
 were exiting the simulation domain.  That is necessary to produce the
 correct subsonic conditions that the particle insertions due to this
 command are trying to achieve.
+
+The {custom} keyword can be used to tailor the emission of particles
+from individual surface elements.  This is done by using custom
+per-surf vectors or arrays defined by other commands.  E.g. the
+"read_surf"_read_surf.html command which can read per-surf attributes
+included in the surface data file.  Or the custom command which allows
+for definition of custom per-surf vectors or arrays and their
+initialization by use of "surf-style variables"_variable.html.  See
+"Section Howto 6.17"_Section_howto.html#howto_17 for a discussion of
+custom per-surf attributes.
+
+The {attribute} value of the {custom} keyword can be any of the following:
+
+nrho = number density = per-surf vector
+vstream = 3-component streaming velocity = per-surf array with 3 columns
+speed = length of streaming velocity vector in normal direction = per-surf vector
+temp = temperature = per-surf vector :ul
+
+The {s_name} value of the {custom} keyword is the name of the custom
+per-surf vector or array.  It must store floating-point values and be
+a vector or 3-column array, as indicated in the list above.
+
+When the fix emit/surf command calculates the number of particles (and
+their attributes) to be emitted from each surface element, by default
+it uses the mixture properties of the specified {mix-ID} for number
+density, streaming velocity, and temperature, i.e. the same values for
+all surface elements.  If the {custom} keyword is used for one or more
+of these properties, the values of the associated custom per-surf
+vector(s) or array(s) override the default mixture properties.
+
+Note that {custom} attribute {vstream} can only be used if the
+{normal} keyword is set to {no}, which is the default.  The {custom}
+attribute {speed} should be used instead if the {normal} keyword is
+set to {yes}.  In this case the custom per-surf vector should store
+the "speed" of the emission in the direction normal to each surface
+element.  I.e. the length of the streaming velocity vector, as
+described above for the {normal} keyword.
 
 :line
 

--- a/doc/read_surf.html
+++ b/doc/read_surf.html
@@ -62,7 +62,7 @@
 <P><B>Examples:</B>
 </P>
 <PRE>read_surf surf.sphere
-read_surf surf.sphere type custom temperature double 0
+read_surf surf.sphere type custom temperature float 0
 read_surf surf.sphere group sphere2 typeadd 1
 read_surf surf.file trans 10 5 0 scale 3 3 3 invert clip
 read_surf surf.file trans 10 5 0 scale 3 3 3 invert clip 1.0e-6

--- a/doc/read_surf.txt
+++ b/doc/read_surf.txt
@@ -55,7 +55,7 @@ keyword = {type} or {custom} or {origin} or {trans} or {atrans} or
 [Examples:]
 
 read_surf surf.sphere
-read_surf surf.sphere type custom temperature double 0
+read_surf surf.sphere type custom temperature float 0
 read_surf surf.sphere group sphere2 typeadd 1
 read_surf surf.file trans 10 5 0 scale 3 3 3 invert clip
 read_surf surf.file trans 10 5 0 scale 3 3 3 invert clip 1.0e-6

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -407,11 +407,6 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
   else grid->find_neighbors();
   comm->reset_neighbors();
 
-  // if not before first run,
-  // notify all classes that store per-grid data that grid may have changed
-
-  if (update->first_update) grid->notify_changed();
-
   // if explicit distributed surfs
   // set redistribute timestep and clear custom status flags
 
@@ -420,6 +415,12 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
     for (int i = 0; i < surf->ncustom; i++)
       surf->estatus[i] = 0;
   }
+
+  // if not before first run:
+  // notify all classes that store per-grid data that grid may have changed
+  // do this after clearing custom status flags in case classes use that info
+
+  if (update->first_update) grid->notify_changed();
 
   MPI_Barrier(world);
   double time5 = MPI_Wtime();

--- a/src/create_isurf.cpp
+++ b/src/create_isurf.cpp
@@ -168,7 +168,7 @@ void CreateISurf::command(int narg, char **arg)
   // store corner point values in fix ablate instance
   // this call will also create implicit surfs
   // set pushflag = 0 so averaging option is not overridden
-  
+
   tvalues = NULL;
   int pushflag = 0;
   char *sgroupID = arg[0];
@@ -294,7 +294,7 @@ void CreateISurf::surface_edge2d()
   int isurf, nsurf, side, hitflag;
   double param, oparam;
 
-  // initialize param to avoid error 
+  // initialize param to avoid error
 
   param = 0.0;
 
@@ -440,7 +440,7 @@ void CreateISurf::surface_edge3d()
   int isurf, nsurf, hitflag, side;
   double param, oparam;
 
-  // initialize param to avoid error 
+  // initialize param to avoid error
 
   param = 0.0;
 
@@ -648,18 +648,18 @@ void CreateISurf::sync(int which)
                     if (dtotal[jadj] < 0) dtotal[jadj] = dtemp;
                     else dtotal[jadj] = MIN(dtotal[jadj],dtemp);
                   }
-                } 
+                }
               } else if (which == CVAL) {
-                dtotal[0] = 
+                dtotal[0] =
                   MAX(dtotal[0],cvalues[jcell][jcorner]);
               }
             } else {
               if (which == SVAL) {
                 if (sghost[jcell-nglocal][jcorner] < 2)
-                  dtotal[0] = 
+                  dtotal[0] =
                     MAX(dtotal[0],
                     static_cast<double>(sghost[jcell-nglocal][jcorner]));
-              } else if (which == IVAL) { 
+              } else if (which == IVAL) {
                 for (jadj = 0; jadj < nadj; jadj++) {
                   double dtemp = ighost[jcell-nglocal][jcorner][jadj];
                   if (dtemp>=0) {
@@ -686,7 +686,7 @@ void CreateISurf::sync(int which)
 }
 
 /* ----------------------------------------------------------------------
-   communicate my side, intersection, or corner values that are shared by 
+   communicate my side, intersection, or corner values that are shared by
    neighbor cells each corner point is shared by N cells, less on borders
    done via irregular comm
 
@@ -834,7 +834,7 @@ void CreateISurf::comm_neigh_corners(int which)
     icell = ilocal - nglocal;
 
     if (which == SVAL) {
-      for (j = 0; j < ncorner; j++) 
+      for (j = 0; j < ncorner; j++)
         sghost[icell][j] = static_cast<int> (rbuf[m++]);
     } else if (which == IVAL) {
       for (j = 0; j < ncorner; j++)
@@ -971,7 +971,7 @@ int CreateISurf::find_side_2d()
 
       for (int i = 0; i < ncorner; i++) {
         if (svalues[icell][i] == 0 || svalues[icell][i] == 1) continue;
-        
+
         ixfirst = (i % 2) - 1;
         iyfirst = (i/2 % 2) - 1;
 
@@ -1121,7 +1121,7 @@ int CreateISurf::find_side_3d()
 
       for (int i = 0; i < ncorner; i++) {
         if (svalues[icell][i] > -1 && svalues[icell][i] < 2) continue;
-        
+
         ixfirst = (i % 2) - 1;
         iyfirst = (i/2 % 2) - 1;
         izfirst = (i / 4) - 1;
@@ -1464,25 +1464,25 @@ int CreateISurf::corner_hit3d(double *p1, double *p2,
 
   double dx[26], dy[26], dz[26];
   double dp = mind/1000.0;
-  dx[0] = dx[2] = dx[3] = dx[4] = 
+  dx[0] = dx[2] = dx[3] = dx[4] =
     dx[15] = dx[16] = dx[18] = dx[23] = dx[24] = dp;
-  dx[7] = dx[9] = dx[10] = dx[11] = 
+  dx[7] = dx[9] = dx[10] = dx[11] =
     dx[14] = dx[17] = dx[19] = dx[22] = dx[25] = -dp;
-  dx[1] = dx[5] = dx[6] = dx[8] = 
+  dx[1] = dx[5] = dx[6] = dx[8] =
     dx[12] = dx[13] = dx[20] = dx[21] = 0;
 
-  dy[0] = dy[1] = dy[3] = dy[5] = 
+  dy[0] = dy[1] = dy[3] = dy[5] =
     dy[14] = dy[16] = dy[19] = dy[21] = dy[25] = dp;
-  dy[7] = dy[8] = dy[10] = dy[12] = 
+  dy[7] = dy[8] = dy[10] = dy[12] =
     dy[15] = dy[17] = dy[18] = dy[20] = dy[24] = -dp;
-  dy[2] = dy[4] = dy[6] = dy[9] = 
+  dy[2] = dy[4] = dy[6] = dy[9] =
     dy[11] = dy[13] = dy[22] = dy[23] = 0;
 
-  dz[0] = dz[1] = dz[2] = dz[6] = 
+  dz[0] = dz[1] = dz[2] = dz[6] =
     dz[14] = dz[15] = dz[17] = dz[20] = dz[22] = dp;
-  dz[7] = dz[8] = dz[9] = dz[13] = 
+  dz[7] = dz[8] = dz[9] = dz[13] =
     dz[16] = dz[18] = dz[19] = dz[21] = dz[23] = -dp;
-  dz[3] = dz[4] = dz[5] = dz[10] = 
+  dz[3] = dz[4] = dz[5] = dz[10] =
     dz[11] = dz[12] = dz[24] = dz[25] = 0;
 
   for (int i = 0; i < 26; i++) {
@@ -1493,7 +1493,7 @@ int CreateISurf::corner_hit3d(double *p1, double *p2,
     p2p[0] = p2[0] + dx[i];
     p2p[1] = p2[1] + dy[i];
     p2p[2] = p2[2] + dz[i];
- 
+
     h = Geometry::line_tri_intersect(p1p,p2p,tri->p1,tri->p2,tri->p3,
         tri->norm,d3dum,tparam,tside);
     if (h) {
@@ -1525,7 +1525,7 @@ double CreateISurf::param2in(double param, double v1)
 {
   double v0;
 
-  // param is proportional to cell length so 
+  // param is proportional to cell length so
   // ... lo = 0; hi = 1
   // trying to find v0
   // param = (thresh  - v0) / (v1 - v0)

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -824,7 +824,7 @@ void DumpSurf::pack_custom(int n)
       }
     }
   } else {
-    if (surf->esize[index] == INT) {
+    if (surf->esize[index] == 0) {
       double *vector = surf->edvec[surf->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
         buf[n] = vector[clocal[i]];

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -301,10 +301,6 @@ void FixBalance::end_of_step()
   grid->reset_neighbors();
   comm->reset_neighbors();
 
-  // notify all classes that store per-grid data that grid may have changed
-
-  grid->notify_changed();
-
   // if explicit distributed surfs
   // set redistribute timestep and clear custom status flags
 
@@ -313,6 +309,11 @@ void FixBalance::end_of_step()
     for (int i = 0; i < surf->ncustom; i++)
       surf->estatus[i] = 0;
   }
+
+  // notify all classes that store per-grid data that grid may have changed
+  // do this after clearing custom status flags in case classes use that info
+  
+  grid->notify_changed();
 
   // final imbalance factor
   // for RCB TIME, cannot compute imbalance from timers since grid cells moved

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -312,7 +312,7 @@ void FixBalance::end_of_step()
 
   // notify all classes that store per-grid data that grid may have changed
   // do this after clearing custom status flags in case classes use that info
-  
+
   grid->notify_changed();
 
   // final imbalance factor

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -69,9 +69,15 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
   subsonic = 0;
   subsonic_style = NOSUBSONIC;
   subsonic_warning = 0;
-  custom_nrho_flag = custom_vstream_flag = custom_speed_flag = custom_temp_flag = 0;
-  custom_nrho = custom_vstream = custom_speed = custom_temp = NULL;
+  
+  nrho_custom_flag = vstream_custom_flag = speed_custom_flag =
+    temp_custom_flag = fractions_custom_flag = 0;
+  nrho_custom_id = vstream_custom_id = speed_custom_id =
+    temp_custom_id = fractions_custom_id = NULL;
 
+  max_cummulative = 0;
+  cummulative_custom = NULL;
+  
   int iarg = 4;
   options(narg-iarg,&arg[iarg]);
 
@@ -106,11 +112,14 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
 FixEmitSurf::~FixEmitSurf()
 {
   delete [] npstr;
-  delete [] custom_nrho;
-  delete [] custom_vstream;
-  delete [] custom_speed;
-  delete [] custom_temp;
-
+  
+  delete [] nrho_custom_id;
+  delete [] vstream_custom_id;
+  delete [] speed_custom_id;
+  delete [] temp_custom_id;
+  delete [] fractions_custom_id;
+  memory->destroy(cummulative_custom);
+  
   for (int i = 0; i < ntaskmax; i++) {
     delete [] tasks[i].ntargetsp;
     delete [] tasks[i].vscale;
@@ -203,40 +212,81 @@ void FixEmitSurf::init()
 
   // check custom per-surf vectors or arrays
   
-  if (custom_nrho_flag) {
-    icustom_nrho = surf->find_custom(custom_nrho);
-    if (icustom_nrho < 0) error->all(FLERR,"Could not find fix surf/emit nrho custom attribute");
-    if (surf->etype[icustom_nrho] != DOUBLE)
+  if (nrho_custom_flag) {
+    nrho_custom_index = surf->find_custom(nrho_custom_id);
+    if (nrho_custom_index < 0) error->all(FLERR,"Could not find fix surf/emit nrho custom attribute");
+    if (surf->etype[nrho_custom_index] != DOUBLE)
       error->all(FLERR,"Fix emit/surf nrho custom attribute must be floating point");
-    if (surf->esize[icustom_nrho] != 0)
+    if (surf->esize[nrho_custom_index] != 0)
       error->all(FLERR,"Fix emit/surf nrho custom attribute must be a vector");
   }
 
-  if (custom_vstream_flag) {
-    icustom_vstream = surf->find_custom(custom_vstream);
-    if (icustom_vstream < 0) error->all(FLERR,"Could not find fix surf/emit vstream custom attribute");
-    if (surf->etype[icustom_vstream] != DOUBLE)
+  if (vstream_custom_flag) {
+    vstream_custom_index = surf->find_custom(vstream_custom_id);
+    if (vstream_custom_index < 0)
+      error->all(FLERR,"Could not find fix surf/emit vstream custom attribute");
+    if (surf->etype[vstream_custom_index] != DOUBLE)
       error->all(FLERR,"Fix emit/surf vstream custom attribute must be floating point");
-    if (surf->esize[icustom_vstream] != 3)
+    if (surf->esize[vstream_custom_index] != 3)
       error->all(FLERR,"Fix emit/surf vstream custom attribute must be an array with 3 columns");
   }
-
-  if (custom_speed_flag) {
-    icustom_speed = surf->find_custom(custom_speed);
-    if (icustom_speed < 0) error->all(FLERR,"Could not find fix surf/emit speed custom attribute");
-    if (surf->etype[icustom_speed] != DOUBLE)
+    
+  if (speed_custom_flag) {
+    speed_custom_index = surf->find_custom(speed_custom_id);
+    if (speed_custom_index < 0) error->all(FLERR,"Could not find fix surf/emit speed custom attribute");
+    if (surf->etype[speed_custom_index] != DOUBLE)
       error->all(FLERR,"Fix emit/surf speed custom attribute must be floating point");
-    if (surf->esize[icustom_speed] != 0)
+    if (surf->esize[speed_custom_index] != 0)
       error->all(FLERR,"Fix emit/surf speed custom attribute must be a vector");
   }
 
-  if (custom_temp_flag) {
-    icustom_temp = surf->find_custom(custom_temp);
-    if (icustom_temp < 0) error->all(FLERR,"Could not find fix surf/emit temp custom attribute");
-    if (surf->etype[icustom_temp] != DOUBLE)
+  if (temp_custom_flag) {
+    temp_custom_index = surf->find_custom(temp_custom_id);
+    if (temp_custom_index < 0) error->all(FLERR,"Could not find fix surf/emit temp custom attribute");
+    if (surf->etype[temp_custom_index] != DOUBLE)
       error->all(FLERR,"Fix emit/surf temp custom attribute must be floating point");
-    if (surf->esize[icustom_temp] != 0)
+    if (surf->esize[temp_custom_index] != 0)
       error->all(FLERR,"Fix emit/surf temp custom attribute must be a vector");
+  }
+
+  if (fractions_custom_flag) {
+    fractions_custom_index = surf->find_custom(fractions_custom_id);
+    if (fractions_custom_index < 0)
+      error->all(FLERR,"Could not find fix surf/emit fractions custom attribute");
+    if (surf->etype[fractions_custom_index] != DOUBLE)
+      error->all(FLERR,"Fix emit/surf fractions custom attribute must be floating point");
+    if (surf->esize[fractions_custom_index] != nspecies)
+      error->all(FLERR,"Fix emit/surf fractions custom attribute must be an array "
+                 "with columns = # of species in mixture");
+  }
+
+  // if custom fractions is set, reset any fractions which are less than zero
+  // do this for owned custom surfs, grid_changed() will propagate to nlocal+nghost surfs
+
+  if (fractions_custom_flag) {
+    double **fractions = surf->edarray[surf->ewhich[fractions_custom_index]];
+
+    int isp,nunset;
+    double sum,newfrac;
+    
+    int nsown = surf->nown;
+    for (int i = 0; i < nsown; i++) {
+      nunset = 0;
+      sum = 0.0;
+      for (isp = 0; isp < nspecies; isp++) {
+        if (fractions[i][isp] >= 0.0) sum += fractions[i][isp];
+        else nunset++;
+      }
+
+      if (nunset == 0) {
+        if (sum != 1.0) error->all(FLERR,"Fix emit/surf custom fractions do not sum to 1.0");
+      } else {
+        newfrac = (1.0 - sum) / nunset;
+        for (isp = 0; isp < nspecies; isp++) {
+          if (fractions[i][isp] < 0.0) fractions[i][isp] = newfrac;
+        }
+      }
+    }
   }
 
   // create tasks for all grid cells
@@ -253,8 +303,47 @@ void FixEmitSurf::init()
 
 void FixEmitSurf::grid_changed()
 {
+  // if any custom attributes are used
+  // ensure owned custom values are spread to nlocal+nghost surfs
+
+  if (nrho_custom_flag && surf->estatus[nrho_custom_index] == 0)
+    surf->spread_custom(nrho_custom_index);
+  if (vstream_custom_flag && surf->estatus[vstream_custom_index] == 0)
+    surf->spread_custom(vstream_custom_index);
+  if (speed_custom_flag && surf->estatus[speed_custom_index] == 0)
+    surf->spread_custom(speed_custom_index);
+  if (temp_custom_flag && surf->estatus[temp_custom_index] == 0)
+    surf->spread_custom(temp_custom_index);
+  if (fractions_custom_flag && surf->estatus[fractions_custom_index] == 0)
+    surf->spread_custom(fractions_custom_index);
+
+  // create tasks for grid cell / surf pairs
+  
   create_tasks();
 
+  // if custom fractions requested and perspecies = 0
+  // setup cummulaitve_custom array for nlocal surfs
+
+  if (fractions_custom_flag && !perspecies) {
+    int nslocal = surf->nlocal;
+    if (nslocal > max_cummulative) {
+      memory->destroy(cummulative_custom);
+      max_cummulative = nslocal;
+      memory->create(cummulative_custom,nslocal,nspecies,"fix/emit/surf:cummulative_custom");
+    }
+
+    double **fractions = surf->edarray_local[surf->ewhich[fractions_custom_index]];
+    int isp;
+    
+    for (int isurf = 0; isurf < nslocal; isurf++) {
+      for (isp = 0; isp < nspecies; isp++) {
+        if (isp) cummulative_custom[isurf][isp] =
+                   cummulative_custom[isurf][isp-1] + fractions[isurf][isp];
+        else cummulative_custom[isurf][isp] = fractions[isurf][isp];
+      }
+    }
+  }
+  
   // for MODE = CONSTANT or VARIABLE
   // set per-task ntarget to fraction of its area / total area
 
@@ -281,26 +370,11 @@ void FixEmitSurf::create_task(int icell)
   int i,m,isurf,isp,npoint,isplit,subcell;
   double indot,area,areaone,ntargetsp;
   double *normal,*p1,*p2,*p3,*path;
-  double *vector_nrho,*vector_speed,*vector_temp;
-  double **array_vstream;
   double cpath[36],delta[3],e1[3],e2[3];
-
-  Surf::Line *lines = surf->lines;
-  Surf::Tri *tris = surf->tris;
 
   Grid::ChildCell *cells = grid->cells;
   Grid::ChildInfo *cinfo = grid->cinfo;
   Grid::SplitInfo *sinfo = grid->sinfo;
-
-  double nrho = particle->mixture[imix]->nrho;
-  double *vstream = particle->mixture[imix]->vstream;
-  double *vscale = particle->mixture[imix]->vscale;
-  double temp_thermal = particle->mixture[imix]->temp_thermal;
-
-  if (custom_nrho_flag) vector_nrho = surf->edvec[surf->ewhich[icustom_nrho]];
-  if (custom_vstream_flag) array_vstream = surf->edarray[surf->ewhich[icustom_vstream]];
-  if (custom_speed_flag) vector_speed = surf->edvec[surf->ewhich[icustom_speed]];
-  if (custom_temp_flag) vector_temp = surf->edvec[surf->ewhich[icustom_temp]];
 
   // no tasks if no surfs in cell
 
@@ -310,13 +384,29 @@ void FixEmitSurf::create_task(int icell)
 
   if (cinfo[icell].volume == 0.0) return;
 
-  // loop over surfs in cell
-  // use Cut2d/Cut3d to find overlap area and geoemtry of overlap
+  // setup for loop over surfs
 
+  Surf::Line *lines = surf->lines;
+  Surf::Tri *tris = surf->tris;
+
+  double nrho = particle->mixture[imix]->nrho;
+  double *vstream = particle->mixture[imix]->vstream;
+  double *vscale = particle->mixture[imix]->vscale;
+  double temp_thermal = particle->mixture[imix]->temp_thermal;
+
+  if (nrho_custom_flag) nrho_custom = surf->edvec_local[surf->ewhich[nrho_custom_index]];
+  if (vstream_custom_flag) vstream_custom = surf->edarray_local[surf->ewhich[vstream_custom_index]];
+  if (speed_custom_flag) speed_custom = surf->edvec_local[surf->ewhich[speed_custom_index]];
+  if (temp_custom_flag) temp_custom = surf->edvec_local[surf->ewhich[temp_custom_index]];
+  if (fractions_custom_flag) fractions_custom = surf->edarray_local[surf->ewhich[fractions_custom_index]];
+  
   double *lo = cells[icell].lo;
   double *hi = cells[icell].hi;
   surfint *csurfs = cells[icell].csurfs;
   int nsurf = cells[icell].nsurf;
+
+  // loop over surfs in cell
+  // use Cut2d/Cut3d to find overlap area and geoemtry of overlap
 
   for (i = 0; i < nsurf; i++) {
     isurf = csurfs[i];
@@ -327,12 +417,13 @@ void FixEmitSurf::create_task(int icell)
       if (!(tris[isurf].mask & groupbit)) continue;
     }
 
-    // override mixture properties with custom per-surf attributes
+    // if requested, override mixture properties with custom per-surf attributes
 
-    if (custom_nrho_flag) nrho = vector_nrho[isurf];
-    if (custom_vstream_flag) vstream = array_vstream[isurf];
-    if (custom_speed_flag) magvstream = vector_speed[isurf];
-    if (custom_temp_flag) temp_thermal = vector_temp[isurf];
+    if (nrho_custom_flag) nrho = nrho_custom[isurf];
+    if (vstream_custom_flag) vstream = vstream_custom[isurf];
+    if (speed_custom_flag) magvstream = speed_custom[isurf];
+    if (temp_custom_flag) temp_thermal = temp_custom[isurf];
+    if (fractions_custom_flag) fraction = fractions_custom[isurf];
 
     // set cell parameters of task
     // pcell = sub cell for particles if a split cell
@@ -566,6 +657,8 @@ void FixEmitSurf::perform_task()
         ninsert = static_cast<int> (ntarget);
         scosine = indot / vscale[isp];
 
+        // loop over ninsert for each species
+        
         nactual = 0;
         for (m = 0; m < ninsert; m++) {
           if (dimension == 2) {
@@ -657,6 +750,12 @@ void FixEmitSurf::perform_task()
       else if (npmode == CONSTANT) ntarget = np * tasks[i].ntarget;
       else if (npmode == VARIABLE) ntarget = npcurrent * tasks[i].ntarget;
       ninsert = static_cast<int> (ntarget + random->uniform());
+          
+      // loop over ninsert for all species
+      // use cummulative fractions to assign species for each insertion
+      // if requested, override cummulative from mixture with cummulative for isurf
+
+      if (fractions_custom_flag) cummulative = cummulative_custom[isurf];
 
       nactual = 0;
       for (int m = 0; m < ninsert; m++) {
@@ -1090,41 +1189,50 @@ int FixEmitSurf::option(int narg, char **arg)
     if (3 > narg) error->all(FLERR,"Illegal fix emit/surf command");
     
     if (strcmp(arg[1],"nrho") == 0) {
-      custom_nrho_flag = 1;
+      nrho_custom_flag = 1;
       if (strstr(arg[2],"s_") != arg[2])
         error->all(FLERR,"Illegal fix emit/surf command");
       int n = strlen(arg[2]);
-      delete [] custom_nrho;
-      custom_nrho = new char[n];
-      strcpy(custom_nrho,&arg[2][2]);
-      
+      delete [] nrho_custom_id;
+      nrho_custom_id = new char[n];
+      strcpy(nrho_custom_id,&arg[2][2]);
+
     } else if (strcmp(arg[1],"vstream") == 0) {
-      custom_vstream_flag = 1;
+      vstream_custom_flag = 1;
       if (strstr(arg[2],"s_") != arg[2])
         error->all(FLERR,"Illegal fix emit/surf command");
       int n = strlen(arg[2]);
-      delete [] custom_vstream;
-      custom_vstream = new char[n];
-      strcpy(custom_vstream,&arg[2][2]);
-      
+      delete [] vstream_custom_id;
+      vstream_custom_id = new char[n];
+      strcpy(vstream_custom_id,&arg[2][2]);
+
     } else if (strcmp(arg[1],"speed") == 0) {
-      custom_speed_flag = 1;
+      speed_custom_flag = 1;
       if (strstr(arg[2],"s_") != arg[2])
         error->all(FLERR,"Illegal fix emit/surf command");
       int n = strlen(arg[2]);
-      delete [] custom_speed;
-      custom_speed = new char[n];
-      strcpy(custom_speed,&arg[2][2]);
-      
+      delete [] speed_custom_id;
+      speed_custom_id = new char[n];
+      strcpy(speed_custom_id,&arg[2][2]);
+
     } else if (strcmp(arg[1],"temp") == 0) {
-      custom_temp_flag = 1;
+      temp_custom_flag = 1;
       if (strstr(arg[2],"s_") != arg[2])
         error->all(FLERR,"Illegal fix emit/surf command");
       int n = strlen(arg[2]);
-      delete [] custom_temp;
-      custom_temp = new char[n];
-      strcpy(custom_temp,&arg[2][2]);
-      
+      delete [] temp_custom_id;
+      temp_custom_id = new char[n];
+      strcpy(temp_custom_id,&arg[2][2]);
+
+    } else if (strcmp(arg[1],"fractions") == 0) {
+      fractions_custom_flag = 1;
+      if (strstr(arg[2],"s_") != arg[2])
+        error->all(FLERR,"Illegal fix emit/surf command");
+      int n = strlen(arg[2]);
+      delete [] fractions_custom_id;
+      fractions_custom_id = new char[n];
+      strcpy(fractions_custom_id,&arg[2][2]);
+
     } else error->all(FLERR,"Illegal fix emit/surf command");
     return 3;
   }

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -69,7 +69,7 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
   subsonic = 0;
   subsonic_style = NOSUBSONIC;
   subsonic_warning = 0;
-  
+
   nrho_custom_flag = vstream_custom_flag = speed_custom_flag =
     temp_custom_flag = fractions_custom_flag = 0;
   nrho_custom_id = vstream_custom_id = speed_custom_id =
@@ -77,7 +77,7 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
 
   max_cummulative = 0;
   cummulative_custom = NULL;
-  
+
   int iarg = 4;
   options(narg-iarg,&arg[iarg]);
 
@@ -120,14 +120,14 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
 FixEmitSurf::~FixEmitSurf()
 {
   delete [] npstr;
-  
+
   delete [] nrho_custom_id;
   delete [] vstream_custom_id;
   delete [] speed_custom_id;
   delete [] temp_custom_id;
   delete [] fractions_custom_id;
   memory->destroy(cummulative_custom);
-  
+
   for (int i = 0; i < ntaskmax; i++) {
     delete [] tasks[i].ntargetsp;
     delete [] tasks[i].vscale;
@@ -219,7 +219,7 @@ void FixEmitSurf::init()
   }
 
   // check custom per-surf vectors or arrays
-  
+
   if (nrho_custom_flag) {
     nrho_custom_index = surf->find_custom(nrho_custom_id);
     if (nrho_custom_index < 0) error->all(FLERR,"Could not find fix surf/emit nrho custom attribute");
@@ -238,7 +238,7 @@ void FixEmitSurf::init()
     if (surf->esize[vstream_custom_index] != 3)
       error->all(FLERR,"Fix emit/surf vstream custom attribute must be an array with 3 columns");
   }
-    
+
   if (speed_custom_flag) {
     speed_custom_index = surf->find_custom(speed_custom_id);
     if (speed_custom_index < 0) error->all(FLERR,"Could not find fix surf/emit speed custom attribute");
@@ -276,7 +276,7 @@ void FixEmitSurf::init()
 
     int isp,nunset;
     double sum,newfrac;
-    
+
     int nsown = surf->nown;
     for (int i = 0; i < nsown; i++) {
       nunset = 0;
@@ -326,7 +326,7 @@ void FixEmitSurf::grid_changed()
     surf->spread_custom(fractions_custom_index);
 
   // create tasks for grid cell / surf pairs
-  
+
   create_tasks();
 
   // if custom fractions requested and perspecies = 0,
@@ -342,7 +342,7 @@ void FixEmitSurf::grid_changed()
 
     double **fractions = surf->edarray_local[surf->ewhich[fractions_custom_index]];
     int isp;
-    
+
     for (int isurf = 0; isurf < nslocal; isurf++) {
       for (isp = 0; isp < nspecies; isp++) {
         if (isp) cummulative_custom[isurf][isp] =
@@ -351,7 +351,7 @@ void FixEmitSurf::grid_changed()
       }
     }
   }
-  
+
   // for MODE = CONSTANT or VARIABLE
   // set per-task ntarget to fraction of its area / total area
 
@@ -409,7 +409,7 @@ void FixEmitSurf::create_task(int icell)
   if (fractions_custom_flag) fractions_custom =
                                surf->edarray_local[surf->ewhich[fractions_custom_index]];
   double temp_thermal_custom;
-  
+
   double *lo = cells[icell].lo;
   double *hi = cells[icell].hi;
   surfint *csurfs = cells[icell].csurfs;
@@ -572,7 +572,7 @@ void FixEmitSurf::create_task(int icell)
     // may be overwritten by subsonic methods
 
     double utemp;
-    
+
     tasks[ntask].nrho = nrho;
     if (temp_custom_flag) {
       tasks[ntask].temp_thermal = temp_thermal_custom;
@@ -645,7 +645,7 @@ void FixEmitSurf::perform_task()
 
   Surf::Line *lines = surf->lines;
   Surf::Tri *tris = surf->tris;
-  
+
   int nfix_update_custom = modify->n_update_custom;
 
   for (i = 0; i < ntask; i++) {
@@ -678,7 +678,7 @@ void FixEmitSurf::perform_task()
         scosine = indot / vscale[isp];
 
         // loop over ninsert for each species
-        
+
         nactual = 0;
         for (m = 0; m < ninsert; m++) {
           if (dimension == 2) {
@@ -1206,7 +1206,7 @@ int FixEmitSurf::option(int narg, char **arg)
 
   if (strcmp(arg[0],"custom") == 0) {
     if (3 > narg) error->all(FLERR,"Illegal fix emit/surf command");
-    
+
     if (strcmp(arg[1],"nrho") == 0) {
       nrho_custom_flag = 1;
       if (strstr(arg[2],"s_") != arg[2])

--- a/src/fix_emit_surf.h
+++ b/src/fix_emit_surf.h
@@ -65,6 +65,7 @@ class FixEmitSurf : public FixEmit {
     double temp_thermal;        // from mixture or adjacent subsonic cell
     double temp_rot;            // from mixture or subsonic temp_thermal
     double temp_vib;            // from mixture or subsonic temp_thermal
+    double magvstream;          // from mixture
     double vstream[3];          // from mixture or adjacent subsonic cell
     double *ntargetsp;          // # of mols to insert for each species,
                                 //   only defined for PERSPECIES
@@ -88,6 +89,12 @@ class FixEmitSurf : public FixEmit {
   double magvstream;       // magnitude of mixture vstream
   double norm_vstream[3];  // direction of mixture vstream
 
+  // custom options for per-surf emission properties
+
+  int custom_nrho_flag,custom_vstream_flag,custom_speed_flag,custom_temp_flag;
+  char *custom_nrho,*custom_vstream,*custom_speed,*custom_temp;
+  int icustom_nrho,icustom_vstream,icustom_speed,icustom_temp;
+  
   // active grid cells assigned to tasks, used by subsonic sorting
 
   int maxactive;

--- a/src/fix_emit_surf.h
+++ b/src/fix_emit_surf.h
@@ -91,10 +91,15 @@ class FixEmitSurf : public FixEmit {
 
   // custom options for per-surf emission properties
 
-  int custom_nrho_flag,custom_vstream_flag,custom_speed_flag,custom_temp_flag;
-  char *custom_nrho,*custom_vstream,*custom_speed,*custom_temp;
-  int icustom_nrho,icustom_vstream,icustom_speed,icustom_temp;
-  
+  int nrho_custom_flag,vstream_custom_flag,speed_custom_flag,temp_custom_flag,fractions_custom_flag;
+  char *nrho_custom_id,*vstream_custom_id,*speed_custom_id,*temp_custom_id,*fractions_custom_id;
+  int nrho_custom_index,vstream_custom_index,speed_custom_index,temp_custom_index,fractions_custom_index;
+  double *nrho_custom,*speed_custom,*temp_custom;
+  double **vstream_custom,**fractions_custom;
+
+  int max_cummulative;
+  double **cummulative_custom;     // local to this fix, not actually custom data
+
   // active grid cells assigned to tasks, used by subsonic sorting
 
   int maxactive;

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -670,7 +670,10 @@ bool line_line_intersect(double *start, double *stop,
   //     depending on direction of 2 lines
   //   thus this can lead to no collision with either line
   //   typical observed dot values were 1.0e-18, so use EPSSQ = 1.0e-16
-
+  // NOTE: EPSSQ and EPSSQNEG are not normalized to size of line
+  //   this means the test is not robust for lines of widely varying size
+  //   better test would be something like EPS * line-length
+  
   MathExtra::sub3(v1,v0,edge);
   MathExtra::sub3(point,v0,pvec);
   if (MathExtra::dot3(edge,pvec) < EPSSQNEG) return false;
@@ -1010,6 +1013,10 @@ bool line_tri_intersect(double *start, double *stop,
   //     depending on direction of 2 tri norms
   //   thus this can lead to no collision with either tri
   //   typical observed dot values were -1.0e-18, so use EPSSQNEG = -1.0e-16
+  // NOTE: EPSSQ and EPSSQNEG are not normalized to size of triangle
+  //   this means the test is not robust for tris of widely varying size
+  //   better test would be something like EPS * max-edge-length
+  //     but that would be expensive to calculate 
 
   MathExtra::sub3(v1,v0,edge);
   MathExtra::sub3(point,v0,pvec);

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -673,7 +673,7 @@ bool line_line_intersect(double *start, double *stop,
   // NOTE: EPSSQ and EPSSQNEG are not normalized to size of line
   //   this means the test is not robust for lines of widely varying size
   //   better test would be something like EPS * line-length
-  
+
   MathExtra::sub3(v1,v0,edge);
   MathExtra::sub3(point,v0,pvec);
   if (MathExtra::dot3(edge,pvec) < EPSSQNEG) return false;
@@ -1016,7 +1016,7 @@ bool line_tri_intersect(double *start, double *stop,
   // NOTE: EPSSQ and EPSSQNEG are not normalized to size of triangle
   //   this means the test is not robust for tris of widely varying size
   //   better test would be something like EPS * max-edge-length
-  //     but that would be expensive to calculate 
+  //     but that would be expensive to calculate
 
   MathExtra::sub3(v1,v0,edge);
   MathExtra::sub3(point,v0,pvec);

--- a/src/grid.cpp
+++ b/src/grid.cpp
@@ -1291,9 +1291,9 @@ void Grid::unset_neighbors()
 {
   // set unset_flag = 0/1 depending on whether unset is performed
   // so that reset_neighbors() can check it
-  
+
   unset_flag = 0;
-  
+
   if (!exist_ghost) return;
 
   // no change in neigh[] needed if nflag = NUNKNOWN, NPBUNKNOWN, or NBOUND
@@ -1333,14 +1333,14 @@ void Grid::reset_neighbors()
   // if unset operation was not performed, cannot reset
   // instead must perform full find_neighbors() operation
   // this can happen if "global gridcut" is used after grid is created
-  
+
   if (!unset_flag) {
     find_neighbors();
     return;
   }
-  
+
   unset_flag = 0;
-  
+
   // insure all cell IDs (owned + ghost) are hashed
 
   rehash();

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1642,7 +1642,7 @@ void Grid::clear_surf_implicit()
 
   // store cellIDs = list of cellID each particle is in
   // sub-cells and parent split cell have the same cellID
-  
+
   Particle::OnePart *particles = particle->particles;
   int nplocal = particle->nlocal;
 


### PR DESCRIPTION
## Purpose

Enable fix emit/surf to emit particles from surfaces using custom per-surf values for density, temperature, and vstream (or speed).
This allows customization of the emission properties of different surface elements.  The per-surf values can be defined by the read_surf or custom commands.

## Author(s)

Steve

## Backward Compatibility

New feature, hopefully does not break any existing features.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


