### PR TITLE
Fix some issues with the fix ave/surf command

### DIFF
--- a/src/custom.cpp
+++ b/src/custom.cpp
@@ -174,7 +174,7 @@ void Custom::command(int narg, char **arg)
   // cindex = index of existing custom attribute
   // otherwise create custom attribute if it does not exist
   // error check that name or name[] matches new or existing attribute
-  
+
   if (mode == PARTICLE) {
     cindex = particle->find_custom(aname);
     if (cindex >= 0) {
@@ -183,7 +183,7 @@ void Custom::command(int narg, char **arg)
     } else {
       cindex = particle->add_custom(aname,ctype,csize);
     }
-    
+
   } else if (mode == GRID) {
     cindex = grid->find_custom(aname);
     if (cindex >= 0) {
@@ -192,7 +192,7 @@ void Custom::command(int narg, char **arg)
     } else {
       cindex = grid->add_custom(aname,ctype,csize);
     }
-  
+
   } else if (mode == SURF) {
     cindex = surf->find_custom(aname);
     if (cindex >= 0) {
@@ -208,7 +208,7 @@ void Custom::command(int narg, char **arg)
   if (csize != 0 && ccol == 0) eflag = 1;
   if (csize != 0 && ccol > csize) eflag = 1;
   if (eflag) error->all(FLERR,"Custom name does not match new or existing custom attribute");
-  
+
   // evaluate variable
   // store result as floating point scalar or vector
 

--- a/src/fix_ave_surf.cpp
+++ b/src/fix_ave_surf.cpp
@@ -303,7 +303,7 @@ FixAveSurf::~FixAveSurf()
     memory->destroy(bufvec);
     memory->destroy(bufarray);
   }
-  
+
   if (nvalues == 1) memory->destroy(vector_surf);
   else memory->destroy(array_surf);
   if (ave == RUNNING) {
@@ -515,7 +515,7 @@ void FixAveSurf::end_of_step()
 	input->variable->compute_surf(n,accvec,1,1);
       else
 	input->variable->compute_surf(n,&accarray[0][m],nvalues,1);
-      
+
     // access custom attribute
 
     } else if (which[m] == CUSTOM) {
@@ -574,7 +574,7 @@ void FixAveSurf::end_of_step()
   irepeat = 0;
   nvalid = ntimestep+per_surf_freq - (nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
- 
+
   // if all input values are computes which tally particle/surf interactions:
   //   invoke surf->collate() on tallies this fix stores for multiple steps
   //   this merges tallies to owned surfs

--- a/src/fix_ave_surf.cpp
+++ b/src/fix_ave_surf.cpp
@@ -135,7 +135,7 @@ FixAveSurf::FixAveSurf(SPARTA *sparta, int narg, char **arg) :
   if (per_surf_freq % nevery || (nrepeat-1)*nevery >= per_surf_freq)
     error->all(FLERR,"Illegal fix ave/surf command");
 
-  int count_tally = 0;
+  count_tally = 0;
 
   for (int i = 0; i < nvalues; i++) {
     if (which[i] == COMPUTE) {
@@ -297,10 +297,13 @@ FixAveSurf::~FixAveSurf()
   for (int i = 0; i < nvalues; i++) delete [] ids[i];
   delete [] ids;
 
-  memory->destroy(bufvec);
-  memory->destroy(bufarray);
   memory->destroy(masks);
 
+  if (count_tally) {
+    memory->destroy(bufvec);
+    memory->destroy(bufarray);
+  }
+  
   if (nvalues == 1) memory->destroy(vector_surf);
   else memory->destroy(array_surf);
   if (ave == RUNNING) {
@@ -508,11 +511,11 @@ void FixAveSurf::end_of_step()
     // evaluate surf-style variable
 
     } else if (which[m] == VARIABLE) {
-      if (j == 0)
+      if (nvalues == 1)
 	input->variable->compute_surf(n,accvec,1,1);
       else
 	input->variable->compute_surf(n,&accarray[0][m],nvalues,1);
-
+      
     // access custom attribute
 
     } else if (which[m] == CUSTOM) {
@@ -571,19 +574,21 @@ void FixAveSurf::end_of_step()
   irepeat = 0;
   nvalid = ntimestep+per_surf_freq - (nrepeat-1)*nevery;
   modify->addstep_compute(nvalid);
+ 
+  // if all input values are computes which tally particle/surf interactions:
+  //   invoke surf->collate() on tallies this fix stores for multiple steps
+  //   this merges tallies to owned surfs
 
-  // invoke surf->collate() on tallies this fix stores for multiple steps
-  // this merges tallies to owned surfs
-  // NOTE: this should only be done if source is a COMPUTE ?
-
-  if (nvalues == 1) {
-    surf->collate_vector(ntally,tally2surf,vec_tally,1,bufvec);
-    for (i = 0; i < nown; i++) accvec[i] += bufvec[i];
-  } else {
-    surf->collate_array(ntally,nvalues,tally2surf,array_tally,bufarray);
-    for (i = 0; i < nown; i++)
-      for (m = 0; m < nvalues; m++)
-        accarray[i][m] += bufarray[i][m];
+  if (count_tally) {
+    if (nvalues == 1) {
+      surf->collate_vector(ntally,tally2surf,vec_tally,1,bufvec);
+      for (i = 0; i < nown; i++) accvec[i] += bufvec[i];
+    } else {
+      surf->collate_array(ntally,nvalues,tally2surf,array_tally,bufarray);
+      for (i = 0; i < nown; i++)
+        for (m = 0; m < nvalues; m++)
+          accarray[i][m] += bufarray[i][m];
+    }
   }
 
   // normalize the accumulators for output on Nfreq timestep

--- a/src/fix_ave_surf.h
+++ b/src/fix_ave_surf.h
@@ -58,6 +58,8 @@ class FixAveSurf : public Fix {
   double *vec_tally;       // tally values, maxtally in length
   double **array_tally;
 
+  int count_tally;         // # of values which process particle/surf tallies
+
   // hash for surf IDs
 
 #ifdef SPARTA_MAP


### PR DESCRIPTION
## Purpose

Fix a couple of bugs in the fix ave/surf command

(1) Input values for surf-style variables were sometimes not processed correctly
(2) Using input values which were not computes which tally particle/surf interactions, was triggering post-processing
     of the tallies which was not appropriate for those kinds of input values.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


