### PR TITLE
Add a variable special function which allows particle-style vars to access per-grid quantities

### DIFF
--- a/doc/dump.html
+++ b/doc/dump.html
@@ -34,13 +34,14 @@
 <LI>args = list of arguments for a particular style 
 
 <PRE>  <I>particle</I> args = list of particle attributes
-    possible attributes = id, type, proc, x, y, z, xs, ys, zs, vx, vy, vz,
+    possible attributes = id, type, proc, cellID, x, y, z, xs, ys, zs, vx, vy, vz,
                           ke, erot, evib, 
                           c_ID, c_ID[N], f_ID, f_ID[N], v_name, p_name, p_name[N] 
 </PRE>
 <PRE>      id = particle ID
       type = particle species as an integer index
       proc = ID of owning processor
+      cellID = ID of grid cell particle is in
       x,y,z = unscaled particle coordinates
       xs,ys,zs = scaled particle coordinates
       vx,vy,vz = particle velocities

--- a/doc/dump.txt
+++ b/doc/dump.txt
@@ -23,13 +23,14 @@ N = dump every this many timesteps :l
 file = name of file to write dump info to :l
 args = list of arguments for a particular style :l
   {particle} args = list of particle attributes
-    possible attributes = id, type, proc, x, y, z, xs, ys, zs, vx, vy, vz,
+    possible attributes = id, type, proc, cellID, x, y, z, xs, ys, zs, vx, vy, vz,
                           ke, erot, evib, 
                           c_ID, c_ID\[N\], f_ID, f_ID\[N\], v_name, p_name, p_name\[N\] :pre
 
       id = particle ID
       type = particle species as an integer index
       proc = ID of owning processor
+      cellID = ID of grid cell particle is in
       x,y,z = unscaled particle coordinates
       xs,ys,zs = scaled particle coordinates
       vx,vy,vz = particle velocities

--- a/doc/variable.html
+++ b/doc/variable.html
@@ -56,7 +56,7 @@
                      sin(x), cos(x), tan(x), asin(x), acos(x), atan(x), atan2(y,x), erf(x),
                      random(x,y), normal(x,y), ceil(x), floor(x), round(x)
                      ramp(x,y), stagger(x,y), logfreq(x,y,z), stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
-    special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
+    special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x), grid2part(x)
     particle vectors = id, type, mass, q, mu, x, y, z, vx, vy, vz
     grid vectors = cxlo, cxhi, cylo, cyhi, czlo, czhi
     compute references = c_ID, c_ID[I], c_ID[I][J]
@@ -361,7 +361,7 @@ variables.
 <TR><TD >Stats keywords</TD><TD > step, np, vol, etc</TD></TR>
 <TR><TD >Math operators</TD><TD > (), -x, x+y, x-y, x*y, x/y, x^y, x%y, x==y, x!=y, x<y, x<=y, x>y, x>=y, x&&y, x||y, !x</TD></TR>
 <TR><TD >Math functions</TD><TD > sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x),      asin(x), acos(x), atan(x), atan2(y,x), erf(x), random(x,y,z), normal(x,y,z),      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z),      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)</TD></TR>
-<TR><TD >Special functions</TD><TD > sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)</TD></TR>
+<TR><TD >Special functions</TD><TD > sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x), grid2part(x)</TD></TR>
 <TR><TD >Particle vectors</TD><TD > id, type, mass, q, mu, x, y, z, vx, vy, vz</TD></TR>
 <TR><TD >Grid vectors = cxlo, cxhi, cylo, cyhi, czlo, czhi</TD></TR>
 <TR><TD >Compute references</TD><TD > c_ID, c_ID[I], c_ID[I][J]</TD></TR>
@@ -619,6 +619,35 @@ when they are defined in the input script, this is the value that will
 be returned the first time the next() function is invoked.  If next()
 is invoked more times than there are lines in the file, the variable
 is deleted, similar to how the <A HREF = "next.html">next</A> command operates.
+</P>
+<P>The grid2part(x) function can only be used in a particle-style
+variable formula.  Its purpose is to enable each particle to access a
+per-grid quantity for the grid cell it is currently in.  The per-grid
+quantity must be produced by a compute or fix.  When the
+particle-style variable formula is evaluated for each particle, the
+per-grid vector or array from the compute or fix is accessed, using
+the grid cell index for each particle.
+</P>
+<P>An example of its usage is as follows:
+</P>
+<PRE>variable     csq particle "vx*vx + vy*vy + vz*vz"
+compute      therm thermal/grid all all temp press
+variable     csq_norm particle v_csq/grid2part(c_therm<B>1</B>) 
+</PRE>
+<P>The per-particle variable csq_norm will calculate the kinetic energy
+for each particle, normalized by the thermal temperature of the full
+set of particles for the grid cell it is in.  The latter is computed
+by the <A HREF = "compute_thermal_grid.html">compute thermal/grid</A> command.
+</P>
+<P>The grid2part(x) function takes 1 argument which is of the form "c_ID"
+or "c_ID[N]" or "f_ID" or "f_ID[N]".  The first two are computes
+and the second two are fixes; the ID in the reference should be
+replaced by the ID of a compute or fix defined elsewhere in the input
+script.  The compute or fix must produce either a per-grid vector or
+array.  If it produces a per-grid vector, then the notation without
+"[N]" should be used.  If it produces a per-grid array, then the
+notation with "[N]" should be used, when N is an integer, to specify
+which column of the per-grid array is being referenced.
 </P>
 <HR>
 

--- a/doc/variable.txt
+++ b/doc/variable.txt
@@ -51,7 +51,7 @@ style = {delete} or {index} or {loop} or {world} or {universe} or {uloop} or {st
                      sin(x), cos(x), tan(x), asin(x), acos(x), atan(x), atan2(y,x), erf(x),
                      random(x,y), normal(x,y), ceil(x), floor(x), round(x)
                      ramp(x,y), stagger(x,y), logfreq(x,y,z), stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
-    special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
+    special functions = sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x), grid2part(x)
     particle vectors = id, type, mass, q, mu, x, y, z, vx, vy, vz
     grid vectors = cxlo, cxhi, cylo, cyhi, czlo, czhi
     compute references = c_ID, c_ID\[I\], c_ID\[I\]\[J\]
@@ -357,7 +357,7 @@ Math functions: sqrt(x), exp(x), ln(x), log(x), abs(x), sin(x), cos(x), tan(x), 
      asin(x), acos(x), atan(x), atan2(y,x), erf(x), random(x,y,z), normal(x,y,z), \
      ceil(x), floor(x), round(x), ramp(x,y), stagger(x,y), logfreq(x,y,z), \
      stride(x,y,z), vdisplace(x,y), swiggle(x,y,z), cwiggle(x,y,z)
-Special functions: sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x)
+Special functions: sum(x), min(x), max(x), ave(x), trap(x), slope(x), next(x), grid2part(x)
 Particle vectors: id, type, mass, q, mu, x, y, z, vx, vy, vz
 Grid vectors = cxlo, cxhi, cylo, cyhi, czlo, czhi
 Compute references: c_ID, c_ID\[I\], c_ID\[I\]\[J\]
@@ -614,6 +614,35 @@ when they are defined in the input script, this is the value that will
 be returned the first time the next() function is invoked.  If next()
 is invoked more times than there are lines in the file, the variable
 is deleted, similar to how the "next"_next.html command operates.
+
+The grid2part(x) function can only be used in a particle-style
+variable formula.  Its purpose is to enable each particle to access a
+per-grid quantity for the grid cell it is currently in.  The per-grid
+quantity must be produced by a compute or fix.  When the
+particle-style variable formula is evaluated for each particle, the
+per-grid vector or array from the compute or fix is accessed, using
+the grid cell index for each particle.
+
+An example of its usage is as follows:
+
+variable     csq particle "vx*vx + vy*vy + vz*vz"
+compute      therm thermal/grid all all temp press
+variable     csq_norm particle v_csq/grid2part(c_therm[1]) :pre
+
+The per-particle variable csq_norm will calculate the kinetic energy
+for each particle, normalized by the thermal temperature of the full
+set of particles for the grid cell it is in.  The latter is computed
+by the "compute thermal/grid"_compute_thermal_grid.html command.
+
+The grid2part(x) function takes 1 argument which is of the form "c_ID"
+or "c_ID\[N\]" or "f_ID" or "f_ID\[N\]".  The first two are computes
+and the second two are fixes; the ID in the reference should be
+replaced by the ID of a compute or fix defined elsewhere in the input
+script.  The compute or fix must produce either a per-grid vector or
+array.  If it produces a per-grid vector, then the notation without
+"\[N\]" should be used.  If it produces a per-grid array, then the
+notation with "\[N\]" should be used, when N is an integer, to specify
+which column of the per-grid array is being referenced.
 
 :line
 

--- a/src/create_isurf.cpp
+++ b/src/create_isurf.cpp
@@ -391,7 +391,7 @@ void CreateISurf::surface_edge2d()
           if (ivalues[icell][j][n2] > oparam || ivalues[icell][j][n2] < 0)
             ivalues[icell][j][n2] = oparam;
 
-          if ((mvalues[icell][i] < 0 || param <= mvalues[icell][i]) && 
+          if ((mvalues[icell][i] < 0 || param <= mvalues[icell][i]) &&
                svalues[icell][i] != 2) {
             if (param == 0) svalues[icell][i] = 0;
 
@@ -404,7 +404,7 @@ void CreateISurf::surface_edge2d()
             mvalues[icell][i] = param;
           }
 
-          if ((mvalues[icell][j] < 0 || oparam <= mvalues[icell][j]) && 
+          if ((mvalues[icell][j] < 0 || oparam <= mvalues[icell][j]) &&
                svalues[icell][j] != 2) {
             if (oparam == 0) svalues[icell][j] = 0;
             else if (fabs(mvalues[icell][j]-oparam) < EPSILON_GRID
@@ -538,7 +538,7 @@ void CreateISurf::surface_edge3d()
           if (ivalues[icell][j][n2] > oparam || ivalues[icell][j][n2] < 0)
             ivalues[icell][j][n2] = oparam;
 
-          if ((mvalues[icell][i] < 0 || param <= mvalues[icell][i]) && 
+          if ((mvalues[icell][i] < 0 || param <= mvalues[icell][i]) &&
                svalues[icell][i] != 2) {
             if (param == 0) svalues[icell][i] = 0;
 
@@ -550,7 +550,7 @@ void CreateISurf::surface_edge3d()
             mvalues[icell][i] = param;
           }
 
-          if ((mvalues[icell][j] < 0 || oparam <= mvalues[icell][j]) && 
+          if ((mvalues[icell][j] < 0 || oparam <= mvalues[icell][j]) &&
                svalues[icell][j] != 2) {
             if (oparam == 0) svalues[icell][j] = 0;
             else if (fabs(mvalues[icell][j]-oparam) < EPSILON_GRID

--- a/src/dump_particle.cpp
+++ b/src/dump_particle.cpp
@@ -20,6 +20,7 @@
 #include "domain.h"
 #include "region.h"
 #include "particle.h"
+#include "grid.h"
 #include "mixture.h"
 #include "modify.h"
 #include "compute.h"
@@ -33,7 +34,7 @@ using namespace SPARTA_NS;
 
 // customize by adding keyword
 
-enum{ID,TYPE,PROC,X,Y,Z,XS,YS,ZS,VX,VY,VZ,KE,EROT,EVIB,
+enum{ID,TYPE,PROC,CELLID,X,Y,Z,XS,YS,ZS,VX,VY,VZ,KE,EROT,EVIB,
      CUSTOM,COMPUTE,FIX,VARIABLE};
 enum{LT,LE,GT,GE,EQ,NEQ};
 enum{INT,DOUBLE,BIGINT,STRING};        // same as Dump
@@ -364,9 +365,10 @@ int DumpParticle::count()
 
   // un-choose if not in mixture
 
+  Grid::ChildCell *cells = grid->cells;
   Particle::OnePart *particles = particle->particles;
   int *species2species = particle->mixture[imix]->species2species;
-
+  
   for (i = 0; i < nlocal; i++)
     if (species2species[particles[i].ispecies] < 0) choose[i] = 0;
 
@@ -406,6 +408,10 @@ int DumpParticle::count()
         nstride = 1;
       } else if (thresh_array[ithresh] == PROC) {
         for (i = 0; i < nlocal; i++) dchoose[i] = me;
+        ptr = dchoose;
+        nstride = 1;
+      } else if (thresh_array[ithresh] == CELLID) {
+        for (i = 0; i < nlocal; i++) dchoose[i] = cells[particles[i].icell].id;
         ptr = dchoose;
         nstride = 1;
 
@@ -660,6 +666,10 @@ int DumpParticle::parse_fields(int narg, char **arg)
     } else if (strcmp(arg[iarg],"proc") == 0) {
       pack_choice[i] = &DumpParticle::pack_proc;
       vtype[i] = INT;
+    } else if (strcmp(arg[iarg],"cellID") == 0) {
+      pack_choice[i] = &DumpParticle::pack_cellid;
+      if (sizeof(cellint) == sizeof(smallint)) vtype[i] = INT;
+      else vtype[i] = BIGINT;
 
     } else if (strcmp(arg[iarg],"x") == 0) {
       pack_choice[i] = &DumpParticle::pack_x;
@@ -992,6 +1002,7 @@ int DumpParticle::modify_param(int narg, char **arg)
     if (strcmp(arg[1],"id") == 0) thresh_array[nthresh] = ID;
     else if (strcmp(arg[1],"type") == 0) thresh_array[nthresh] = TYPE;
     else if (strcmp(arg[1],"proc") == 0) thresh_array[nthresh] = PROC;
+    else if (strcmp(arg[1],"cellID") == 0) thresh_array[nthresh] = CELLID;
 
     else if (strcmp(arg[1],"x") == 0) thresh_array[nthresh] = X;
     else if (strcmp(arg[1],"y") == 0) thresh_array[nthresh] = Y;
@@ -1322,6 +1333,24 @@ void DumpParticle::pack_proc(int n)
 {
   for (int i = 0; i < nchoose; i++) {
     buf[n] = me;
+    n += size_one;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void DumpParticle::pack_cellid(int n)
+{
+  Particle::OnePart *particles = particle->particles;
+  Grid::ChildCell *cells = grid->cells;
+
+  // NOTE: cellint (bigint) won't fit in double in some cases
+
+  int icell;
+  
+  for (int i = 0; i < nchoose; i++) {
+    icell = particles[clist[i]].icell;
+    buf[n] = cells[icell].id;
     n += size_one;
   }
 }

--- a/src/dump_particle.cpp
+++ b/src/dump_particle.cpp
@@ -368,7 +368,7 @@ int DumpParticle::count()
   Grid::ChildCell *cells = grid->cells;
   Particle::OnePart *particles = particle->particles;
   int *species2species = particle->mixture[imix]->species2species;
-  
+
   for (i = 0; i < nlocal; i++)
     if (species2species[particles[i].ispecies] < 0) choose[i] = 0;
 
@@ -1347,7 +1347,7 @@ void DumpParticle::pack_cellid(int n)
   // NOTE: cellint (bigint) won't fit in double in some cases
 
   int icell;
-  
+
   for (int i = 0; i < nchoose; i++) {
     icell = particles[clist[i]].icell;
     buf[n] = cells[icell].id;

--- a/src/dump_particle.h
+++ b/src/dump_particle.h
@@ -113,6 +113,7 @@ class DumpParticle : public Dump {
   void pack_id(int);
   void pack_type(int);
   void pack_proc(int);
+  void pack_cellid(int);
 
   void pack_x(int);
   void pack_y(int);

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3685,20 +3685,20 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
   // special function grid2part() that allows
   // per-particle access of pre-grid quantities
-    
+
   } else if (strcmp(word,"grid2part") == 0) {
     if (narg != 1)
       error->all(FLERR,"Invalid special function in variable formula");
 
     if (tree == NULL || treestyle != PARTICLE)
       error->all(FLERR,"Variable grid2part() can only be used by particle-style variable");
-    
+
     Compute *compute = NULL;
     Fix *fix = NULL;
     int index,nvec,nstride;
 
     // compute that produces per-grid vector or array
-    
+
     if (strstr(arg1,"c_") == arg1) {
       ptr1 = strchr(arg1,'[');
       if (ptr1) {
@@ -3714,7 +3714,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
       if (!compute->per_grid_flag)
         error->all(FLERR,"Variable grid2part() arg is not a per-grid compute");
-      
+
       if (index == 0 && compute->size_per_grid_cols == 0) {
         if (!compute->first_init)
           error->all(FLERR,"Variable formula compute cannot be invoked"
@@ -3728,7 +3728,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
           compute->post_process_grid(0,1,NULL,NULL,NULL,1);
         else if (compute->post_process_isurf_grid_flag)
           compute->post_process_isurf_grid();
-       
+
         Tree *newtree = new Tree();
         newtree->type = PARTGRIDARRAY;
         newtree->array = compute->vector_grid;
@@ -3773,7 +3773,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
         newtree->selfalloc = 0;
         newtree->left = newtree->middle = newtree->right = NULL;
         treestack[ntreestack++] = newtree;
-        
+
       } else error->all(FLERR,"Mismatched compute in variable formula");
 
     // fix that produces per-grid vector or array
@@ -3789,7 +3789,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       int ifix = modify->find_fix(&arg1[2]);
       if (ifix < 0) error->all(FLERR,"Invalid fix ID in variable formula");
       fix = modify->fix[ifix];
-      
+
       if (!fix->per_grid_flag)
         error->all(FLERR,"Variable grid2part() arg is not a per-grid fix");
       if (update->runflag > 0 && update->ntimestep % fix->per_grid_freq)
@@ -3803,7 +3803,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
         newtree->selfalloc = 0;
         newtree->left = newtree->middle = newtree->right = NULL;
         treestack[ntreestack++] = newtree;
-        
+
       } else if (index && fix->size_per_grid_cols != 0) {
         if (index > fix->size_per_grid_cols)
           error->all(FLERR,"Variable formula fix array is accessed out-of-range");
@@ -3815,7 +3815,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
         newtree->selfalloc = 0;
         newtree->left = newtree->middle = newtree->right = NULL;
         treestack[ntreestack++] = newtree;
-        
+
       } else error->all(FLERR,"Mismatched compute in variable formula");
 
     } else error->all(FLERR,"Invalid variable style in special function grid2part()");

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3438,6 +3438,7 @@ int Variable::math_function(char *word, char *contents, Tree **tree,
    push result onto tree or arg stack
    word = special function
    contents = str between parentheses with one,two,three args
+     currently, all special functions just take one arg
    return 0 if not a match, 1 if successfully processed
    customize by adding a special function:
      sum(x),min(x),max(x),ave(x),trap(x),slope(x),next(x),grid2part(x)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -3654,7 +3654,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       treestack[ntreestack++] = newtree;
     } else argstack[nargstack++] = value;
 
-  // special function for file-style variable
+  // special function next() for file-style variable
 
   } else if (strcmp(word,"next") == 0) {
     if (narg != 1)
@@ -3682,7 +3682,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
     } else error->all(FLERR,"Invalid variable style in special function next");
 
-  // special function that allows per-particle access of grid quantities
+  // special function grid2part() that allows
+  // per-particle access of pre-grid quantities
     
   } else if (strcmp(word,"grid2part") == 0) {
     if (narg != 1)

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -2232,7 +2232,7 @@ double Variable::evaluate(char *str, Tree **tree)
 
   if (nopstack) error->all(FLERR,"Invalid syntax in variable formula");
 
-  // for particle-style variable, return remaining tree
+  // for particle-style, grid-style, or surf-style variable, return remaining tree
   // for equal-style variable, return remaining arg
 
   if (tree) {

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -60,18 +60,18 @@ enum{PARTICLE_CUSTOM,GRID_CUSTOM,SURF_CUSTOM};
 
 // customize by adding a function
 // if add before OR,
-// also set precedence level in constructor and precedence length in *.h
+//   also set precedence level in constructor and precedence length in *.h
 
 enum{DONE,ADD,SUBTRACT,MULTIPLY,DIVIDE,CARAT,MODULO,UNARY,
      NOT,EQ,NE,LT,LE,GT,GE,AND,OR,
      SQRT,EXP,LN,LOG,ABS,SIN,COS,TAN,ASIN,ACOS,ATAN,ATAN2,ERF,
      RANDOM,NORMAL,CEIL,FLOOR,ROUND,RAMP,STAGGER,LOGFREQ,STRIDE,
      VDISPLACE,SWIGGLE,CWIGGLE,
-     VALUE,ARRAY,ARRAYINT,PARTARRAYDOUBLE,PARTARRAYINT,SPECARRAY};
+     VALUE,ARRAY,ARRAYINT,PARTARRAYDOUBLE,PARTARRAYINT,SPECARRAY,PARTGRIDARRAY};
 
 // customize by adding a special function
 
-enum{SUM,XMIN,XMAX,AVE,TRAP,SLOPE};
+enum{SUM,XMIN,XMAX,AVE,TRAP,SLOPE,GRID2PART};
 
 #define INVOKED_SCALAR 1
 #define INVOKED_VECTOR 2
@@ -1339,7 +1339,7 @@ double Variable::evaluate(char *str, Tree **tree)
         // c_ID[i] = vector from per-grid array
         // if compute sets post_process_grid_flag:
         //   then values are in computes's vector_grid,
-        //   must store them locally via add_vector()
+        //   must store them locally via add_storage()
         //   since compute's vector_grid will be overwritten
         //   if this variable accesses multiple columns from compute's array
 
@@ -2720,6 +2720,10 @@ double Variable::eval_tree(Tree *tree, int i)
   if (tree->type == SPECARRAY)
     return *((double *)
              &tree->carray[particle->particles[i].ispecies*tree->nstride]);
+  if (tree->type == PARTGRIDARRAY) {
+    int icell = particle->particles[i].icell;
+    return tree->array[icell*tree->nstride];
+  }
 
   if (tree->type == ADD)
     return eval_tree(tree->left,i) + eval_tree(tree->right,i);
@@ -3436,7 +3440,7 @@ int Variable::math_function(char *word, char *contents, Tree **tree,
    contents = str between parentheses with one,two,three args
    return 0 if not a match, 1 if successfully processed
    customize by adding a special function:
-     sum(x),min(x),max(x),ave(x),trap(x),slope(x),next(x)
+     sum(x),min(x),max(x),ave(x),trap(x),slope(x),next(x),grid2part(x)
 ------------------------------------------------------------------------- */
 
 int Variable::special_function(char *word, char *contents, Tree **tree,
@@ -3449,7 +3453,7 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
 
   if (strcmp(word,"sum") && strcmp(word,"min") && strcmp(word,"max") &&
       strcmp(word,"ave") && strcmp(word,"trap") && strcmp(word,"slope") &&
-      strcmp(word,"next"))
+      strcmp(word,"next") && strcmp(word,"grid2part"))
     return 0;
 
   // parse contents for arg1,arg2,arg3 separated by commas
@@ -3499,6 +3503,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
     if (narg != 1)
       error->all(FLERR,"Invalid special function in variable formula");
 
+    // compute that produces global vector or array
+
     Compute *compute = NULL;
     Fix *fix = NULL;
     int index,nvec,nstride;
@@ -3539,6 +3545,8 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
         nvec = compute->size_array_rows;
         nstride = compute->size_array_cols;
       } else error->all(FLERR,"Mismatched compute in variable formula");
+
+    // fix that produces global vector or array
 
     } else if (strstr(arg1,"f_") == arg1) {
       ptr1 = strchr(arg1,'[');
@@ -3673,6 +3681,142 @@ int Variable::special_function(char *word, char *contents, Tree **tree,
       } else argstack[nargstack++] = value;
 
     } else error->all(FLERR,"Invalid variable style in special function next");
+
+  // special function that allows per-particle access of grid quantities
+    
+  } else if (strcmp(word,"grid2part") == 0) {
+    if (narg != 1)
+      error->all(FLERR,"Invalid special function in variable formula");
+
+    if (tree == NULL || treestyle != PARTICLE)
+      error->all(FLERR,"Variable grid2part() can only be used by particle-style variable");
+    
+    Compute *compute = NULL;
+    Fix *fix = NULL;
+    int index,nvec,nstride;
+
+    // compute that produces per-grid vector or array
+    
+    if (strstr(arg1,"c_") == arg1) {
+      ptr1 = strchr(arg1,'[');
+      if (ptr1) {
+        ptr2 = ptr1;
+        index = int_between_brackets(ptr2,0);
+        *ptr1 = '\0';
+      } else index = 0;
+
+      int icompute = modify->find_compute(&arg1[2]);
+      if (icompute < 0)
+        error->all(FLERR,"Invalid compute ID in variable formula");
+      compute = modify->compute[icompute];
+
+      if (!compute->per_grid_flag)
+        error->all(FLERR,"Variable grid2part() arg is not a per-grid compute");
+      
+      if (index == 0 && compute->size_per_grid_cols == 0) {
+        if (!compute->first_init)
+          error->all(FLERR,"Variable formula compute cannot be invoked"
+                     " before initialized");
+        if (!(compute->invoked_flag & INVOKED_PER_GRID)) {
+          compute->compute_per_grid();
+          compute->invoked_flag |= INVOKED_PER_GRID;
+        }
+
+        if (compute->post_process_grid_flag)
+          compute->post_process_grid(0,1,NULL,NULL,NULL,1);
+        else if (compute->post_process_isurf_grid_flag)
+          compute->post_process_isurf_grid();
+       
+        Tree *newtree = new Tree();
+        newtree->type = PARTGRIDARRAY;
+        newtree->array = compute->vector_grid;
+        newtree->nstride = 1;
+        newtree->selfalloc = 0;
+        newtree->left = newtree->middle = newtree->right = NULL;
+        treestack[ntreestack++] = newtree;
+
+      } else if (index && compute->size_per_grid_cols != 0) {
+
+        if (index > compute->size_per_grid_cols)
+          error->all(FLERR,"Variable formula compute array "
+                       "is accessed out-of-range");
+        if (!compute->first_init)
+          error->all(FLERR,"Variable formula compute cannot be invoked"
+                     " before initialized");
+        if (!(compute->invoked_flag & INVOKED_PER_GRID)) {
+          compute->compute_per_grid();
+          compute->invoked_flag |= INVOKED_PER_GRID;
+        }
+
+        if (compute->post_process_grid_flag)
+          compute->post_process_grid(index,1,NULL,NULL,NULL,1);
+        else if (compute->post_process_isurf_grid_flag)
+          compute->post_process_isurf_grid();
+
+        // if compute sets post_process_grid_flag:
+        //   then values are in computes's vector_grid,
+        //   must store them locally via add_storage()
+        //   since compute's vector_grid will be overwritten
+        //   if this variable accesses multiple columns from compute's array
+
+        Tree *newtree = new Tree();
+        newtree->type = PARTGRIDARRAY;
+        if (compute->post_process_grid_flag) {
+          newtree->array = add_storage(compute->vector_grid);
+          newtree->nstride = 1;
+        } else {
+          newtree->array = &compute->array_grid[0][index-1];
+          newtree->nstride = compute->size_per_grid_cols;
+        }
+        newtree->selfalloc = 0;
+        newtree->left = newtree->middle = newtree->right = NULL;
+        treestack[ntreestack++] = newtree;
+        
+      } else error->all(FLERR,"Mismatched compute in variable formula");
+
+    // fix that produces per-grid vector or array
+
+    } else if (strstr(arg1,"f_") == arg1) {
+      ptr1 = strchr(arg1,'[');
+      if (ptr1) {
+        ptr2 = ptr1;
+        index = int_between_brackets(ptr2,0);
+        *ptr1 = '\0';
+      } else index = 0;
+
+      int ifix = modify->find_fix(&arg1[2]);
+      if (ifix < 0) error->all(FLERR,"Invalid fix ID in variable formula");
+      fix = modify->fix[ifix];
+      
+      if (!fix->per_grid_flag)
+        error->all(FLERR,"Variable grid2part() arg is not a per-grid fix");
+      if (update->runflag > 0 && update->ntimestep % fix->per_grid_freq)
+        error->all(FLERR,"Fix in variable not computed at compatible time");
+
+      if (index == 0 && fix->size_per_grid_cols == 0) {
+        Tree *newtree = new Tree();
+        newtree->type = PARTGRIDARRAY;
+        newtree->array = fix->vector_grid;
+        newtree->nstride = 1;
+        newtree->selfalloc = 0;
+        newtree->left = newtree->middle = newtree->right = NULL;
+        treestack[ntreestack++] = newtree;
+        
+      } else if (index && fix->size_per_grid_cols != 0) {
+        if (index > fix->size_per_grid_cols)
+          error->all(FLERR,"Variable formula fix array is accessed out-of-range");
+
+        Tree *newtree = new Tree();
+        newtree->type = ARRAY;
+        newtree->array = &fix->array_grid[0][index-1];
+        newtree->nstride = fix->size_per_grid_cols;
+        newtree->selfalloc = 0;
+        newtree->left = newtree->middle = newtree->right = NULL;
+        treestack[ntreestack++] = newtree;
+        
+      } else error->all(FLERR,"Mismatched compute in variable formula");
+
+    } else error->all(FLERR,"Invalid variable style in special function grid2part()");
   }
 
   delete [] arg1;
@@ -3864,6 +4008,7 @@ char *Variable::find_next_comma(char *str)
 
 /* ----------------------------------------------------------------------
    copy of cvec in local storage
+   used for per-grid vector which could otherwise be overidden
    return local ptr to copied vec
 ------------------------------------------------------------------------- */
 


### PR DESCRIPTION
## Purpose

Enable a particle-style variable to use per-grid quantities in its formula.  This is done by adding a grid2part() special function which takes a single argument, which is reference to a per-grid compute or fix.  When the formula is evaluated for each particle, the grid cell the particle is in is used to access a per-grid quantity.

Example:
variable  csq particle "vx*vx + vy*vy + vz*vz"
compute therm thermal/grid all all temp press
variable csq_norm particle v_csq/grid2part(c_therm[1])

Csq_norm will calculate the KE of each particle normalized by the thermal temperature of the particles in the grid cell the particle is in.

Also added the keyword cellID to particle dump files, so the owning grid cell for each particle can be output if desired.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


