### PR TITLE
Bug fix for new grid2part() variable function

### DIFF
--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -769,6 +769,7 @@ void Variable::compute_particle(int ivar, double *result,
     error->all(FLERR,"Variable has circular dependency");
   eval_in_progress[ivar] = 1;
 
+  nvec_storage = 0;
   treestyle = PARTICLE;
   evaluate(data[ivar][0],&tree);
   collapse_tree(tree);


### PR DESCRIPTION
## Purpose

An initialization was missing from this recently merged grid2part() function.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


