### PR TITLE
Enable read of surfs after particles are created

### DIFF
--- a/src/read_surf.cpp
+++ b/src/read_surf.cpp
@@ -387,7 +387,7 @@ void ReadSurf::command(int narg, char **arg)
 
     for (int icell = 0; icell < nglocal; icell++) {
       if (cinfo[icell].type == INSIDE) {
-        if (partflag == KEEP)
+        if (partflag == KEEP && cinfo[icell].count > 0)
           error->one(FLERR,"Particles are inside new surfaces");
         if (cinfo[icell].count) delflag = 1;
         particle->remove_all_from_cell(cinfo[icell].first);


### PR DESCRIPTION
## Purpose
If a surface was read after particles have been created and the `particle keep` flag was turned on to leave all particles in place, the code would throw an error. It turns out, if any grid cells were completely inside the surface then the error was produced, even if no particles were inside that cell. 

## Author(s)

Zak Echo

## Backward Compatibility

There should not be any effect on existing input decks unless they were hitting this error, in which case they hopefully now work.

## Implementation Notes

This commit simply adds a condition to the error that there must be particles inside the cell.

I used a cube surface in a 10x10x10 grid. I emitted from the surface of the cube, then after a few hundred timesteps I removed the cube and reread the surface file back in.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [X] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included - N/A
- [ ] One or more example input decks are included - N/A
- [X] The source code follows the SPARTA formatting guidelines



