### PR TITLE
Add fix halt, copied and adapted from LAMMPS

### DIFF
--- a/doc/fix_halt.html
+++ b/doc/fix_halt.html
@@ -79,6 +79,14 @@ stop the run after an hour of walltime:
 <PRE>variable cpu equal cpu
 fix 10 halt 10 v_cpu > 3600.0 
 </PRE>
+<P>The commands above apply only to the time spent in the current run
+command. If multiple run commands are used in the same input script,
+one can also stop the run after a predetermined amount of <I>total</I>
+walltime:
+</P>
+<PRE>variable wall equal wall
+fix 10 halt 10 v_wall > 3600.0 
+</PRE>
 <P>Similarly one can stop the run after a predetermined amount of
 simulation time, which is useful when using a <A HREF = "fix_dt_reset.html">variable
 timestep</A>:
@@ -134,7 +142,9 @@ files</A>.
 
 <P><B>Restrictions:</B> none
 </P>
-<P><B>Related commands:</B> none
+<P><B>Related commands:</B>
+</P>
+<P><A HREF = "run.html">run</A>
 </P>
 <P><B>Default:</B>
 </P>

--- a/doc/fix_halt.html
+++ b/doc/fix_halt.html
@@ -71,13 +71,20 @@ properties, grid properties, surface properties, global values
 calculated by a <A HREF = "compute.html">compute</A> or <A HREF = "fix.html">fix</A>, or
 references to other <A HREF = "varible.html">variables</A>. Thus they are a very
 general means of computing some attribute of the current system.  For
-example, the following two versions of a fix halt command will do the
-same thing:
+example, the following two versions of a fix halt command will both
+stop the run after an hour of walltime:
 </P>
 <PRE>fix 10 halt 10 tlimit > 3600.0 
 </PRE>
 <PRE>variable cpu equal cpu
 fix 10 halt 10 v_cpu > 3600.0 
+</PRE>
+<P>Similarly one can stop the run after a predetermined amount of
+simulation time, which is useful when using a <A HREF = "fix_dt_reset.html">variable
+timestep</A>:
+</P>
+<PRE>variable time equal time
+fix 10 halt 10 v_time > 1.0e-3 
 </PRE>
 <P>The choice of operators listed above are the usual comparison
 operators. The XOR operation (exclusive or) is also included as "|^".

--- a/doc/fix_halt.html
+++ b/doc/fix_halt.html
@@ -1,0 +1,136 @@
+<HTML>
+<CENTER><A HREF = "https://sparta.github.io">SPARTA WWW Site</A> - <A HREF = "Manual.html">SPARTA Documentation</A> - <A HREF = "Section_commands.html#comm">SPARTA Commands</A> 
+</CENTER>
+
+
+
+
+
+
+<HR>
+
+<H3>fix halt command 
+</H3>
+<P><B>Syntax:</B>
+</P>
+<PRE>fix ID halt N attribute operator avalue keyword value ... 
+</PRE>
+<UL><LI>ID is documented in <A HREF = "fix.html">fix</A> command 
+
+<LI>halt = style name of this fix command 
+
+<LI>N = check halt condition every N timesteps 
+
+<LI>attribute = <I>tlimit</I> or v_name 
+
+<PRE>  tlimit = elapsed CPU time (in seconds)
+  v_name = name of <A HREF = "variable.html">equal-style variable</A> 
+</PRE>
+<LI>operator = "<" or "<=" or ">" or ">=" or "==" or "!=" or "|^" 
+
+<LI>avalue = numeric value to compare attribute to 
+
+<LI>zero or more keyword/value pairs may be appended 
+
+<LI>keyword = <I>error</I> or <I>message</I> 
+
+<PRE>  error value = <I>hard</I> or <I>soft</I> or <I>continue</I>
+  message value = <I>yes</I> or <I>no</I> 
+</PRE>
+
+</UL>
+<P><B>Examples:</B>
+</P>
+<PRE>fix 10 halt 10 tlimit > 3600.0
+fix 10 halt 10 v_myCheck != 0 error soft 
+</PRE>
+<P><B>Description:</B>
+</P>
+<P>Check a condition every N steps during a simulation run. N must be
+>=1. If the condition is met, exit the run.
+</P>
+<P>The specified <I>attribute</I> can be one of the options listed above,
+namely <I>tlimit</I>, or an <A HREF = "variable.html">equal-style variable</A> referenced
+as <I>v_name</I>, where "name" is the name of a variable that has been
+defined previously in the input script.
+</P>
+<P>The <I>tlimit</I> attribute queries the elapsed CPU time (in seconds) since
+the current run began, and sets <I>attribute</I> to that value. The clock
+starts at the beginning of the current run (not when the fix command
+is specified), so that any setup time for the run is not included in
+the elapsed time. The timer invocation and syncing across all
+processors (via MPI_Allreduce) is performed (typically) only a small
+number of times and the elapsed times are used to predict when the
+end-of-the-run will be.  This can be useful when performing benchmark
+calculations for a desired length of time with minimal overhead.
+</P>
+<P>Equal-style variables evaluate to a numeric value. See the
+<A HREF = "variable.html">variable</A> command for a description. They calculate
+formulas which can involve mathematical operations, particle
+properties, grid properties, surface properties, global values
+calculated by a <A HREF = "compute.html">compute</A> or <A HREF = "fix.html">fix</A>, or
+references to other <A HREF = "varible.html">variables</A>. Thus they are a very
+general means of computing some attribute of the current system.  For
+example, the following two versions of a fix halt command will do the
+same thing:
+</P>
+<PRE>fix 10 halt 10 tlimit > 3600.0 
+</PRE>
+<PRE>variable cpu equal cpu
+fix 10 halt 10 v_cpu > 3600.0 
+</PRE>
+<P>The choice of operators listed above are the usual comparison
+operators. The XOR operation (exclusive or) is also included as "|^".
+In this context, XOR means that if either the attribute or avalue is
+0.0 and the other is non-zero, then the result is "true". Otherwise it
+is "false".
+</P>
+<P>The specified <I>avalue</I> must be a numeric value.
+</P>
+<P>The optional <I>error</I> keyword determines how the current run is halted.
+If its value is <I>hard</I>, then SPARTA will stop with an error message.
+</P>
+<P>If its value is <I>soft</I>, SPARTA will exit the current run, but continue
+to execute subsequent commands in the input script. However,
+additional <A HREF = "run.html">run</A> commands will be skipped. For example, this
+allows a script to output the current state of the system, e.g. via a
+<A HREF = "write_grid.html">write_grid</A> or <A HREF = "write_restart.html">write_restart</A>
+command.
+</P>
+<P>If its value is <I>continue</I>, the behavior is the same as for soft,
+except subsequent run commands are executed. This allows your script
+to remedy the condition that triggered the halt, if necessary.  Note
+that you may wish use the <A HREF = "unfix.html">unfix</A> command on the fix halt
+ID, so that the same condition is not immediately triggered in a
+subsequent run.
+</P>
+<HR>
+
+<P>The optional <I>message</I> keyword determines whether a message is printed
+to the screen and logfile when the halt condition is triggered. If
+<I>message</I> is set to <I>yes</I>, a one line message with the values that
+triggered the halt is printed. If <I>message</I> is set to <I>no</I>, no message
+is printed; the run simply exits. The latter may be desirable for
+post-processing tools that extract statistical information from log
+files.
+</P>
+<HR>
+
+<P><B>Restart, output info:</B>
+</P>
+<P>No information about this fix is written to <A HREF = "restart.html">binary restart
+files</A>.
+</P>
+<P>This fix produces no output.
+</P>
+<HR>
+
+<P><B>Restrictions:</B> none
+</P>
+<P><B>Related commands:</B> none
+</P>
+<P><B>Default:</B>
+</P>
+<P>The option defaults are error = soft and message = yes.
+</P>
+</HTML>

--- a/doc/fix_halt.txt
+++ b/doc/fix_halt.txt
@@ -66,6 +66,14 @@ fix 10 halt 10 tlimit > 3600.0 :pre
 variable cpu equal cpu
 fix 10 halt 10 v_cpu > 3600.0 :pre
 
+The commands above apply only to the time spent in the current run
+command. If multiple run commands are used in the same input script,
+one can also stop the run after a predetermined amount of {total}
+walltime:
+
+variable wall equal wall
+fix 10 halt 10 v_wall > 3600.0 :pre
+
 Similarly one can stop the run after a predetermined amount of
 simulation time, which is useful when using a "variable
 timestep"_fix_dt_reset.html:
@@ -121,7 +129,9 @@ This fix produces no output.
 
 [Restrictions:] none
 
-[Related commands:] none
+[Related commands:]
+
+"run"_run.html
 
 [Default:]
 

--- a/doc/fix_halt.txt
+++ b/doc/fix_halt.txt
@@ -1,0 +1,121 @@
+"SPARTA WWW Site"_sws - "SPARTA Documentation"_sd - "SPARTA Commands"_sc :c
+ 
+:link(sws,https://sparta.github.io)
+:link(sd,Manual.html)
+:link(sc,Section_commands.html#comm)
+
+:line
+
+fix halt command :h3
+
+[Syntax:]
+
+fix ID halt N attribute operator avalue keyword value ... :pre
+
+ID is documented in "fix"_fix.html command :ulb,l
+halt = style name of this fix command :l
+N = check halt condition every N timesteps :l
+attribute = {tlimit} or v_name :l
+  tlimit = elapsed CPU time (in seconds)
+  v_name = name of "equal-style variable"_variable.html :pre
+operator = "<" or "<=" or ">" or ">=" or "==" or "!=" or "|^" :l
+avalue = numeric value to compare attribute to :l
+zero or more keyword/value pairs may be appended :l
+keyword = {error} or {message} :l
+  error value = {hard} or {soft} or {continue}
+  message value = {yes} or {no} :pre
+:ule
+
+[Examples:]
+
+fix 10 halt 10 tlimit > 3600.0
+fix 10 halt 10 v_myCheck != 0 error soft :pre
+
+[Description:]
+
+Check a condition every N steps during a simulation run. N must be
+>=1. If the condition is met, exit the run.
+
+The specified {attribute} can be one of the options listed above,
+namely {tlimit}, or an "equal-style variable"_variable.html referenced
+as {v_name}, where "name" is the name of a variable that has been
+defined previously in the input script.
+
+The {tlimit} attribute queries the elapsed CPU time (in seconds) since
+the current run began, and sets {attribute} to that value. The clock
+starts at the beginning of the current run (not when the fix command
+is specified), so that any setup time for the run is not included in
+the elapsed time. The timer invocation and syncing across all
+processors (via MPI_Allreduce) is performed (typically) only a small
+number of times and the elapsed times are used to predict when the
+end-of-the-run will be.  This can be useful when performing benchmark
+calculations for a desired length of time with minimal overhead.
+
+Equal-style variables evaluate to a numeric value. See the
+"variable"_variable.html command for a description. They calculate
+formulas which can involve mathematical operations, particle
+properties, grid properties, surface properties, global values
+calculated by a "compute"_compute.html or "fix"_fix.html, or
+references to other "variables"_varible.html. Thus they are a very
+general means of computing some attribute of the current system.  For
+example, the following two versions of a fix halt command will do the
+same thing:
+
+fix 10 halt 10 tlimit > 3600.0 :pre
+
+variable cpu equal cpu
+fix 10 halt 10 v_cpu > 3600.0 :pre
+
+The choice of operators listed above are the usual comparison
+operators. The XOR operation (exclusive or) is also included as "|^".
+In this context, XOR means that if either the attribute or avalue is
+0.0 and the other is non-zero, then the result is "true". Otherwise it
+is "false".
+
+The specified {avalue} must be a numeric value.
+
+The optional {error} keyword determines how the current run is halted.
+If its value is {hard}, then SPARTA will stop with an error message.
+
+If its value is {soft}, SPARTA will exit the current run, but continue
+to execute subsequent commands in the input script. However,
+additional "run"_run.html commands will be skipped. For example, this
+allows a script to output the current state of the system, e.g. via a
+"write_grid"_write_grid.html or "write_restart"_write_restart.html
+command.
+
+If its value is {continue}, the behavior is the same as for soft,
+except subsequent run commands are executed. This allows your script
+to remedy the condition that triggered the halt, if necessary.  Note
+that you may wish use the "unfix"_unfix.html command on the fix halt
+ID, so that the same condition is not immediately triggered in a
+subsequent run.
+
+:line
+
+The optional {message} keyword determines whether a message is printed
+to the screen and logfile when the halt condition is triggered. If
+{message} is set to {yes}, a one line message with the values that
+triggered the halt is printed. If {message} is set to {no}, no message
+is printed; the run simply exits. The latter may be desirable for
+post-processing tools that extract statistical information from log
+files.
+
+:line
+
+[Restart, output info:]
+
+No information about this fix is written to "binary restart
+files"_restart.html.
+
+This fix produces no output.
+
+:line
+
+[Restrictions:] none
+
+[Related commands:] none
+
+[Default:]
+
+The option defaults are error = soft and message = yes.

--- a/doc/fix_halt.txt
+++ b/doc/fix_halt.txt
@@ -58,13 +58,20 @@ properties, grid properties, surface properties, global values
 calculated by a "compute"_compute.html or "fix"_fix.html, or
 references to other "variables"_varible.html. Thus they are a very
 general means of computing some attribute of the current system.  For
-example, the following two versions of a fix halt command will do the
-same thing:
+example, the following two versions of a fix halt command will both
+stop the run after an hour of walltime:
 
 fix 10 halt 10 tlimit > 3600.0 :pre
 
 variable cpu equal cpu
 fix 10 halt 10 v_cpu > 3600.0 :pre
+
+Similarly one can stop the run after a predetermined amount of
+simulation time, which is useful when using a "variable
+timestep"_fix_dt_reset.html:
+
+variable time equal time
+fix 10 halt 10 v_time > 1.0e-3 :pre
 
 The choice of operators listed above are the usual comparison
 operators. The XOR operation (exclusive or) is also included as "|^".

--- a/doc/run.html
+++ b/doc/run.html
@@ -15,11 +15,11 @@
 </P>
 <PRE>run N keyword values ... 
 </PRE>
-<UL><LI>value = # of integer timesteps N or ending time (see <I>time</I> keyword below)  
+<UL><LI>value = # of integer timesteps N 
 
 <LI>zero or more keyword/value pairs may be appended 
 
-<LI>keyword = <I>upto</I> or <I>start</I> or <I>stop</I> or <I>pre</I> or <I>post</I> or <I>every</I> or <I>time</I> 
+<LI>keyword = <I>upto</I> or <I>start</I> or <I>stop</I> or <I>pre</I> or <I>post</I> or <I>every</I> 
 
 <PRE>  <I>upto</I> value = none
   <I>start</I> value = N1
@@ -31,8 +31,7 @@
   <I>every</I> values = M c1 c2 ...
     M = break the run into M-timestep segments and invoke one or more commands between each segment
     c1,c2,...,cN = one or more SPARTA commands, each enclosed in quotes
-    c1 = NULL means no command will be invoked
-  <I>time</I> value = none 
+    c1 = NULL means no command will be invoked 
 </PRE>
 
 </UL>
@@ -43,15 +42,11 @@ run 1000000 upto
 run 100 start 0 stop 1000
 run 1000 pre no post yes
 run 100000 start 0 stop 1000000 every 1000 "print 'Temp = $t'"
-run 100000 every 1000 NULL
-run 5.7 time
-run 5.7 time every 100 NULL 
+run 100000 every 1000 NULL 
 </PRE>
 <P><B>Description:</B>
 </P>
-<P>Run or continue a simulation for a specified number of timesteps.  If
-the <I>time</I> keyword is used, run for a specified amount of physical
-time.
+<P>Run or continue a simulation for a specified number of timesteps.
 </P>
 <P>A value of N = 0 is acceptable; only the statistics of the system are
 computed and printed without taking a timestep.
@@ -64,9 +59,7 @@ machine that allocates chunks of time and terminate your job when time
 is exceeded.  If you need to restart your script multiple times
 (reading in the last restart file), you can keep restarting your
 script with the same run command until the simulation finally
-completes.  If the <I>time</I> keyword is used, the <I>upto</I> keyword is not
-needed since the time option runs the simulation "up to" the specified
-time.
+completes.
 </P>
 <P>The <I>start</I> or <I>stop</I> keywords can be used if multiple runs are being
 performed and you want a <A HREF = "variable.html">variable</A> or <A HREF = "fix.html">fix</A>
@@ -177,22 +170,8 @@ command:
 run will print the full timing summary, but these operations will be
 skipped for intermediate runs.
 </P>
-<P>If the <I>time</I> keyword is used in conjunction with the <I>every</I> keyword,
-the shorter runs of M steps each are performed until the specified end
-time is reached, possibly reducing the number of steps in the last run.
-</P>
-<P>IMPORTANT NOTE: You might hope to specify a command that exits the run
-by jumping out of the loop, e.g.
-</P>
-<PRE>compute t temp
-variable T equal c_t
-run 10000 every 100 "if '$T < 300.0' then 'jump SELF afterrun'" 
-</PRE>
-<P>Unfortunately this will not currently work.  The run command simply
-executes each command one at a time each time it pauses, then
-continues the run.  You can replace the jump command with a simple
-<A HREF = "quit.html">quit</A> command and cause SPARTA to exit during the
-middle of a run when the condition is met.
+<P>If you want SPARTA to exit early during the middle of a run when a
+condition is met, use <A HREF = "fix_halt.html">fix halt</A>.
 </P>
 <P><B>Restrictions:</B>
 </P>
@@ -201,7 +180,9 @@ integer, so you are limited to slightly more than 2 billion steps
 (2^31) in a single run.  However, you can perform successive runs to
 run a simulation for any number of steps (ok, up to 2^63 steps).
 </P>
-<P><B>Related commands:</B> none
+<P><B>Related commands:</B>
+</P>
+<P><A HREF = "fix_halt.html">fix halt</A>
 </P>
 <P><B>Default:</B>
 </P>

--- a/doc/run.txt
+++ b/doc/run.txt
@@ -12,9 +12,9 @@ run command :h3
 
 run N keyword values ... :pre
 
-value = # of integer timesteps N or ending time (see {time} keyword below)  :ulb,l
+value = # of integer timesteps N :ulb,l
 zero or more keyword/value pairs may be appended :l
-keyword = {upto} or {start} or {stop} or {pre} or {post} or {every} or {time} :l
+keyword = {upto} or {start} or {stop} or {pre} or {post} or {every} :l
   {upto} value = none
   {start} value = N1
     N1 = timestep at which 1st run started
@@ -25,8 +25,7 @@ keyword = {upto} or {start} or {stop} or {pre} or {post} or {every} or {time} :l
   {every} values = M c1 c2 ...
     M = break the run into M-timestep segments and invoke one or more commands between each segment
     c1,c2,...,cN = one or more SPARTA commands, each enclosed in quotes
-    c1 = NULL means no command will be invoked
-  {time} value = none :pre
+    c1 = NULL means no command will be invoked :pre
 :ule
 
 [Examples:]
@@ -36,15 +35,11 @@ run 1000000 upto
 run 100 start 0 stop 1000
 run 1000 pre no post yes
 run 100000 start 0 stop 1000000 every 1000 "print 'Temp = $t'"
-run 100000 every 1000 NULL
-run 5.7 time
-run 5.7 time every 100 NULL :pre
+run 100000 every 1000 NULL :pre
 
 [Description:]
 
-Run or continue a simulation for a specified number of timesteps.  If
-the {time} keyword is used, run for a specified amount of physical
-time.
+Run or continue a simulation for a specified number of timesteps.
 
 A value of N = 0 is acceptable; only the statistics of the system are
 computed and printed without taking a timestep.
@@ -57,9 +52,7 @@ machine that allocates chunks of time and terminate your job when time
 is exceeded.  If you need to restart your script multiple times
 (reading in the last restart file), you can keep restarting your
 script with the same run command until the simulation finally
-completes.  If the {time} keyword is used, the {upto} keyword is not
-needed since the time option runs the simulation "up to" the specified
-time.
+completes.
 
 The {start} or {stop} keywords can be used if multiple runs are being
 performed and you want a "variable"_variable.html or "fix"_fix.html
@@ -170,22 +163,8 @@ If the {pre} and {post} options are set to "no" when used with the
 run will print the full timing summary, but these operations will be
 skipped for intermediate runs.
 
-If the {time} keyword is used in conjunction with the {every} keyword,
-the shorter runs of M steps each are performed until the specified end
-time is reached, possibly reducing the number of steps in the last run.
-
-IMPORTANT NOTE: You might hope to specify a command that exits the run
-by jumping out of the loop, e.g.
-
-compute t temp
-variable T equal c_t
-run 10000 every 100 "if '$T < 300.0' then 'jump SELF afterrun'" :pre
-
-Unfortunately this will not currently work.  The run command simply
-executes each command one at a time each time it pauses, then
-continues the run.  You can replace the jump command with a simple
-"quit"_quit.html command and cause SPARTA to exit during the
-middle of a run when the condition is met.
+If you want SPARTA to exit early during the middle of a run when a
+condition is met, use "fix halt"_fix_halt.html.
 
 [Restrictions:]
 
@@ -194,7 +173,9 @@ integer, so you are limited to slightly more than 2 billion steps
 (2^31) in a single run.  However, you can perform successive runs to
 run a simulation for any number of steps (ok, up to 2^63 steps).
 
-[Related commands:] none
+[Related commands:]
+
+"fix halt"_fix_halt.html
 
 [Default:]
 

--- a/src/fix.cpp
+++ b/src/fix.cpp
@@ -56,6 +56,7 @@ Fix::Fix(SPARTA *sparta, int, char **arg) : Pointers(sparta)
 
   START_OF_STEP = 1;
   END_OF_STEP = 2;
+  POST_RUN = 3;
 
   kokkos_flag = 0;
   copy = uncopy = copymode = 0;

--- a/src/fix.h
+++ b/src/fix.h
@@ -62,7 +62,7 @@ class Fix : protected Pointers {
   int per_grid_field;            // 0/1 if produces per-grid external field
   int field_active[3];           // 0/1 for active x,y,z components of ext field
 
-  int START_OF_STEP,END_OF_STEP;    // mask settings
+  int START_OF_STEP,END_OF_STEP,POST_RUN;    // mask settings
 
   int kokkos_flag;              // 0/1 if Kokkos fix
   int copy,uncopy,copymode;     // used by Kokkos, prevent deallocation of
@@ -81,6 +81,7 @@ class Fix : protected Pointers {
 
   virtual void start_of_step() {}
   virtual void end_of_step() {}
+  virtual void post_run() {}
   virtual void update_custom(int, double, double, double, double *) {}
   virtual void gas_react(int) {}
   virtual void surf_react(Particle::OnePart *, int &, int &) {}

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -13,8 +13,9 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   File copied and adapted from LAMMPS (lammps.org), October 2024
-   Author: Axel Kohlmeyer (Temple U)
+   File adapted from LAMMPS (https://www.lammps.org), October 2024
+   Ported to SPARTA by: Stan Moore (SNL)
+   Original Author: Axel Kohlmeyer (Temple U)
 ------------------------------------------------------------------------- */
 
 #include "fix_halt.h"

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -1,0 +1,257 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   File copied and adapted from LAMMPS (lammps.org), October 2024
+   Author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "fix_halt.h"
+
+#include "comm.h"
+#include "error.h"
+#include "input.h"
+#include "modify.h"
+#include "timer.h"
+#include "update.h"
+#include "utils.h"
+#include "variable.h"
+
+#include <cmath>
+#include <cstring>
+
+using namespace SPARTA_NS;
+
+enum { TLIMIT, VARIABLE };
+enum { LT, LE, GT, GE, EQ, NEQ, XOR };
+enum { HARD, SOFT, CONTINUE };
+enum { NOMSG = 0, YESMSG = 1 };
+
+/* ---------------------------------------------------------------------- */
+
+FixHalt::FixHalt(SPARTA *sparta, int narg, char **arg) :
+    Fix(sparta, narg, arg), idvar(nullptr)
+{
+  if (narg < 6) utils::missing_cmd_args(FLERR, "fix halt", error);
+  nevery = utils::inumeric(FLERR, arg[2], false, sparta);
+  if (nevery <= 0) error->all(FLERR, "Illegal fix halt command: nevery must be > 0");
+
+  // comparison args
+
+  idvar = nullptr;
+  int iarg = 3;
+
+  if (strcmp(arg[iarg], "tlimit") == 0) {
+    attribute = TLIMIT;
+  } else {
+    if (!utils::strmatch(arg[iarg],"^v_")) {
+      char msg[128];
+      sprintf(msg, "Invalid fix halt attribute %s", arg[iarg]);
+      error->all(FLERR, msg);
+    }
+
+    char* str = arg[iarg];
+    attribute = VARIABLE;
+    int n = strlen(&str[2]) + 1;
+    idvar = new char[n];
+    strcpy(idvar,&str[2]);
+    ivar = input->variable->find(idvar);
+
+    if (ivar < 0) error->all(FLERR, "Could not find fix halt variable name");
+    if (input->variable->equal_style(ivar) == 0)
+      error->all(FLERR, "Fix halt variable is not equal-style variable");
+  }
+
+  // clang-format off
+  ++iarg;
+  if (strcmp(arg[iarg],"<") == 0) operation = LT;
+  else if (strcmp(arg[iarg],"<=") == 0) operation = LE;
+  else if (strcmp(arg[iarg],">") == 0) operation = GT;
+  else if (strcmp(arg[iarg],">=") == 0) operation = GE;
+  else if (strcmp(arg[iarg],"==") == 0) operation = EQ;
+  else if (strcmp(arg[iarg],"!=") == 0) operation = NEQ;
+  else if (strcmp(arg[iarg],"|^") == 0) operation = XOR;
+  else error->all(FLERR,"Invalid fix halt operator");
+
+  ++iarg;
+  value = utils::numeric(FLERR, arg[iarg], false, sparta);
+
+  // parse optional args
+
+  eflag = SOFT;
+  msgflag = YESMSG;
+  ++iarg;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg], "error") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "fix halt error", error);
+      if (strcmp(arg[iarg + 1], "hard") == 0) eflag = HARD;
+      else if (strcmp(arg[iarg + 1], "soft") == 0) eflag = SOFT;
+      else if (strcmp(arg[iarg + 1], "continue") == 0) eflag = CONTINUE;
+      else {
+        char msg[128];
+        sprintf(msg, "Unknown fix halt error condition %s", arg[iarg]);
+        error->all(FLERR, msg);
+      }
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "message") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "fix halt message", error);
+      msgflag = utils::logical(FLERR, arg[iarg + 1], false, sparta);
+      iarg += 2;
+    } else {
+      char msg[128];
+      sprintf(msg, "Unknown fix halt keyword %s", arg[iarg]);
+      error->all(FLERR, msg);
+    }
+  }
+  // clang-format on
+
+  // add nfirst to all computes that store invocation times
+  // since don't know a priori which are invoked via variables by this fix
+  // once in end_of_step() can set timestep for ones actually invoked
+
+  if (attribute == VARIABLE) {
+    const bigint nfirst = (update->ntimestep / nevery) * nevery + nevery;
+    modify->addstep_compute_all(nfirst);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixHalt::~FixHalt()
+{
+  delete[] idvar;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixHalt::setmask()
+{
+  int mask = 0;
+  mask |= END_OF_STEP;
+  mask |= POST_RUN;
+  return mask;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixHalt::init()
+{
+  // set ivar from current variable list
+
+  if (attribute == VARIABLE) {
+    ivar = input->variable->find(idvar);
+    char msg[128];
+    if (ivar < 0) {
+      sprintf(msg, "Could not find fix halt variable %s", idvar);
+      error->all(FLERR, msg);
+    }
+    if (input->variable->equal_style(ivar) == 0) {
+      sprintf(msg, "Fix halt variable %s is not equal-style variable", idvar);
+      error->all(FLERR, msg);
+    }
+  }
+
+  // settings used by TLIMIT
+
+  nextstep = (update->ntimestep / nevery) * nevery + nevery;
+  thisstep = -1;
+  tratio = 0.5;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixHalt::end_of_step()
+{
+  // variable evaluation may invoke computes so wrap with clear/add
+
+  double attvalue;
+
+  if (attribute == TLIMIT) {
+    if (update->ntimestep != nextstep) return;
+    attvalue = tlimit();
+  } else {
+    modify->clearstep_compute();
+    attvalue = input->variable->compute_equal(ivar);
+    modify->addstep_compute(update->ntimestep + nevery);
+  }
+
+  // ensure that the attribute is *exactly* the same on all ranks
+
+  MPI_Bcast(&attvalue, 1, MPI_DOUBLE, 0, world);
+
+  // check if halt is triggered, else just return
+
+  if (operation == LT) {
+    if (attvalue >= value) return;
+  } else if (operation == LE) {
+    if (attvalue > value) return;
+  } else if (operation == GT) {
+    if (attvalue <= value) return;
+  } else if (operation == GE) {
+    if (attvalue < value) return;
+  } else if (operation == EQ) {
+    if (attvalue != value) return;
+  } else if (operation == NEQ) {
+    if (attvalue == value) return;
+  } else if (operation == XOR) {
+    if ((attvalue == 0.0 && value == 0.0) || (attvalue != 0.0 && value != 0.0)) return;
+  }
+
+  // hard halt -> exit SPARTA
+  // soft/continue halt -> trigger timer to break from run loop
+  // print message with ID of fix halt in case multiple instances
+
+  char message[128];
+  sprintf(message, "Fix halt condition for fix-id %s met on step %ld with value %g",
+                                    id, update->ntimestep, attvalue);
+  if (eflag == HARD) {
+    error->all(FLERR, message);
+  } else if ((eflag == SOFT) || (eflag == CONTINUE)) {
+    if ((comm->me == 0) && (msgflag == YESMSG)) error->message(FLERR, message);
+    timer->force_timeout();
+  }
+}
+
+/* ----------------------------------------------------------------------
+   reset expired timer setting to original value, if requested
+------------------------------------------------------------------------- */
+
+void FixHalt::post_run()
+{
+  // continue halt -> subsequent runs are allowed
+
+  if (eflag == CONTINUE) timer->reset_timeout();
+}
+
+/* ----------------------------------------------------------------------
+   compute synced elapsed time
+   reset nextstep = estimate of timestep when run will end
+   first project to 1/2 the run time, thereafter to end of run
+------------------------------------------------------------------------- */
+
+double FixHalt::tlimit()
+{
+  double cpu = timer->elapsed(TIME_LOOP);
+  MPI_Bcast(&cpu, 1, MPI_DOUBLE, 0, world);
+
+  if (cpu < value) {
+    bigint elapsed = update->ntimestep - update->firststep;
+    bigint final = update->firststep + static_cast<bigint>(tratio * value / cpu * elapsed);
+    nextstep = (final / nevery) * nevery + nevery;
+    if (nextstep == update->ntimestep) nextstep += nevery;
+    tratio = 1.0;
+  }
+
+  return cpu;
+}

--- a/src/fix_halt.h
+++ b/src/fix_halt.h
@@ -13,8 +13,9 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   File copied and adapted from LAMMPS (lammps.org), October 2024
-   Author: Axel Kohlmeyer (Temple U)
+   File adapted from LAMMPS (https://www.lammps.org), October 2024
+   Ported to SPARTA by: Stan Moore (SNL)
+   Original Author: Axel Kohlmeyer (Temple U)
 ------------------------------------------------------------------------- */
 
 #ifdef FIX_CLASS

--- a/src/fix_halt.h
+++ b/src/fix_halt.h
@@ -1,0 +1,54 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   File copied and adapted from LAMMPS (lammps.org), October 2024
+   Author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifdef FIX_CLASS
+
+FixStyle(halt,FixHalt)
+
+#else
+
+#ifndef SPARTA_FIX_HALT_H
+#define SPARTA_FIX_HALT_H
+
+#include "fix.h"
+
+namespace SPARTA_NS {
+
+class FixHalt : public Fix {
+ public:
+  FixHalt(class SPARTA *, int, char **);
+  ~FixHalt() override;
+  int setmask() override;
+  void init() override;
+  void end_of_step() override;
+  void post_run() override;
+
+ private:
+  int attribute, operation, eflag, msgflag, ivar;
+  bigint nextstep, thisstep;
+  double value, tratio;
+  char *idvar;
+
+  double tlimit();
+};
+
+}    // namespace SPARTA_NS
+
+#endif
+#endif

--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -32,6 +32,7 @@ using namespace SPARTA_NS;
 
 #define START_OF_STEP  1
 #define END_OF_STEP    2
+#define POST_RUN       3
 
 /* ---------------------------------------------------------------------- */
 
@@ -158,6 +159,20 @@ void Modify::end_of_step()
   for (int i = 0; i < n_end_of_step; i++)
     if (update->ntimestep % end_of_step_every[i] == 0)
       fix[list_end_of_step[i]]->end_of_step();
+}
+
+/* ----------------------------------------------------------------------
+   post_run call
+------------------------------------------------------------------------- */
+
+void Modify::post_run()
+{
+  for (int i = 0; i < nfix; i++) fix[i]->post_run();
+
+  // must reset this to its default value, since computes may be added
+  // or removed between runs and with this change we will redirect any
+  // calls to addstep_compute() to addstep_compute_all() instead.
+  n_timeflag = -1;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/modify.h
+++ b/src/modify.h
@@ -38,6 +38,7 @@ class Modify : protected Pointers {
   void setup();
   virtual void start_of_step();
   virtual void end_of_step();
+  virtual void post_run();
 
   virtual int pack_grid_one(int, char *, int);
   virtual int unpack_grid_one(int, char *);

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -13,8 +13,9 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   Timeout code copied and adapted from LAMMPS (lammps.org), October 2024
-   Author: Axel Kohlmeyer (Temple U)
+   Timeout code adapted from LAMMPS (https://www.lammps.org), October 2024
+   Ported to SPARTA by: Stan Moore (SNL)
+   Original Author: Axel Kohlmeyer (Temple U)
 ------------------------------------------------------------------------- */
 
 #include "mpi.h"

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -12,8 +12,15 @@
    See the README file in the top-level SPARTA directory.
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   Timeout code copied and adapted from LAMMPS (lammps.org), October 2024
+   Author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
 #include "mpi.h"
 #include "timer.h"
+#include "comm.h"
+#include "error.h"
 #include "memory.h"
 
 using namespace SPARTA_NS;
@@ -23,6 +30,11 @@ using namespace SPARTA_NS;
 Timer::Timer(SPARTA *sparta) : Pointers(sparta)
 {
   memory->create(array,TIME_N,"array");
+  _timeout = -1.0;
+  _s_timeout = -1.0;
+  _checkfreq = 10;
+  _nextcheck = -1;
+
 }
 
 /* ---------------------------------------------------------------------- */
@@ -82,4 +94,67 @@ double Timer::elapsed(int which)
 {
   double current_time = MPI_Wtime();
   return (current_time - array[which]);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Timer::init_timeout()
+{
+  _s_timeout = _timeout;
+  if (_timeout < 0)
+    _nextcheck = -1;
+  else
+    _nextcheck = _checkfreq;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Timer::print_timeout(FILE *fp)
+{
+  if (!fp) return;
+
+  // format timeout setting
+  if (_timeout > 0) {
+    // time since init_timeout()
+    const double d = MPI_Wtime() - timeout_start;
+    // remaining timeout in seconds
+    int s = _timeout - d;
+    // remaining 1/100ths of seconds
+    const int hs = 100 * ((_timeout - d) - s);
+    // breaking s down into second/minutes/hours
+    const int seconds = s % 60;
+    s = (s - seconds) / 60;
+    const int minutes = s % 60;
+    const int hours = (s - minutes) / 60;
+    fprintf(fp, "  Walltime left : %d:%02d:%02d.%02d\n", hours, minutes, seconds, hs);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+bool Timer::_check_timeout()
+{
+  double walltime =  MPI_Wtime() - timeout_start;
+  // broadcast time to ensure all ranks act the same.
+  MPI_Bcast(&walltime, 1, MPI_DOUBLE, 0, world);
+
+  printf("%g %g\n",walltime,_timeout);
+
+  if (walltime < _timeout) {
+    _nextcheck += _checkfreq;
+    return false;
+  } else {
+    if (comm->me == 0) error->warning(FLERR, "Wall time limit reached");
+    _timeout = 0.0;
+    return true;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+double Timer::get_timeout_remain()
+{
+  double remain = _timeout + timeout_start - MPI_Wtime();
+  // never report a negative remaining time.
+  if (remain < 0.0) remain = 0.0;
+  return (_timeout < 0.0) ? 0.0 : remain;
 }

--- a/src/timer.h
+++ b/src/timer.h
@@ -34,8 +34,42 @@ class Timer : protected Pointers {
   void barrier_stop(int);
   double elapsed(int);
 
+  // initialize timeout timer
+  void init_timeout();
+
+  // trigger enforced timeout
+  void force_timeout() { _timeout = 0.0; }
+
+  // restore original timeout setting after enforce timeout
+  void reset_timeout() { _timeout = _s_timeout; }
+
+  // get remaining time in seconds. 0.0 if inactive, negative if expired
+  double get_timeout_remain();
+
+  // print timeout message
+  void print_timeout(FILE *);
+
+  // check for timeout. inline wrapper around internal
+  // function to reduce overhead in case there is no check.
+  bool check_timeout(int step)
+  {
+    if (_timeout == 0.0) return true;
+    if (_nextcheck != step)
+      return false;
+    else
+      return _check_timeout();
+  }
+
  private:
   double previous_time;
+  double timeout_start;
+  double _timeout;      // max allowed wall time in seconds. infinity if negative
+  double _s_timeout;    // copy of timeout for restoring after a forced timeout
+  int _checkfreq;       // frequency of timeout checking
+  int _nextcheck;       // loop number of next timeout check
+
+  // check for timeout
+  bool _check_timeout();
 };
 
 }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -290,6 +290,11 @@ void Update::run(int nsteps)
 
   for (int i = 0; i < nsteps; i++) {
 
+    if (timer->check_timeout(i)) {
+      update->nsteps = i;
+      break;
+    }
+
     ntimestep++;
 
     if (collide_react) collide_react_reset();
@@ -344,6 +349,8 @@ void Update::run(int nsteps)
       timer->stamp(TIME_OUTPUT);
     }
   }
+
+  modify->post_run();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,8 +13,9 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   File copied and adapted from LAMMPS (lammps.org), October 2024
-   Author: Axel Kohlmeyer (Temple U)
+   File adapted from LAMMPS (https://www.lammps.org), October 2024
+   Ported to SPARTA by: Stan Moore (SNL)
+   Original Author: Axel Kohlmeyer (Temple U)
 ------------------------------------------------------------------------- */
 
 #include "utils.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,967 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   File copied and adapted from LAMMPS (lammps.org), October 2024
+   Author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "utils.h"
+
+#include "comm.h"
+#include "compute.h"
+#include "domain.h"
+#include "error.h"
+#include "fix.h"
+#include "input.h"
+#include "memory.h"
+#include "modify.h"
+#include "universe.h"
+#include "update.h"
+#include "variable.h"
+
+#include <cctype>
+#include <cerrno>
+#include <cstring>
+#include <ctime>
+#include <stdexcept>
+
+/*
+ * Mini regex-module adapted from https://github.com/kokke/tiny-regex-c
+ * which is in the public domain.
+ *
+ * Supports:
+ * ---------
+ *   '.'        Dot, matches any character
+ *   '^'        Start anchor, matches beginning of string
+ *   '$'        End anchor, matches end of string
+ *   '*'        Asterisk, match zero or more (greedy)
+ *   '+'        Plus, match one or more (greedy)
+ *   '?'        Question, match zero or one (non-greedy)
+ *   '[abc]'    Character class, match if one of {'a', 'b', 'c'}
+ *   '[a-zA-Z]' Character ranges, the character set of the ranges { a-z | A-Z }
+ *   '\s'       Whitespace, \t \f \r \n \v and spaces
+ *   '\S'       Non-whitespace
+ *   '\w'       Alphanumeric, [a-zA-Z0-9_]
+ *   '\W'       Non-alphanumeric
+ *   '\d'       Digits, [0-9]
+ *   '\D'       Non-digits
+ *   '\i'       Integer chars, [0-9], '+' and '-'
+ *   '\I'       Non-integers
+ *   '\f'       Floating point number chars, [0-9], '.', 'e', 'E', '+' and '-'
+ *   '\F'       Non-floats
+ *
+ * *NOT* supported:
+ *   '[^abc]'   Inverted class
+ *   'a|b'      Branches
+ *   '(abc)+'   Groups
+ */
+
+extern "C" {
+/** Match text against a (simplified) regular expression
+   * (regexp will be compiled automatically). */
+static int re_match(const char *text, const char *pattern);
+
+/** Match find substring that matches a (simplified) regular expression
+   * (regexp will be compiled automatically). */
+static int re_find(const char *text, const char *pattern, int *matchlen);
+}
+
+////////////////////////////////////////////////////////////////////////
+
+using namespace SPARTA_NS;
+
+/** More flexible and specific matching of a string against a pattern.
+ *  This function is supposed to be a more safe, more specific and
+ *  simple to use API to find pattern matches. The purpose is to replace
+ *  uses of either strncmp() or strstr() in the code base to find
+ *  sub-strings safely. With strncmp() finding prefixes, the number of
+ *  characters to match must be counted, which can lead to errors,
+ *  while using "^pattern" will do the same with less problems.
+ *  Matching for suffixes using strstr() is not as specific as 'pattern$',
+ *  and complex matches, e.g. "^rigid.*\/small.*", to match all small
+ *  body optimized rigid fixes require only one test.
+ *
+ *  The use of std::string arguments allows for simple concatenation
+ *  even with char * type variables.
+ *  Example: utils::strmatch(text, std::string("^") + charptr)
+ */
+bool utils::strmatch(const std::string &text, const std::string &pattern)
+{
+  const int pos = re_match(text.c_str(), pattern.c_str());
+  return (pos >= 0);
+}
+
+/** This function is a companion function to utils::strmatch(). Arguments
+ *  and logic is the same, but instead of a boolean, it returns the
+ *  sub-string that matches the regex pattern.  There can be only one match.
+ *  This can be used as a more flexible alternative to strstr().
+ */
+std::string utils::strfind(const std::string &text, const std::string &pattern)
+{
+  int matchlen;
+  const int pos = re_find(text.c_str(), pattern.c_str(), &matchlen);
+  if ((pos >= 0) && (matchlen > 0))
+    return text.substr(pos, matchlen);
+  else
+    return "";
+}
+
+void utils::missing_cmd_args(const std::string &file, int line, const std::string &cmd,
+                             Error *error)
+{
+  char msg[128];
+  sprintf(msg,"Illegal %s command: missing argument(s)",cmd.c_str());
+  if (error) error->all(file.c_str(), line, msg);
+}
+
+/* specialization for the case of just a single string argument */
+
+void utils::logmesg(SPARTA *sparta, const std::string &mesg)
+{
+  if (sparta->screen) fputs(mesg.c_str(), sparta->screen);
+  if (sparta->logfile) fputs(mesg.c_str(), sparta->logfile);
+}
+
+/* ----------------------------------------------------------------------
+   read a boolean value from a string
+   transform to lower case before checking
+   generate an error if is not a legitimate boolean
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+int utils::logical(const char *file, int line, const std::string &str, bool do_abort, SPARTA *sparta)
+{
+  if (str.empty()) {
+    const char msg[] = "Expected boolean parameter instead of NULL or empty string "
+                       "in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+
+  // convert to ascii
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  int rv = 0;
+  if ((buf == "yes") || (buf == "on") || (buf == "true") || (buf == "1")) {
+    rv = 1;
+  } else if ((buf == "no") || (buf == "off") || (buf == "false") || (buf == "0")) {
+    rv = 0;
+  } else {
+    std::string msg("Expected boolean parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg.c_str());
+    else
+      sparta->error->all(file, line, msg.c_str());
+  }
+  return rv;
+}
+
+/* ----------------------------------------------------------------------
+   wrapper for logical() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+int utils::logical(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta)
+{
+  if (str)
+    return logical(file, line, std::string(str), do_abort, sparta);
+  else
+    return logical(file, line, std::string(""), do_abort, sparta);
+}
+
+/* ----------------------------------------------------------------------
+   read a floating point value from a string
+   generate an error if not a legitimate floating point value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+double utils::numeric(const char *file, int line, const std::string &str, bool do_abort,
+                      SPARTA *sparta)
+{
+  if (str.empty()) {
+    const char msg[] = "Expected floating point parameter instead of"
+                       " NULL or empty string in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (!is_double(buf)) {
+    std::string msg("Expected floating point parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg.c_str());
+    else
+      sparta->error->all(file, line, msg.c_str());
+  }
+
+  double rv = 0;
+  char msg[128];
+  sprintf(msg,"Floating point number %s in input script or data file is invalid", buf.c_str());
+  try {
+    std::size_t endpos;
+    rv = std::stod(buf, &endpos);
+    if (buf.size() != endpos) {
+      if (do_abort)
+        sparta->error->one(file, line, msg);
+      else
+        sparta->error->all(file, line, msg);
+    }
+  } catch (std::invalid_argument const &) {
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  } catch (std::out_of_range const &) {
+    sprintf(msg,"Floating point number %s in input script or data file is out of range", buf.c_str());
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+  return rv;
+}
+
+/* ----------------------------------------------------------------------
+   wrapper for numeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+double utils::numeric(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta)
+{
+  if (str)
+    return numeric(file, line, std::string(str), do_abort, sparta);
+  else
+    return numeric(file, line, std::string(""), do_abort, sparta);
+}
+
+/* ----------------------------------------------------------------------
+   read an integer value from a string
+   generate an error if not a legitimate integer value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+int utils::inumeric(const char *file, int line, const std::string &str, bool do_abort, SPARTA *sparta)
+{
+  if (str.empty()) {
+    const char msg[] = "Expected integer parameter instead of"
+                       " NULL or empty string in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (!is_integer(buf)) {
+    std::string msg("Expected integer parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg.c_str());
+    else
+      sparta->error->all(file, line, msg.c_str());
+  }
+
+  int rv = 0;
+  char msg[128];
+  sprintf(msg,"Integer %s in input script or data file is invalid", buf.c_str());
+  try {
+    std::size_t endpos;
+    rv = std::stoi(buf, &endpos);
+    if (buf.size() != endpos) {
+      if (do_abort)
+        sparta->error->one(file, line, msg);
+      else
+        sparta->error->all(file, line, msg);
+    }
+  } catch (std::invalid_argument const &) {
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  } catch (std::out_of_range const &) {
+    char msg[128];
+    sprintf(msg,"Integer %s in input script or data file is out of range", buf.c_str());
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+  return rv;
+}
+
+/* ----------------------------------------------------------------------
+   wrapper for inumeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+int utils::inumeric(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta)
+{
+  if (str)
+    return inumeric(file, line, std::string(str), do_abort, sparta);
+  else
+    return inumeric(file, line, std::string(""), do_abort, sparta);
+}
+
+/* ----------------------------------------------------------------------
+   read a big integer value from a string
+   generate an error if not a legitimate integer value
+   called by various commands to check validity of their arguments
+------------------------------------------------------------------------- */
+
+bigint utils::bnumeric(const char *file, int line, const std::string &str, bool do_abort,
+                       SPARTA *sparta)
+{
+  if (str.empty()) {
+    const char msg[] = "Expected integer parameter instead of"
+                       " NULL or empty string in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+
+  std::string buf(str);
+  if (has_utf8(buf)) buf = utf8_subst(buf);
+
+  if (!is_integer(buf)) {
+    std::string msg("Expected integer parameter instead of '");
+    msg += buf + "' in input script or data file";
+    if (do_abort)
+      sparta->error->one(file, line, msg.c_str());
+    else
+      sparta->error->all(file, line, msg.c_str());
+  }
+
+  long long rv = 0;
+  char msg[128];
+  sprintf(msg,"Integer %s in input script or data file is invalid", buf.c_str());
+  try {
+    std::size_t endpos;
+    rv = std::stoll(buf, &endpos);
+    if (buf.size() != endpos) {
+      if (do_abort)
+        sparta->error->one(file, line, msg);
+      else
+        sparta->error->all(file, line, msg);
+    }
+    if ((rv < (-MAXBIGINT - 1) || (rv > MAXBIGINT))) throw std::out_of_range("bigint");
+  } catch (std::invalid_argument const &) {
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  } catch (std::out_of_range const &) {
+    char msg[128];
+    sprintf(msg,"Integer %s in input script or data file is out of range", buf.c_str());
+    if (do_abort)
+      sparta->error->one(file, line, msg);
+    else
+      sparta->error->all(file, line, msg);
+  }
+  return static_cast<bigint>(rv);
+}
+
+/* ----------------------------------------------------------------------
+   wrapper for bnumeric() that accepts a char pointer instead of a string
+------------------------------------------------------------------------- */
+
+bigint utils::bnumeric(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta)
+{
+  if (str)
+    return bnumeric(file, line, std::string(str), do_abort, sparta);
+  else
+    return bnumeric(file, line, std::string(""), do_abort, sparta);
+}
+
+/* ----------------------------------------------------------------------
+   Make copy of string in new storage. Works like the (non-portable)
+   C-style strdup() but also accepts a C++ string as argument.
+------------------------------------------------------------------------- */
+
+char *utils::strdup(const std::string &text)
+{
+  auto tmp = new char[text.size() + 1];
+  strcpy(tmp, text.c_str());    // NOLINT
+  return tmp;
+}
+
+/* ----------------------------------------------------------------------
+   Replace UTF-8 encoded chars with known ASCII equivalents
+------------------------------------------------------------------------- */
+
+std::string utils::utf8_subst(const std::string &line)
+{
+  const auto *const in = (const unsigned char *) line.c_str();
+  const int len = line.size();
+  std::string out;
+
+  for (int i = 0; i < len; ++i) {
+
+    // UTF-8 2-byte character
+    if ((in[i] & 0xe0U) == 0xc0U) {
+      if ((i + 1) < len) {
+        // NON-BREAKING SPACE (U+00A0)
+        if ((in[i] == 0xc2U) && (in[i + 1] == 0xa0U)) out += ' ', ++i;
+        // MODIFIER LETTER PLUS SIGN (U+02D6)
+        if ((in[i] == 0xcbU) && (in[i + 1] == 0x96U)) out += '+', ++i;
+        // MODIFIER LETTER MINUS SIGN (U+02D7)
+        if ((in[i] == 0xcbU) && (in[i + 1] == 0x97U)) out += '-', ++i;
+      }
+      // UTF-8 3-byte character
+    } else if ((in[i] & 0xf0U) == 0xe0U) {
+      if ((i + 2) < len) {
+        // EN QUAD (U+2000)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x80U)) out += ' ', i += 2;
+        // EM QUAD (U+2001)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x81U)) out += ' ', i += 2;
+        // EN SPACE (U+2002)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x82U)) out += ' ', i += 2;
+        // EM SPACE (U+2003)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x83U)) out += ' ', i += 2;
+        // THREE-PER-EM SPACE (U+2004)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x84U)) out += ' ', i += 2;
+        // FOUR-PER-EM SPACE (U+2005)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x85U)) out += ' ', i += 2;
+        // SIX-PER-EM SPACE (U+2006)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x86U)) out += ' ', i += 2;
+        // FIGURE SPACE (U+2007)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x87U)) out += ' ', i += 2;
+        // PUNCTUATION SPACE (U+2008)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x88U)) out += ' ', i += 2;
+        // THIN SPACE (U+2009)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x89U)) out += ' ', i += 2;
+        // HAIR SPACE (U+200A)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x8aU)) out += ' ', i += 2;
+        // ZERO WIDTH SPACE (U+200B)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x8bU)) out += ' ', i += 2;
+        // LEFT SINGLE QUOTATION MARK (U+2018)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x98U)) out += '\'', i += 2;
+        // RIGHT SINGLE QUOTATION MARK (U+2019)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x99U)) out += '\'', i += 2;
+        // LEFT DOUBLE QUOTATION MARK (U+201C)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x9cU)) out += '"', i += 2;
+        // RIGHT DOUBLE QUOTATION MARK (U+201D)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0x9dU)) out += '"', i += 2;
+        // NARROW NO-BREAK SPACE (U+202F)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x80U) && (in[i + 2] == 0xafU)) out += ' ', i += 2;
+        // WORD JOINER (U+2060)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x81U) && (in[i + 2] == 0xa0U)) out += ' ', i += 2;
+        // INVISIBLE SEPARATOR (U+2063)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x81U) && (in[i + 2] == 0xa3U)) out += ' ', i += 2;
+        // INVISIBLE PLUS (U+2064)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x81U) && (in[i + 2] == 0xa4U)) out += '+', i += 2;
+        // MINUS SIGN (U+2212)
+        if ((in[i] == 0xe2U) && (in[i + 1] == 0x88U) && (in[i + 2] == 0x92U)) out += '-', i += 2;
+        // ZERO WIDTH NO-BREAK SPACE (U+FEFF)
+        if ((in[i] == 0xefU) && (in[i + 1] == 0xbbU) && (in[i + 2] == 0xbfU)) out += ' ', i += 2;
+      }
+      // UTF-8 4-byte character
+    } else if ((in[i] & 0xf8U) == 0xf0U) {
+      if ((i + 3) < len) { ; }
+    } else
+      out += in[i];
+  }
+  return out;
+}
+
+/* ----------------------------------------------------------------------
+   Return whether string is a valid integer number
+------------------------------------------------------------------------- */
+
+bool utils::is_integer(const std::string &str)
+{
+  if (str.empty()) return false;
+
+  return strmatch(str, "^[+-]?\\d+$");
+}
+
+/* ----------------------------------------------------------------------
+   Return whether string is a valid floating-point number
+------------------------------------------------------------------------- */
+
+bool utils::is_double(const std::string &str)
+{
+  if (str.empty()) return false;
+
+  return strmatch(str, "^[+-]?\\d+\\.?\\d*$") ||
+      strmatch(str, "^[+-]?\\d+\\.?\\d*[eE][+-]?\\d+$") || strmatch(str, "^[+-]?\\d*\\.?\\d+$") ||
+      strmatch(str, "^[+-]?\\d*\\.?\\d+[eE][+-]?\\d+$");
+}
+
+/* ------------------------------------------------------------------ */
+
+extern "C" {
+
+/* Typedef'd pointer to get abstract datatype. */
+typedef struct regex_t *re_t;
+typedef struct regex_context_t *re_ctx_t;
+
+/* Compile regex string pattern to a regex_t-array. */
+static re_t re_compile(re_ctx_t context, const char *pattern);
+
+/* Find matches of the compiled pattern inside text. */
+static int re_matchp(const char *text, re_t pattern, int *matchlen);
+
+/* Definitions: */
+
+#define MAX_REGEXP_OBJECTS 256 /* Max number of regex symbols in expression. */
+#define MAX_CHAR_CLASS_LEN 256 /* Max length of character-class buffer in.   */
+
+enum {
+  RX_UNUSED,
+  RX_DOT,
+  RX_BEGIN,
+  RX_END,
+  RX_QUESTIONMARK,
+  RX_STAR,
+  RX_PLUS,
+  RX_CHAR,
+  RX_CHAR_CLASS,
+  RX_INV_CHAR_CLASS,
+  RX_DIGIT,
+  RX_NOT_DIGIT,
+  RX_INTEGER,
+  RX_NOT_INTEGER,
+  RX_FLOAT,
+  RX_NOT_FLOAT,
+  RX_ALPHA,
+  RX_NOT_ALPHA,
+  RX_WHITESPACE,
+  RX_NOT_WHITESPACE /*, BRANCH */
+};
+
+typedef struct regex_t {
+  unsigned char type; /* CHAR, STAR, etc.                      */
+  union {
+    unsigned char ch;   /*      the character itself             */
+    unsigned char *ccl; /*  OR  a pointer to characters in class */
+  } u;
+} regex_t;
+
+typedef struct regex_context_t {
+  /* MAX_REGEXP_OBJECTS is the max number of symbols in the expression.
+       MAX_CHAR_CLASS_LEN determines the size of buffer for chars in all char-classes in the expression. */
+  regex_t re_compiled[MAX_REGEXP_OBJECTS];
+  unsigned char ccl_buf[MAX_CHAR_CLASS_LEN];
+} regex_context_t;
+
+int re_match(const char *text, const char *pattern)
+{
+  regex_context_t context;
+  int dummy;
+  return re_matchp(text, re_compile(&context, pattern), &dummy);
+}
+
+int re_find(const char *text, const char *pattern, int *matchlen)
+{
+  regex_context_t context;
+  return re_matchp(text, re_compile(&context, pattern), matchlen);
+}
+
+/* Private function declarations: */
+static int matchpattern(regex_t *pattern, const char *text, int *matchlen);
+static int matchcharclass(char c, const char *str);
+static int matchstar(regex_t p, regex_t *pattern, const char *text, int *matchlen);
+static int matchplus(regex_t p, regex_t *pattern, const char *text, int *matchlen);
+static int matchone(regex_t p, char c);
+static int matchdigit(char c);
+static int matchint(char c);
+static int matchfloat(char c);
+static int matchalpha(char c);
+static int matchwhitespace(char c);
+static int matchmetachar(char c, const char *str);
+static int matchrange(char c, const char *str);
+static int matchdot(char c);
+static int ismetachar(char c);
+
+/* Semi-public functions: */
+int re_matchp(const char *text, re_t pattern, int *matchlen)
+{
+  *matchlen = 0;
+  if (pattern != nullptr) {
+    if (pattern[0].type == RX_BEGIN) {
+      return ((matchpattern(&pattern[1], text, matchlen)) ? 0 : -1);
+    } else {
+      int idx = -1;
+
+      do {
+        idx += 1;
+
+        if (matchpattern(pattern, text, matchlen)) {
+          if (text[0] == '\0') return -1;
+
+          return idx;
+        }
+      } while (*text++ != '\0');
+    }
+  }
+  return -1;
+}
+
+re_t re_compile(re_ctx_t context, const char *pattern)
+{
+  regex_t *const re_compiled = context->re_compiled;
+  unsigned char *const ccl_buf = context->ccl_buf;
+  int ccl_bufidx = 1;
+
+  char c;    /* current char in pattern   */
+  int i = 0; /* index into pattern        */
+  int j = 0; /* index into re_compiled    */
+
+  while (pattern[i] != '\0' && (j + 1 < MAX_REGEXP_OBJECTS)) {
+    c = pattern[i];
+
+    switch (c) {
+        /* Meta-characters: */
+      case '^': {
+        re_compiled[j].type = RX_BEGIN;
+      } break;
+      case '$': {
+        re_compiled[j].type = RX_END;
+      } break;
+      case '.': {
+        re_compiled[j].type = RX_DOT;
+      } break;
+      case '*': {
+        re_compiled[j].type = RX_STAR;
+      } break;
+      case '+': {
+        re_compiled[j].type = RX_PLUS;
+      } break;
+      case '?': {
+        re_compiled[j].type = RX_QUESTIONMARK;
+      } break;
+
+        /* Escaped character-classes (\s \w ...): */
+      case '\\': {
+        if (pattern[i + 1] != '\0') {
+          /* Skip the escape-char '\\' */
+          i += 1;
+          /* ... and check the next */
+          switch (pattern[i]) {
+              /* Meta-character: */
+            case 'd': {
+              re_compiled[j].type = RX_DIGIT;
+            } break;
+            case 'D': {
+              re_compiled[j].type = RX_NOT_DIGIT;
+            } break;
+            case 'i': {
+              re_compiled[j].type = RX_INTEGER;
+            } break;
+            case 'I': {
+              re_compiled[j].type = RX_NOT_INTEGER;
+            } break;
+            case 'f': {
+              re_compiled[j].type = RX_FLOAT;
+            } break;
+            case 'F': {
+              re_compiled[j].type = RX_NOT_FLOAT;
+            } break;
+            case 'w': {
+              re_compiled[j].type = RX_ALPHA;
+            } break;
+            case 'W': {
+              re_compiled[j].type = RX_NOT_ALPHA;
+            } break;
+            case 's': {
+              re_compiled[j].type = RX_WHITESPACE;
+            } break;
+            case 'S': {
+              re_compiled[j].type = RX_NOT_WHITESPACE;
+            } break;
+
+              /* Escaped character, e.g. '.' or '$' */
+            default: {
+              re_compiled[j].type = RX_CHAR;
+              re_compiled[j].u.ch = pattern[i];
+            } break;
+          }
+        }
+        /* '\\' as last char in pattern -> invalid regular expression. */
+      } break;
+
+        /* Character class: */
+      case '[': {
+        /* Remember where the char-buffer starts. */
+        int buf_begin = ccl_bufidx;
+
+        /* Look-ahead to determine if negated */
+        if (pattern[i + 1] == '^') {
+          re_compiled[j].type = RX_INV_CHAR_CLASS;
+          i += 1;                  /* Increment i to avoid including '^' in the char-buffer */
+          if (pattern[i + 1] == 0) /* incomplete pattern, missing non-zero char after '^' */
+          {
+            return nullptr;
+          }
+        } else {
+          re_compiled[j].type = RX_CHAR_CLASS;
+        }
+
+        /* Copy characters inside [..] to buffer */
+        while ((pattern[++i] != ']') && (pattern[i] != '\0')) {
+          /* Missing ] */
+          if (pattern[i] == '\\') {
+            if (ccl_bufidx >= MAX_CHAR_CLASS_LEN - 1) { return nullptr; }
+            if (pattern[i + 1] == 0) /* incomplete pattern, missing non-zero char after '\\' */
+            {
+              return nullptr;
+            }
+            ccl_buf[ccl_bufidx++] = pattern[i++];
+          } else if (ccl_bufidx >= MAX_CHAR_CLASS_LEN) {
+            return nullptr;
+          }
+          ccl_buf[ccl_bufidx++] = pattern[i];
+        }
+        if (ccl_bufidx >= MAX_CHAR_CLASS_LEN) {
+          /* Catches cases such as [00000000000000000000000000000000000000][ */
+          return nullptr;
+        }
+        /* Null-terminate string end */
+        ccl_buf[ccl_bufidx++] = 0;
+        re_compiled[j].u.ccl = &ccl_buf[buf_begin];
+      } break;
+
+        /* Other characters: */
+      default: {
+        re_compiled[j].type = RX_CHAR;
+        re_compiled[j].u.ch = c;
+      } break;
+    }
+    /* no buffer-out-of-bounds access on invalid patterns -
+     * see https://github.com/kokke/tiny-regex-c/commit/1a279e04014b70b0695fba559a7c05d55e6ee90b */
+    if (pattern[i] == 0) { return nullptr; }
+
+    i += 1;
+    j += 1;
+  }
+  /* 'RX_UNUSED' is a sentinel used to indicate end-of-pattern */
+  re_compiled[j].type = RX_UNUSED;
+
+  return (re_t) re_compiled;
+}
+
+/* Private functions: */
+static int matchdigit(char c)
+{
+  return isdigit(c);
+}
+
+static int matchint(char c)
+{
+  return (matchdigit(c) || (c == '-') || (c == '+'));
+}
+
+static int matchfloat(char c)
+{
+  return (matchint(c) || (c == '.') || (c == 'e') || (c == 'E'));
+}
+
+static int matchalpha(char c)
+{
+  return isalpha(c);
+}
+
+static int matchwhitespace(char c)
+{
+  return isspace(c);
+}
+
+static int matchalphanum(char c)
+{
+  return ((c == '_') || matchalpha(c) || matchdigit(c));
+}
+
+static int matchrange(char c, const char *str)
+{
+  return ((c != '-') && (str[0] != '\0') && (str[0] != '-') && (str[1] == '-') &&
+          (str[1] != '\0') && (str[2] != '\0') && ((c >= str[0]) && (c <= str[2])));
+}
+
+static int matchdot(char c)
+{
+#if defined(RE_DOT_MATCHES_NEWLINE) && (RE_DOT_MATCHES_NEWLINE == 1)
+  (void) c;
+  return 1;
+#else
+  return c != '\n' && c != '\r';
+#endif
+}
+
+static int ismetachar(char c)
+{
+  return ((c == 's') || (c == 'S') || (c == 'w') || (c == 'W') || (c == 'd') || (c == 'D'));
+}
+
+static int matchmetachar(char c, const char *str)
+{
+  switch (str[0]) {
+    case 'd':
+      return matchdigit(c);
+    case 'D':
+      return !matchdigit(c);
+    case 'i':
+      return matchint(c);
+    case 'I':
+      return !matchint(c);
+    case 'f':
+      return matchfloat(c);
+    case 'F':
+      return !matchfloat(c);
+    case 'w':
+      return matchalphanum(c);
+    case 'W':
+      return !matchalphanum(c);
+    case 's':
+      return matchwhitespace(c);
+    case 'S':
+      return !matchwhitespace(c);
+    default:
+      return (c == str[0]);
+  }
+}
+
+static int matchcharclass(char c, const char *str)
+{
+  do {
+    if (matchrange(c, str)) {
+      return 1;
+    } else if (str[0] == '\\') {
+      /* Escape-char: increment str-ptr and match on next char */
+      str += 1;
+      if (matchmetachar(c, str)) {
+        return 1;
+      } else if ((c == str[0]) && !ismetachar(c)) {
+        return 1;
+      }
+    } else if (c == str[0]) {
+      if (c == '-') {
+        return ((str[-1] == '\0') || (str[1] == '\0'));
+      } else {
+        return 1;
+      }
+    }
+  } while (*str++ != '\0');
+
+  return 0;
+}
+
+static int matchone(regex_t p, char c)
+{
+  switch (p.type) {
+    case RX_DOT:
+      return matchdot(c);
+    case RX_CHAR_CLASS:
+      return matchcharclass(c, (const char *) p.u.ccl);
+    case RX_INV_CHAR_CLASS:
+      return !matchcharclass(c, (const char *) p.u.ccl);
+    case RX_DIGIT:
+      return matchdigit(c);
+    case RX_NOT_DIGIT:
+      return !matchdigit(c);
+    case RX_INTEGER:
+      return matchint(c);
+    case RX_NOT_INTEGER:
+      return !matchint(c);
+    case RX_FLOAT:
+      return matchfloat(c);
+    case RX_NOT_FLOAT:
+      return !matchfloat(c);
+    case RX_ALPHA:
+      return matchalphanum(c);
+    case RX_NOT_ALPHA:
+      return !matchalphanum(c);
+    case RX_WHITESPACE:
+      return matchwhitespace(c);
+    case RX_NOT_WHITESPACE:
+      return !matchwhitespace(c);
+    default:
+      return (p.u.ch == c);
+  }
+}
+
+static int matchstar(regex_t p, regex_t *pattern, const char *text, int *matchlen)
+{
+  int prelen = *matchlen;
+  const char *prepos = text;
+  while ((text[0] != '\0') && matchone(p, *text)) {
+    text++;
+    (*matchlen)++;
+  }
+  while (text >= prepos) {
+    if (matchpattern(pattern, text--, matchlen)) return 1;
+    (*matchlen)--;
+  }
+
+  *matchlen = prelen;
+  return 0;
+}
+
+static int matchplus(regex_t p, regex_t *pattern, const char *text, int *matchlen)
+{
+  const char *prepos = text;
+  while ((text[0] != '\0') && matchone(p, *text)) {
+    text++;
+    (*matchlen)++;
+  }
+  while (text > prepos) {
+    if (matchpattern(pattern, text--, matchlen)) return 1;
+    (*matchlen)--;
+  }
+  return 0;
+}
+
+static int matchquestion(regex_t p, regex_t *pattern, const char *text, int *matchlen)
+{
+  if (p.type == RX_UNUSED) return 1;
+  if (matchpattern(pattern, text, matchlen)) return 1;
+  if (*text && matchone(p, *text++)) {
+    if (matchpattern(pattern, text, matchlen)) {
+      (*matchlen)++;
+      return 1;
+    }
+  }
+  return 0;
+}
+
+/* Iterative matching */
+static int matchpattern(regex_t *pattern, const char *text, int *matchlen)
+{
+  int pre = *matchlen;
+  do {
+    if ((pattern[0].type == RX_UNUSED) || (pattern[1].type == RX_QUESTIONMARK)) {
+      return matchquestion(pattern[0], &pattern[2], text, matchlen);
+    } else if (pattern[1].type == RX_STAR) {
+      return matchstar(pattern[0], &pattern[2], text, matchlen);
+    } else if (pattern[1].type == RX_PLUS) {
+      return matchplus(pattern[0], &pattern[2], text, matchlen);
+    } else if ((pattern[0].type == RX_END) && pattern[1].type == RX_UNUSED) {
+      return (text[0] == '\0');
+    }
+    (*matchlen)++;
+  } while ((text[0] != '\0') && matchone(*pattern++, *text++));
+
+  *matchlen = pre;
+  return 0;
+}
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -13,8 +13,9 @@
 ------------------------------------------------------------------------- */
 
 /* ----------------------------------------------------------------------
-   File copied and adapted from LAMMPS (lammps.org), October 2024
-   Author: Axel Kohlmeyer (Temple U)
+   File adapted from LAMMPS (https://www.lammps.org), October 2024
+   Ported to SPARTA by: Stan Moore (SNL)
+   Original Author: Axel Kohlmeyer (Temple U)
 ------------------------------------------------------------------------- */
 
 #ifndef SPARTA_UTILS_H

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,226 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   File copied and adapted from LAMMPS (lammps.org), October 2024
+   Author: Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_UTILS_H
+#define SPARTA_UTILS_H
+
+#include "spatype.h"
+
+#include <mpi.h>
+
+#include <vector>
+#include <string>
+
+namespace SPARTA_NS {
+
+// forward declarations
+class Error;
+class SPARTA;
+
+namespace utils {
+
+  /*! Match text against a simplified regex pattern
+   *
+   *  \param text the text to be matched against the pattern
+   *  \param pattern the search pattern, which may contain regexp markers
+   *  \return true if the pattern matches, false if not */
+
+  bool strmatch(const std::string &text, const std::string &pattern);
+
+  /*! Find sub-string that matches a simplified regex pattern
+   *
+   *  \param text the text to be matched against the pattern
+   *  \param pattern the search pattern, which may contain regexp markers
+   *  \return the string that matches the pattern or an empty one */
+
+  std::string strfind(const std::string &text, const std::string &pattern);
+
+  /*! Print error message about missing arguments for command
+   *
+   * This function simplifies the repetitive reporting missing arguments to a command.
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param cmd      name of the failing command
+   *  \param error    pointer to Error class instance (for abort) or nullptr */
+
+  void missing_cmd_args(const std::string &file, int line, const std::string &cmd, Error *error);
+
+  /*! \overload
+   *
+   *  \param sparta    pointer to SPARTA class instance
+   *  \param mesg   string with message to be printed */
+
+  void logmesg(SPARTA *sparta, const std::string &mesg);
+
+  int logical(const char *file, int line, const std::string &str, bool do_abort, SPARTA *sparta);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to logical
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         1 if string resolves to "true", otherwise 0 */
+
+  int logical(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta);
+
+  /*! Convert a string to a floating point number while checking
+   *  if it is a valid floating point or integer number
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         double precision floating point number */
+
+  double numeric(const char *file, int line, const std::string &str, bool do_abort, SPARTA *sparta);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         double precision floating point number */
+
+  double numeric(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta);
+
+  /*! Convert a string to an integer number while checking
+   *  if it is a valid integer number (regular int)
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         integer number (regular int)  */
+
+  int inumeric(const char *file, int line, const std::string &str, bool do_abort, SPARTA *sparta);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         double precision floating point number */
+
+  int inumeric(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta);
+
+  /*! Convert a string to an integer number while checking
+   *  if it is a valid integer number (bigint)
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         integer number (bigint) */
+
+  bigint bnumeric(const char *file, int line, const std::string &str, bool do_abort, SPARTA *sparta);
+
+  /*! \overload
+   *
+   *  \param file     name of source file for error message
+   *  \param line     line number in source file for error message
+   *  \param str      string to be converted to number
+   *  \param do_abort determines whether to call Error::one() or Error::all()
+   *  \param sparta      pointer to top-level SPARTA class instance
+   *  \return         double precision floating point number */
+
+  bigint bnumeric(const char *file, int line, const char *str, bool do_abort, SPARTA *sparta);
+
+  /*! Make C-style copy of string in new storage
+   *
+   * This allocates a storage buffer and copies the C-style or
+   * C++ style string into it.  The buffer is allocated with "new"
+   * and thus needs to be deallocated with "delete[]".
+   *
+   * \param text  string that should be copied
+   * \return new buffer with copy of string */
+
+  char *strdup(const std::string &text);
+
+  /*! Check if a string will likely have UTF-8 encoded characters
+   *
+   * UTF-8 uses the 7-bit standard ASCII table for the first 127 characters and
+   * all other characters are encoded as multiple bytes.  For the multi-byte
+   * characters the first byte has either the highest two, three, or four bits
+   * set followed by a zero bit and followed by one, two, or three more bytes,
+   * respectively, where the highest bit is set and the second highest bit set
+   * to 0.  The remaining bits combined are the character code, which is thus
+   * limited to 21-bits.
+   *
+   * For the sake of efficiency this test only checks if a character in the string
+   * has the highest bit set and thus is very likely an UTF-8 character.  It will
+   * not be able to tell this this is a valid UTF-8 character or whether it is a
+   * 2-byte, 3-byte, or 4-byte character.
+   *
+\verbatim embed:rst
+
+*See also*
+   :cpp:func:`utils::utf8_subst`
+
+\endverbatim
+   * \param line  string that should be checked
+   * \return true if string contains UTF-8 encoded characters (bool) */
+
+  inline bool has_utf8(const std::string &line)
+  {
+    for (auto c : line)
+      if (c & 0x80U) return true;
+    return false;
+  }
+
+  /*! Replace known UTF-8 characters with ASCII equivalents
+   *
+\verbatim embed:rst
+
+*See also*
+   :cpp:func:`utils::has_utf8`
+
+\endverbatim
+   * \param line  string that should be converted
+   * \return new string with ascii replacements (string) */
+
+  std::string utf8_subst(const std::string &line);
+
+  /*! Check if string can be converted to valid integer
+   *
+   * \param str string that should be checked
+   * \return true, if string contains valid a integer, false otherwise */
+
+  bool is_integer(const std::string &str);
+
+  /*! Check if string can be converted to valid floating-point number
+   *
+   * \param str string that should be checked
+   * \return true, if string contains valid number, false otherwise */
+
+  bool is_double(const std::string &str);
+
+}    // namespace utils
+}    // namespace SPARTA_NS
+
+#endif


### PR DESCRIPTION
## Purpose

Add `fix halt`, copied and adapted from LAMMPS. This fix allows one to stop the simulation after a user-specified walltime limit, or based on the output from a variable.

## Author(s)

Code was adapted to SPARTA by Stan Moore (SNL), original LAMMPS code was written by Axel Kohlmeyer (Temple U)

## Backward Compatibility

Yes

Closes #519
Closes #522
