### PR TITLE
Update surf2paraview.py

### DIFF
--- a/tools/paraview/surf2paraview.py
+++ b/tools/paraview/surf2paraview.py
@@ -97,7 +97,7 @@ def read_elements(sif, num_points, num_elements, ug, three_d_file):
 
   if ug.GetNumberOfCells():
     print("Error reading SPARTA surf input file")
-    print("Trangles or Lines section of file occurs more than once")
+    print("Triangles or Lines section of file occurs more than once")
     sys.exit(1)
 
   for line in sif:
@@ -105,17 +105,17 @@ def read_elements(sif, num_points, num_elements, ug, three_d_file):
     if s and len(s.split()) >= num_items_per_line:
       if three_d_file:
         tri = vtk.vtkTriangle()
-        i = int(s.split()[1])
-        j = int(s.split()[2])
-        k = int(s.split()[3])
+        i = int(s.split()[-3])
+        j = int(s.split()[-2])
+        k = int(s.split()[-1])
         tri.GetPointIds().SetId(0,i-1)
         tri.GetPointIds().SetId(1,j-1)
         tri.GetPointIds().SetId(2,k-1)
         ug.InsertNextCell(tri.GetCellType(), tri.GetPointIds());
       else:
         li = vtk.vtkLine()
-        i = int(s.split()[1])
-        j = int(s.split()[2])
+        i = int(s.split()[-2])
+        j = int(s.split()[-1])
         li.GetPointIds().SetId(0,i-1)
         li.GetPointIds().SetId(1,j-1)
         ug.InsertNextCell(li.GetCellType(), li.GetPointIds());


### PR DESCRIPTION
## Purpose

This fixes #464. 

While #499 was intended to fix this issue, it introduced a new bug. The bug is that the type id was read as one of the point ids. This is because the type is written to the 2nd field.

The present pull request amends this by reading the point ids in reverse order from the end of the line.

Note: while this now supports type, it will fail catastrophically if write_surf is used with custom arg. There is no adhoc solution to support the general case because it would involve unknown number of fields (1 or 2 with type) before the point ids and unknown number of fields after. Solution would have to be to introduce an argument to surf2paraview if custom arg is used and provide the number of fields so that the script can infer the correct position of the point ids in the Lines list.

## Author(s)

Tim Teichmann

## Backward Compatibility

No (fixes bug in previous version)

## Implementation Notes

Trivial

## Post Submission Checklist

_Please check the fields below as they are completed_
- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines
