### PR TITLE
Work around roundoff issues in axisymmetric code

### DIFF
--- a/src/KOKKOS/geometry_kokkos.h
+++ b/src/KOKKOS/geometry_kokkos.h
@@ -171,6 +171,20 @@ bool axi_horizontal_line(double tdelta, double *x, double *v,
     nc = 1;
   }
 
+  // roundoff can cause code to miss collisions
+  //  occurs when t is epsilon greater than tdelta
+  //  set t = tdelta in this case
+
+  if (fabs(t1 - tdelta) < EPSSQ) {
+    if (tdelta > 0.0 && t1 > tdelta) {
+      t1 = tdelta;
+    }
+  } else if (fabs(t2 - tdelta) < EPSSQ) {
+    if (tdelta > 0.0 && t2 > tdelta) {
+      t2 = tdelta;
+    }
+  }
+
   // require first collision time >= 0.0 and <= tdelta
 
   if (t1 < 0.0 || t1 > tdelta) {
@@ -281,6 +295,14 @@ bool axi_line_intersect(double tdelta, double *x, double *v,
   // loop over 1 or 2 possible collision times
 
   while (1) {
+
+    // roundoff can cause code to miss collisions
+    //  occurs when t is epsilon greater than tdelta
+    //  set t = tdelta in this case
+
+    if (fabs(t1 - tdelta) < EPSSQ)
+      if (tdelta > 0.0 && t1 > tdelta)
+        t1 = tdelta;
 
     // test for collision time >= 0.0 and <= tdelta
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -791,6 +791,14 @@ bool axi_line_intersect(double tdelta, double *x, double *v,
 
   while (1) {
 
+    // roundoff can cause code to miss collisions
+    //  occurs when t is epsilon greater than tdelta
+    //  set t = tdelta in this case
+
+    if (fabs(t1 - tdelta) < EPSSQ)
+      if (tdelta > 0.0 && t1 > tdelta)
+        t1 = tdelta;
+
     // test for collision time >= 0.0 and <= tdelta
 
     if (t1 > tdelta) return false;
@@ -933,6 +941,20 @@ bool axi_horizontal_line(double tdelta, double *x, double *v,
   if (x[1] == yhoriz) {
     if (fabs(t1) < fabs(t2)) t1 = t2;
     nc = 1;
+  }
+
+  // roundoff can cause code to miss collisions
+  //  occurs when t is epsilon greater than tdelta
+  //  set t = tdelta in this case
+
+  if (fabs(t1 - tdelta) < EPSSQ) {
+    if (tdelta > 0.0 && t1 > tdelta) {
+      t1 = tdelta;
+    }
+  } else if (fabs(t2 - tdelta) < EPSSQ) {
+    if (tdelta > 0.0 && t2 > tdelta) {
+      t2 = tdelta;
+    }
   }
 
   // require first collision time >= 0.0 and <= tdelta


### PR DESCRIPTION
## Purpose

Work around roundoff issues in axisymmetric code that cause particles to escape into surfaces.
Fixes #527

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

May change trajectories of previous bad cases

## Implementation Notes

Tested on reproducer input from #527 

