### PR TITLE
Renumber implicit surfaces in `write_surf` since ablation may remove surfs

### DIFF
--- a/doc/write_surf.html
+++ b/doc/write_surf.html
@@ -134,7 +134,9 @@ next 3 processors and write it to a surface file.
 </P>
 <HR>
 
-<P><B>Restrictions:</B> none
+<P><B>Restrictions:</B>
+</P>
+<P>The <I>custom</I> keyword cannot be used with implicit surfaces.
 </P>
 <P><B>Related commands:</B>
 </P>

--- a/doc/write_surf.txt
+++ b/doc/write_surf.txt
@@ -127,7 +127,9 @@ next 3 processors and write it to a surface file.
 
 :line
 
-[Restrictions:] none
+[Restrictions:]
+
+The {custom} keyword cannot be used with implicit surfaces.
 
 [Related commands:]
 

--- a/src/write_surf.h
+++ b/src/write_surf.h
@@ -70,6 +70,7 @@ class WriteSurf : protected Pointers {
   void pack_custom(int, double **);
   void write_custom_all(int);
   void write_custom_distributed(int, double **);
+  void renumber_implicit();
 
   // union data struct for packing 32-bit and 64-bit ints into double bufs
   // this avoids aliasing issues by having 2 pointers (double,int)


### PR DESCRIPTION
## Purpose

Renumber implicit surfaces in `write_surf` since ablation may remove surfs. Also document existing restriction that `write_surf` `custom` keyword cannot be used with implicit surfaces.

Fixes #525

## Author(s)

Stan Moore (SNL)

## Backward Compatibility
Yes
