### PR TITLE
Two bugfixes

### DIFF
--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -1259,7 +1259,7 @@ void DumpImage::create_image()
 
     Compute *cx,*cy,*cz;
     Fix *fx,*fy,*fz;
-    int ppgflagx;
+    int ppgflagx,ppgflagy,ppgflagz;
 
     if (gridxflag && gxcolor == ATTRIBUTE) {
       if (gridxwhich == COMPUTE) {
@@ -1286,8 +1286,10 @@ void DumpImage::create_image()
           cy->compute_per_grid();
           cy->invoked_flag |= INVOKED_PER_GRID;
         }
+        ppgflagy = 0;
         if (cy->post_process_grid_flag) {
           cy->post_process_grid(gridycol,1,NULL,NULL,NULL,1);
+          ppgflagy = 1;
         } else if (cy->post_process_isurf_grid_flag)
           cy->post_process_isurf_grid();
       } else if (gridywhich == FIX) {
@@ -1302,8 +1304,10 @@ void DumpImage::create_image()
           cz->compute_per_grid();
           cz->invoked_flag |= INVOKED_PER_GRID;
         }
+        ppgflagz = 0;
         if (cz->post_process_grid_flag) {
           cz->post_process_grid(gridzcol,1,NULL,NULL,NULL,1);
+        ppgflagz = 1;
         } else if (cz->post_process_isurf_grid_flag)
           cz->post_process_isurf_grid();
       } else if (gridzwhich == FIX) {
@@ -1354,7 +1358,7 @@ void DumpImage::create_image()
             color = gcolorproc;
           } else if (gycolor == ATTRIBUTE) {
             if (gridywhich == COMPUTE) {
-              if (gridycol == 0) value = cy->vector_grid[icell];
+              if (gridycol == 0 || ppgflagy) value = cy->vector_grid[icell];
               else value = cy->array_grid[icell][gridycol-1];
             } else if (gridywhich == FIX) {
               if (gridycol == 0) value = fy->vector_grid[icell];
@@ -1378,7 +1382,7 @@ void DumpImage::create_image()
             color = gcolorproc;
           } else if (gzcolor == ATTRIBUTE) {
             if (gridzwhich == COMPUTE) {
-              if (gridzcol == 0) value = cz->vector_grid[icell];
+              if (gridzcol == 0 || ppgflagz) value = cz->vector_grid[icell];
               else value = cz->array_grid[icell][gridzcol-1];
             } else if (gridzwhich == FIX) {
               if (gridzcol == 0) value = fz->vector_grid[icell];

--- a/src/write_surf.h
+++ b/src/write_surf.h
@@ -70,7 +70,6 @@ class WriteSurf : protected Pointers {
   void pack_custom(int, double **);
   void write_custom_all(int);
   void write_custom_distributed(int, double **);
-  void renumber_implicit();
 
   // union data struct for packing 32-bit and 64-bit ints into double bufs
   // this avoids aliasing issues by having 2 pointers (double,int)


### PR DESCRIPTION
## Purpose

- Only renumber surface ids in `write_surf` for the file, but not in the actual data structures since this can cause other issues. (This was feedback from @sjplimp). This was changed recently in #530.
- Fix a bug in `dump image` that led to seg fault

## Author(s)

Stan Moore (SNL), and Steve Plimpton (retired SNL)

## Backward Compatibility

Yes


