### PR TITLE
Document more clearly a round-off with axisymmetric gas/surface collisions

### DIFF
--- a/src/KOKKOS/geometry_kokkos.h
+++ b/src/KOKKOS/geometry_kokkos.h
@@ -17,6 +17,7 @@
 #define EPSSQ 1.0e-16
 #define EPSSQNEG -1.0e-16
 #define EPSSELF 1.0e-6
+#define EPSTIME 1.0e-16
 
 enum{OUTSIDE,INSIDE,ONSURF2OUT,ONSURF2IN};    // same as Update
 
@@ -171,19 +172,15 @@ bool axi_horizontal_line(double tdelta, double *x, double *v,
     nc = 1;
   }
 
-  // roundoff can cause code to miss collisions
-  //  occurs when t is epsilon greater than tdelta
-  //  set t = tdelta in this case
+  // check for roundoff issue which can miss a surf collision
+  // occurs when t1 or t2 is only EPSTIME greater than tdelta
+  //   due to round-off in solution to quadratic equation above
+  // force a collision in this special case by setting t1/t2 = tdelta
 
-  if (fabs(t1 - tdelta) < EPSSQ) {
-    if (tdelta > 0.0 && t1 > tdelta) {
-      t1 = tdelta;
-    }
-  } else if (fabs(t2 - tdelta) < EPSSQ) {
-    if (tdelta > 0.0 && t2 > tdelta) {
-      t2 = tdelta;
-    }
-  }
+  if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)
+    t1 = tdelta;
+  else if (t2 > tdelta && (t2-tdelta) < EPSTIME && tdelta > 0.0)
+    t2 = tdelta;
 
   // require first collision time >= 0.0 and <= tdelta
 
@@ -296,13 +293,13 @@ bool axi_line_intersect(double tdelta, double *x, double *v,
 
   while (1) {
 
-    // roundoff can cause code to miss collisions
-    //  occurs when t is epsilon greater than tdelta
-    //  set t = tdelta in this case
+    // check for roundoff issue which can miss a surf collision
+    // occurs when t1 is only EPSTIME greater than tdelta
+    //   due to round-off in solution to quadratic equation above
+    // force a collision in this special case by setting t1 = tdelta
 
-    if (fabs(t1 - tdelta) < EPSSQ)
-      if (tdelta > 0.0 && t1 > tdelta)
-        t1 = tdelta;
+    if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)
+      t1 = tdelta;
 
     // test for collision time >= 0.0 and <= tdelta
 

--- a/src/KOKKOS/geometry_kokkos.h
+++ b/src/KOKKOS/geometry_kokkos.h
@@ -172,9 +172,10 @@ bool axi_horizontal_line(double tdelta, double *x, double *v,
     nc = 1;
   }
 
-  // check for roundoff issue which can miss a surf collision
-  // occurs when t1 or t2 is only EPSTIME greater than tdelta
-  //   due to round-off in solution to quadratic equation above
+  // check for roundoff issue which can occur when
+  //  axisym surf is nearly exactly on grid cell edge
+  // round-off in solution to quadratic equation
+  //   can cause t1 or t2 to be EPSTIME greater than tdelta and miss collision
   // force a collision in this special case by setting t1/t2 = tdelta
 
   if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)
@@ -293,9 +294,10 @@ bool axi_line_intersect(double tdelta, double *x, double *v,
 
   while (1) {
 
-    // check for roundoff issue which can miss a surf collision
-    // occurs when t1 is only EPSTIME greater than tdelta
-    //   due to round-off in solution to quadratic equation above
+    // check for roundoff issue which can occur when
+    //  axisym surf is nearly exactly on grid cell edge
+    // round-off in solution to quadratic equation
+    //   can cause t1 to be EPSTIME greater than tdelta and miss collision
     // force a collision in this special case by setting t1 = tdelta
 
     if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -21,6 +21,7 @@
 #define EPSSQ 1.0e-16
 #define EPSSQNEG -1.0e-16
 #define EPSSELF 1.0e-6
+#define EPSTIME 1.0e-16
 
 enum{OUTSIDE,INSIDE,ONSURF2OUT,ONSURF2IN};    // same as Update
 
@@ -791,13 +792,13 @@ bool axi_line_intersect(double tdelta, double *x, double *v,
 
   while (1) {
 
-    // roundoff can cause code to miss collisions
-    //  occurs when t is epsilon greater than tdelta
-    //  set t = tdelta in this case
+    // check for roundoff issue which can miss a surf collision
+    // occurs when t1 is only EPSTIME greater than tdelta
+    //   due to round-off in solution to quadratic equation above
+    // force a collision in this special case by setting t1 = tdelta
 
-    if (fabs(t1 - tdelta) < EPSSQ)
-      if (tdelta > 0.0 && t1 > tdelta)
-        t1 = tdelta;
+    if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)
+      t1 = tdelta;
 
     // test for collision time >= 0.0 and <= tdelta
 
@@ -943,19 +944,15 @@ bool axi_horizontal_line(double tdelta, double *x, double *v,
     nc = 1;
   }
 
-  // roundoff can cause code to miss collisions
-  //  occurs when t is epsilon greater than tdelta
-  //  set t = tdelta in this case
+  // check for roundoff issue which can miss a surf collision
+  // occurs when t1 or t2 is only EPSTIME greater than tdelta
+  //   due to round-off in solution to quadratic equation above
+  // force a collision in this special case by setting t1/t2 = tdelta
 
-  if (fabs(t1 - tdelta) < EPSSQ) {
-    if (tdelta > 0.0 && t1 > tdelta) {
-      t1 = tdelta;
-    }
-  } else if (fabs(t2 - tdelta) < EPSSQ) {
-    if (tdelta > 0.0 && t2 > tdelta) {
-      t2 = tdelta;
-    }
-  }
+  if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)
+    t1 = tdelta;
+  else if (t2 > tdelta && (t2-tdelta) < EPSTIME && tdelta > 0.0)
+    t2 = tdelta;
 
   // require first collision time >= 0.0 and <= tdelta
 

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -792,9 +792,10 @@ bool axi_line_intersect(double tdelta, double *x, double *v,
 
   while (1) {
 
-    // check for roundoff issue which can miss a surf collision
-    // occurs when t1 is only EPSTIME greater than tdelta
-    //   due to round-off in solution to quadratic equation above
+    // check for roundoff issue which can occur when
+    //  axisym surf is nearly exactly on grid cell edge
+    // round-off in solution to quadratic equation
+    //   can cause t1 to be EPSTIME greater than tdelta and miss collision
     // force a collision in this special case by setting t1 = tdelta
 
     if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)
@@ -944,9 +945,10 @@ bool axi_horizontal_line(double tdelta, double *x, double *v,
     nc = 1;
   }
 
-  // check for roundoff issue which can miss a surf collision
-  // occurs when t1 or t2 is only EPSTIME greater than tdelta
-  //   due to round-off in solution to quadratic equation above
+  // check for roundoff issue which can occur when
+  //  axisym surf is nearly exactly on grid cell edge
+  // round-off in solution to quadratic equation
+  //   can cause t1 or t2 to be EPSTIME greater than tdelta and miss collision
   // force a collision in this special case by setting t1/t2 = tdelta
 
   if (t1 > tdelta && (t1-tdelta) < EPSTIME && tdelta > 0.0)


### PR DESCRIPTION
## Purpose

Add some code documentation info to a recent PR #528 for a round-off issue when axisymmetric surfs lie nearly exactly on a grid cell boundary.  Also reorder the if test logic to make it a bit more clear.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


