### PR TITLE
Fix rare issue with `Grid::point_outside_surfs_explicit` function

### DIFF
--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1522,6 +1522,43 @@ double tri_fraction(double *x, double *v0, double *v1, double *v2)
   return fracsq;
 }
 
+/* ----------------------------------------------------------------------
+   compute area of an arbitrary polygon
+   npoint = number of points
+   cpath = series of x,y,z triplets that define the polygon
+            e.g. returned from cut2/3d clip_external() function
+------------------------------------------------------------------------- */
+
+double poly_area(int npoint, double *cpath)
+{
+  double sum[3] = {0.0,0.0,0.0};
+  double v1[3],v2[3],xproduct[3];
+  double pt0[3],pti[3],ptip1[3];
+
+  pt0[0] = cpath[0];
+  pt0[1] = cpath[1];
+  pt0[2] = cpath[2];
+
+  for (int i = 1; i < npoint-1; i++) {
+    pti[0] = cpath[3*i];
+    pti[1] = cpath[3*i+1];
+    pti[2] = cpath[3*i+2];
+
+    ptip1[0] = cpath[3*(i+1)];
+    ptip1[1] = cpath[3*(i+1)+1];
+    ptip1[2] = cpath[3*(i+1)+2];
+
+    MathExtra::sub3(pti,pt0,v1);
+    MathExtra::sub3(ptip1,pt0,v2);
+    MathExtra::cross3(v1,v2,xproduct);
+    MathExtra::add3(sum,xproduct,sum);
+  }
+
+  double area = 0.5*sqrt(MathExtra::dot3(sum,sum));
+
+  return area;
+}
+
 /* ---------------------------------------------------------------------- */
 
 }

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -1523,17 +1523,22 @@ double tri_fraction(double *x, double *v0, double *v1, double *v2)
 }
 
 /* ----------------------------------------------------------------------
-   compute area of an arbitrary polygon
+   compute area of an arbitrary convex polygon (does not work for concave)
    npoint = number of points
    cpath = series of x,y,z triplets that define the polygon
             e.g. returned from cut2/3d clip_external() function
+   center = computed centroid of polygon
 ------------------------------------------------------------------------- */
 
-double poly_area(int npoint, double *cpath)
+double poly_area(int npoint, double *cpath, double* center)
 {
-  double sum[3] = {0.0,0.0,0.0};
+  double area = 0.0;
   double v1[3],v2[3],xproduct[3];
-  double pt0[3],pti[3],ptip1[3];
+  double pt0[3],pti[3],ptip1[3],tri_center[3];
+
+  center[0] = 0.0;
+  center[1] = 0.0;
+  center[2] = 0.0;
 
   pt0[0] = cpath[0];
   pt0[1] = cpath[1];
@@ -1551,10 +1556,16 @@ double poly_area(int npoint, double *cpath)
     MathExtra::sub3(pti,pt0,v1);
     MathExtra::sub3(ptip1,pt0,v2);
     MathExtra::cross3(v1,v2,xproduct);
-    MathExtra::add3(sum,xproduct,sum);
+    double tri_area = 0.5*sqrt(MathExtra::dot3(xproduct,xproduct));
+
+    MathExtra::add3(pt0,pti,tri_center);
+    MathExtra::add3(tri_center,ptip1,tri_center);
+    MathExtra::scale3(tri_area/3.0,tri_center);
+    MathExtra::add3(center,tri_center,center);
+    area += tri_area;
   }
 
-  double area = 0.5*sqrt(MathExtra::dot3(sum,sum));
+  MathExtra::scale3(1.0/area,center);
 
   return area;
 }

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -60,6 +60,7 @@ namespace Geometry {
 
   double line_fraction(double *, double *, double *);
   double tri_fraction(double *, double *, double *, double *);
+  double poly_area(int, double *);
 }
 
 #endif

--- a/src/geometry.h
+++ b/src/geometry.h
@@ -60,7 +60,7 @@ namespace Geometry {
 
   double line_fraction(double *, double *, double *);
   double tri_fraction(double *, double *, double *, double *);
-  double poly_area(int, double *);
+  double poly_area(int, double *, double *);
 }
 
 #endif

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1920,6 +1920,9 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
   double minsize = MIN(hi[0]-lo[0],hi[1]-lo[1]);
   double displace = EPSSURF * minsize;
 
+  double maxarea = 0.0;
+  int setflag = 0;
+
   if (dim == 2) {
     int npoint;
     double cpath[4];
@@ -1944,10 +1947,18 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
         if (edge == 4 and norm[1] > 0.0) continue;
       }
 
+      // use the surface with the largest clipped surface area
+      // for surfaces with a tiny interection, the point can get pushed
+      //  too far and end up inside nearby surfaces
+
+      double area = Geometry::poly_area(npoint,cpath);
+      if (area < maxarea) continue;
+      maxarea = area;
+
       x[0] = 0.5*(cpath[0]+cpath[2]) + displace*norm[0];
       x[1] = 0.5*(cpath[1]+cpath[3]) + displace*norm[1];
       x[2] = 0.0;
-      return 1;
+      setflag = 1;
     }
 
   } else {
@@ -1976,20 +1987,29 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
         if (face == 6 and norm[2] > 0.0) continue;
       }
 
+      // use the surface with the largest clipped surface area
+      // for surfaces with a tiny interection, the point can get pushed
+      //  too far and end up inside nearby surfaces
+
+      double area = Geometry::poly_area(npoint,cpath);
+      if (area < maxarea) continue;
+      maxarea = area;
+
       double onethird = 1.0/3.0;
       x[0] = onethird*(cpath[0]+cpath[3]+cpath[6]) + displace*norm[0];
       x[1] = onethird*(cpath[1]+cpath[4]+cpath[7]) + displace*norm[1];
       x[2] = onethird*(cpath[2]+cpath[5]+cpath[8]) + displace*norm[2];
-      return 1;
+      setflag = 1;
     }
   }
 
-  // unable to find a point in flow volume, all surfs invoked "continue"
-  // means entire cell is actually outside or inside, just touched by surfs
-  // if outside, caller does not need to call outside_surfs()
-  // if inside, caller can detect that its flow volume = zero
+  // if setflag equal to 0
+  //  unable to find a point in flow volume, all surfs invoked "continue"
+  //  means entire cell is actually outside or inside, just touched by surfs
+  //  if outside, caller does not need to call outside_surfs()
+  //  if inside, caller can detect that its flow volume = zero
 
-  return 0;
+  return setflag;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1993,12 +1993,12 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
       // use the surface with the largest clipped surface area
       // for surfaces with a tiny intersection, the point can get pushed
       //  too far and end up inside nearby surfaces
+      // push off the centroid of the polygon
 
       double center[3];
       double area = Geometry::poly_area(npoint,cpath,center);
       if (area < maxarea) continue;
       maxarea = area;
-
 
       x[0] = center[0] + displace*norm[0];
       x[1] = center[1] + displace*norm[1];

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1920,6 +1920,7 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
   double minsize = MIN(hi[0]-lo[0],hi[1]-lo[1]);
   double displace = EPSSURF * minsize;
 
+  double maxlength = 0.0;
   double maxarea = 0.0;
   int setflag = 0;
 
@@ -1947,13 +1948,15 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
         if (edge == 4 and norm[1] > 0.0) continue;
       }
 
-      // use the surface with the largest clipped surface area
-      // for surfaces with a tiny interection, the point can get pushed
+      // use the surface with the largest clipped length
+      // for surfaces with a tiny intersection, the point can get pushed
       //  too far and end up inside nearby surfaces
 
-      double area = Geometry::poly_area(npoint,cpath);
-      if (area < maxarea) continue;
-      maxarea = area;
+      double x1 = cpath[2] - cpath[0];
+      double y1 = cpath[3] - cpath[1];
+      double length = sqrt(x1*x1 + y1*y1);
+      if (length < maxlength) continue;
+      maxlength = length;
 
       x[0] = 0.5*(cpath[0]+cpath[2]) + displace*norm[0];
       x[1] = 0.5*(cpath[1]+cpath[3]) + displace*norm[1];
@@ -1988,17 +1991,18 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
       }
 
       // use the surface with the largest clipped surface area
-      // for surfaces with a tiny interection, the point can get pushed
+      // for surfaces with a tiny intersection, the point can get pushed
       //  too far and end up inside nearby surfaces
 
-      double area = Geometry::poly_area(npoint,cpath);
+      double center[3];
+      double area = Geometry::poly_area(npoint,cpath,center);
       if (area < maxarea) continue;
       maxarea = area;
 
-      double onethird = 1.0/3.0;
-      x[0] = onethird*(cpath[0]+cpath[3]+cpath[6]) + displace*norm[0];
-      x[1] = onethird*(cpath[1]+cpath[4]+cpath[7]) + displace*norm[1];
-      x[2] = onethird*(cpath[2]+cpath[5]+cpath[8]) + displace*norm[2];
+
+      x[0] = center[0] + displace*norm[0];
+      x[1] = center[1] + displace*norm[1];
+      x[2] = center[2] + displace*norm[2];
       setflag = 1;
     }
   }

--- a/src/grid_surf.cpp
+++ b/src/grid_surf.cpp
@@ -1948,9 +1948,13 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
         if (edge == 4 and norm[1] > 0.0) continue;
       }
 
-      // use the surface with the largest clipped length
-      // for surfaces with a tiny intersection, the point can get pushed
-      //  too far and end up inside nearby surfaces
+      // for surfaces with a tiny intersection, the point to push off
+      //  from can be very close to another line
+      // if the angle between the two lines is less than 90 degrees,
+      //  the pushed-off point can end up "inside" the surface instead
+      //  of "outside"
+      // using the line with the largest clipped length makes this
+      //  issue very unlikely to occur
 
       double x1 = cpath[2] - cpath[0];
       double y1 = cpath[3] - cpath[1];
@@ -1990,10 +1994,14 @@ int Grid::point_outside_surfs_explicit(int icell, double *x)
         if (face == 6 and norm[2] > 0.0) continue;
       }
 
-      // use the surface with the largest clipped surface area
-      // for surfaces with a tiny intersection, the point can get pushed
-      //  too far and end up inside nearby surfaces
-      // push off the centroid of the polygon
+      // for surfaces with a tiny intersection, the point to push off
+      //  from can be very close to a shared edge with another triangle
+      // if the angle between the two tris is less than 90 degrees,
+      //  the pushed-off point can end up "inside" the surface instead
+      //  of "outside"
+      // using the triangle with the largest clipped area
+      //  and pushing off its centroid makes this issue very unlikely
+      //  to occur
 
       double center[3];
       double area = Geometry::poly_area(npoint,cpath,center);


### PR DESCRIPTION
## Purpose

Fix rare issue with `Grid::point_outside_surfs_explicit` function. This issue caused particles to be created inside surfaces with `create_particles cut yes` and also gave false positives with `fix grid/check outside yes`, saying particles were inside surfaces when they were actually not.

When a surface was clipped to the cell bounds, if the intersection was tiny, the point "outside" the surfs could get pushed too far and actually end up inside nearby surfaces. The solution is to use the surface with the largest clipped area instead of the first surface, and push off the centroid of the entire polygon formed by the clipped surface instead of the center of the first triangle in the polygon. This should have no performance impact except when creating particles and when using `fix grid/check outside yes` which is already optional. `Fix ablate` uses implicit surfaces so it is not affected.

## Author(s)

Stan Moore (SNL), in discussion with Steve Plimpton (SNL retired)

## Backward Compatibility

Yes

## Implementation Notes

Only seen with the "spiky sphere" example (not in the public repo).
