### PR TITLE
Fix bug in `fix_ave_histo` and `fix_ave_histo_weight` with mixtures

### DIFF
--- a/src/KOKKOS/fix_ave_histo_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_kokkos.cpp
@@ -674,7 +674,7 @@ FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticles3, const int i,
                               minmax_type::value_type& lminmax) const
 {
   const int ispecies = d_particles(i).ispecies;
-  if (d_s2g(imix, ispecies) < 0)
+  if (d_s2g(imix, ispecies) >= 0)
   {
     bin_one(lminmax, d_values(i));
   }
@@ -722,7 +722,7 @@ FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesX1, const int i,
    * this code can be recommissioned.
    *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) < 0)
+  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
   {
     bin_one(lminmax, d_particles(i).x[index]);
   }
@@ -781,7 +781,7 @@ FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesV1, const int i,
    * this code can be recommissioned.
    *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) < 0)
+  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
   {
     bin_one(lminmax, d_particles(i).v[index]);
   }

--- a/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
@@ -460,7 +460,7 @@ FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticles3, const in
                                     minmax_type::value_type& lminmax) const
 {
   const int ispecies = d_particles(i).ispecies;
-  if (d_s2g(imix, ispecies) < 0)
+  if (d_s2g(imix, ispecies) >= 0)
   {
     bin_one(lminmax, d_values(i), d_weights(i));
   }
@@ -508,7 +508,7 @@ FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesX1, const i
    * this code can be recommissioned.
    *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) < 0)
+  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
   {
     bin_one(lminmax, d_particles(i).x[index], d_weights(i));
   }
@@ -567,7 +567,7 @@ FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesV1, const i
    * this code can be recommissioned.
    *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) < 0)
+  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
   {
     bin_one(lminmax, d_particles(i).v[index], d_weights(i));
   }

--- a/src/fix_ave_histo.cpp
+++ b/src/fix_ave_histo.cpp
@@ -903,7 +903,7 @@ void FixAveHisto::bin_particles(int attribute, int index)
       int *s2g = particle->mixture[imix]->species2group;
       for (int i = 0; i < nlocal; i++) {
         if (region->match(particles[i].x) &&
-            s2g[particles[i].ispecies] < 0) bin_one(particles[i].v[index]);
+            s2g[particles[i].ispecies] >= 0) bin_one(particles[i].v[index]);
       }
     } else if (regionflag) {
       for (int i = 0; i < nlocal; i++) {
@@ -950,7 +950,7 @@ void FixAveHisto::bin_particles(double *values, int stride)
   } else if (mixflag) {
     int *s2g = particle->mixture[imix]->species2group;
     for (int i = 0; i < nlocal; i++) {
-      if (s2g[particles[i].ispecies] < 0) bin_one(values[m]);
+      if (s2g[particles[i].ispecies] >= 0) bin_one(values[m]);
       m += stride;
     }
   } else {

--- a/src/fix_ave_histo_weight.cpp
+++ b/src/fix_ave_histo_weight.cpp
@@ -332,7 +332,7 @@ void FixAveHistoWeight::bin_particles(int attribute, int index)
     if (regionflag && mixflag) {
       for (int i = 0; i < nlocal; i++) {
         if (region->match(particles[i].x) &&
-            s2g[particles[i].ispecies] < 0)
+            s2g[particles[i].ispecies] >= 0)
           bin_one_weight(particles[i].x[index],weights[mwt]);
         mwt += stridewt;
       }
@@ -359,7 +359,7 @@ void FixAveHistoWeight::bin_particles(int attribute, int index)
     if (regionflag && mixflag) {
       for (int i = 0; i < nlocal; i++) {
         if (region->match(particles[i].x) &&
-            s2g[particles[i].ispecies] < 0)
+            s2g[particles[i].ispecies] >= 0)
           bin_one_weight(particles[i].v[index],weights[mwt]);
         mwt += stridewt;
       }
@@ -418,7 +418,7 @@ void FixAveHistoWeight::bin_particles(double *values, int stride)
     }
   } else if (mixflag) {
     for (int i = 0; i < nlocal; i++) {
-      if (s2g[particles[i].ispecies] < 0)
+      if (s2g[particles[i].ispecies] >= 0)
         bin_one_weight(values[m],weights[mwt]);
       m += stride;
       mwt += stridewt;


### PR DESCRIPTION
## Purpose

Fix bug in `fix_ave_histo` and `fix_ave_histo_weight` leading to particles not being tallied correctly when using the mixtures with the `mix` keyword.

## Author(s)

Stan Moore (SNL), reported by Michael Gallis (SNL)

## Backward Compatibility

Yes

## Implementation Notes

Tested to fix an input from Michael