### PR TITLE
Clarify write_surf doc page for output of implicit surfs

### DIFF
--- a/doc/write_surf.html
+++ b/doc/write_surf.html
@@ -56,11 +56,12 @@ or triangles (3d).  Similarly, if surface elements have been removed
 by the <A HREF = "remove_surf.html">remove_surf</A> command, then points may have
 also been deleted.  In either case, surface points and elements are
 renumbered by these operations to create compressed, contiguous lists.
-These lists are what is output by this command.
+These lists of surface elements are what is output by this command.
 </P>
 <P>The output file is written as a text file in the same format as the
 file the <A HREF = "read_surf.html">read_surf</A> command reads for explicit
-surfaces.
+surfaces.  See the <A HREF = "read_surf.html">read_surf</A> doc page for a
+description of its format.
 </P>
 <P>Similar to <A HREF = "dump.html">dump</A> files, the surface filename can contain
 two wild-card characters.  If a "*" appears in the filename, it is
@@ -80,10 +81,19 @@ discussed below can alter the number of files written.
 </P>
 <P>Note that implicit surfaces read in by the
 <A HREF = "read_isurf.html">read_isurf</A> command can be written out by the
-write_surf command, e.g. for visualization purposes.  But the file
-created by this command cannot be read back in to SPARTA via the
-<A HREF = "read_isurf.html">read_isurf</A> command, because this command creates
-files in an explicit surface format.
+write_surf command, e.g. for visualization purposes or to start a
+second simulation treating implicit surfaces previously ablated via
+the <A HREF = "fix_ablate.html">fix ablate</A> command as constant, unchanging
+explicit surfaces.  Because this command creates files in an explicit
+surface format, it can only be read back in to SPARTA via the
+<A HREF = "read_surf.html">read_surf</A> command.  It cannot be read back in via the
+<A HREF = "read_isurf.html">read_isurf</A> command.
+</P>
+<P>Also note, that implicit surfaces use the grid cell ID as the surface
+element ID for all line segments (2d) or triangles (3d) in the same
+grid cell.  When this command writes them to a file, the surface
+element IDs in the file become integers between 1 and N, where N is
+the total number of implicit surface elements.
 </P>
 <P>See the <A HREF = "Section_howto.html#howto_13">Howto 6.13</A> section of the manual
 for a discussion of explicit and implicit surfaces as well as

--- a/doc/write_surf.txt
+++ b/doc/write_surf.txt
@@ -49,11 +49,12 @@ or triangles (3d).  Similarly, if surface elements have been removed
 by the "remove_surf"_remove_surf.html command, then points may have
 also been deleted.  In either case, surface points and elements are
 renumbered by these operations to create compressed, contiguous lists.
-These lists are what is output by this command.
+These lists of surface elements are what is output by this command.
 
 The output file is written as a text file in the same format as the
 file the "read_surf"_read_surf.html command reads for explicit
-surfaces.
+surfaces.  See the "read_surf"_read_surf.html doc page for a
+description of its format.
 
 Similar to "dump"_dump.html files, the surface filename can contain
 two wild-card characters.  If a "*" appears in the filename, it is
@@ -73,10 +74,19 @@ discussed below can alter the number of files written.
 
 Note that implicit surfaces read in by the
 "read_isurf"_read_isurf.html command can be written out by the
-write_surf command, e.g. for visualization purposes.  But the file
-created by this command cannot be read back in to SPARTA via the
-"read_isurf"_read_isurf.html command, because this command creates
-files in an explicit surface format.
+write_surf command, e.g. for visualization purposes or to start a
+second simulation treating implicit surfaces previously ablated via
+the "fix ablate"_fix_ablate.html command as constant, unchanging
+explicit surfaces.  Because this command creates files in an explicit
+surface format, it can only be read back in to SPARTA via the
+"read_surf"_read_surf.html command.  It cannot be read back in via the
+"read_isurf"_read_isurf.html command.
+
+Also note, that implicit surfaces use the grid cell ID as the surface
+element ID for all line segments (2d) or triangles (3d) in the same
+grid cell.  When this command writes them to a file, the surface
+element IDs in the file become integers between 1 and N, where N is
+the total number of implicit surface elements.
 
 See the "Howto 6.13"_Section_howto.html#howto_13 section of the manual
 for a discussion of explicit and implicit surfaces as well as


### PR DESCRIPTION
## Purpose

On the write_surf doc page, explain in more details how implicit surfs can be written out as explicit surfs.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


