### PR TITLE
Manual TOC for Section_start was out-of-date

### DIFF
--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -106,7 +106,7 @@ it gives quick access to documentation for all SPARTA commands.
 <BR>
   2.4 <A HREF = "Section_start.html#start_4">Building SPARTA as a library</A> 
 <BR>
-  2.5 <A HREF = "Section_start.html#start_5">Tseting SPARTA</A> 
+  2.5 <A HREF = "Section_start.html#start_5">Testing SPARTA</A> 
 <BR>
   2.6 <A HREF = "Section_start.html#start_6">Running SPARTA</A> 
 <BR>

--- a/doc/Manual.html
+++ b/doc/Manual.html
@@ -106,11 +106,13 @@ it gives quick access to documentation for all SPARTA commands.
 <BR>
   2.4 <A HREF = "Section_start.html#start_4">Building SPARTA as a library</A> 
 <BR>
-  2.5 <A HREF = "Section_start.html#start_5">Running SPARTA</A> 
+  2.5 <A HREF = "Section_start.html#start_5">Tseting SPARTA</A> 
 <BR>
-  2.6 <A HREF = "Section_start.html#start_6">Command-line options</A> 
+  2.6 <A HREF = "Section_start.html#start_6">Running SPARTA</A> 
 <BR>
-  2.7 <A HREF = "Section_start.html#start_7">Screen output</A> 
+  2.7 <A HREF = "Section_start.html#start_7">Command-line options</A> 
+<BR>
+  2.8 <A HREF = "start_8">Screen output</A> 
 <BR></UL>
 <LI><A HREF = "Section_commands.html">Commands</A> 
 

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -90,9 +90,10 @@ it gives quick access to documentation for all SPARTA commands.
   2.2 "Making SPARTA"_start_2 :b
   2.3 "Building SPARTA with optional packages"_start_3 :b
   2.4 "Building SPARTA as a library"_start_4 :b
-  2.5 "Running SPARTA"_start_5 :b
-  2.6 "Command-line options"_start_6 :b
-  2.7 "Screen output"_start_7 :ule,b
+  2.5 "Tseting SPARTA"_start_5 :b
+  2.6 "Running SPARTA"_start_6 :b
+  2.7 "Command-line options"_start_7 :b
+  2.8 "Screen output"_start_8 :ule,b
 "Commands"_Section_commands.html :l
   3.1 "SPARTA input script"_cmd_1 :ulb,b
   3.2 "Parsing rules"_cmd_2 :b

--- a/doc/Manual.txt
+++ b/doc/Manual.txt
@@ -90,7 +90,7 @@ it gives quick access to documentation for all SPARTA commands.
   2.2 "Making SPARTA"_start_2 :b
   2.3 "Building SPARTA with optional packages"_start_3 :b
   2.4 "Building SPARTA as a library"_start_4 :b
-  2.5 "Tseting SPARTA"_start_5 :b
+  2.5 "Testing SPARTA"_start_5 :b
   2.6 "Running SPARTA"_start_6 :b
   2.7 "Command-line options"_start_7 :b
   2.8 "Screen output"_start_8 :ule,b

--- a/doc/Section_accelerate.html
+++ b/doc/Section_accelerate.html
@@ -50,7 +50,7 @@ typically no need to run for 1000s of timesteps to get accurate
 timings; you can simply extrapolate from short runs.
 </P>
 <P>For the set of runs, look at the timing data printed to the screen and
-log file at the end of each SPARTA run.  <A HREF = "Section_start.html#start_7">This
+log file at the end of each SPARTA run.  <A HREF = "Section_start.html#start_8">This
 section</A> of the manual has an overview.
 </P>
 <P>Running on one (or a few processors) should give a good estimate of
@@ -141,9 +141,9 @@ it provides, follow these general steps:
 </P>
 <DIV ALIGN=center><TABLE  BORDER=1 >
 <TR><TD >prepare and test a regular SPARTA simulation </TD><TD >  lmp_kokkos_cuda -in in.script; mpirun -np 32 lmp_kokkos_cuda -in in.script </TD></TR>
-<TR><TD >enable specific accelerator support via '-k on' <A HREF = "Section_start.html#start_6">command-line switch</A>, </TD><TD >  -k on g 1 </TD></TR>
-<TR><TD >set any needed options for the package via "-pk" <A HREF = "Section_start.html#start_6">command-line switch</A> or <A HREF = "package.html">package</A> command, </TD><TD >  only if defaults need to be changed, -pk kokkos react/retry yes </TD></TR>
-<TR><TD >use accelerated styles in your input via "-sf" <A HREF = "Section_start.html#start_6">command-line switch</A> or <A HREF = "suffix.html">suffix</A> command </TD><TD > lmp_kokkos_cuda -in in.script -sf kk
+<TR><TD >enable specific accelerator support via '-k on' <A HREF = "Section_start.html#start_7">command-line switch</A>, </TD><TD >  -k on g 1 </TD></TR>
+<TR><TD >set any needed options for the package via "-pk" <A HREF = "Section_start.html#start_7">command-line switch</A> or <A HREF = "package.html">package</A> command, </TD><TD >  only if defaults need to be changed, -pk kokkos react/retry yes </TD></TR>
+<TR><TD >use accelerated styles in your input via "-sf" <A HREF = "Section_start.html#start_7">command-line switch</A> or <A HREF = "suffix.html">suffix</A> command </TD><TD > lmp_kokkos_cuda -in in.script -sf kk
 </TD></TR></TABLE></DIV>
 
 <P>Note that the first 3 steps can be done as a single command with

--- a/doc/Section_accelerate.txt
+++ b/doc/Section_accelerate.txt
@@ -46,7 +46,7 @@ timings; you can simply extrapolate from short runs.
 
 For the set of runs, look at the timing data printed to the screen and
 log file at the end of each SPARTA run.  "This
-section"_Section_start.html#start_7 of the manual has an overview.
+section"_Section_start.html#start_8 of the manual has an overview.
 
 Running on one (or a few processors) should give a good estimate of
 the serial performance and what portions of the timestep are taking
@@ -140,11 +140,11 @@ Then do the following:
 
 prepare and test a regular SPARTA simulation |
   lmp_kokkos_cuda -in in.script; mpirun -np 32 lmp_kokkos_cuda -in in.script |
-enable specific accelerator support via '-k on' "command-line switch"_Section_start.html#start_6, |
+enable specific accelerator support via '-k on' "command-line switch"_Section_start.html#start_7, |
   -k on g 1 |
-set any needed options for the package via "-pk" "command-line switch"_Section_start.html#start_6 or "package"_package.html command, |
+set any needed options for the package via "-pk" "command-line switch"_Section_start.html#start_7 or "package"_package.html command, |
   only if defaults need to be changed, -pk kokkos react/retry yes |
-use accelerated styles in your input via "-sf" "command-line switch"_Section_start.html#start_6 or "suffix"_suffix.html command | lmp_kokkos_cuda -in in.script -sf kk
+use accelerated styles in your input via "-sf" "command-line switch"_Section_start.html#start_7 or "suffix"_suffix.html command | lmp_kokkos_cuda -in in.script -sf kk
 :tb(c=2,s=|)
 
 Note that the first 3 steps can be done as a single command with

--- a/doc/Section_errors.html
+++ b/doc/Section_errors.html
@@ -52,7 +52,7 @@ the <A HREF = "https://sparta.github.io/authors.html">developers</A>.
 <P>If you get an error message about an invalid command in your input
 script, you can determine what command is causing the problem by
 looking in the log.sparta file, or using the <A HREF = "echo.html">echo command</A>
-in your script or "-echo screen" as a <A HREF = "Section_start.html#start_6">command-line
+in your script or "-echo screen" as a <A HREF = "Section_start.html#start_7">command-line
 argument</A> to see it on the screen.  For a
 given command, SPARTA expects certain arguments in a specified order.
 If you mess this up, SPARTA will often flag the error, but it may read

--- a/doc/Section_errors.txt
+++ b/doc/Section_errors.txt
@@ -50,7 +50,7 @@ If you get an error message about an invalid command in your input
 script, you can determine what command is causing the problem by
 looking in the log.sparta file, or using the "echo command"_echo.html
 in your script or "-echo screen" as a "command-line
-argument"_Section_start.html#start_6 to see it on the screen.  For a
+argument"_Section_start.html#start_7 to see it on the screen.  For a
 given command, SPARTA expects certain arguments in a specified order.
 If you mess this up, SPARTA will often flag the error, but it may read
 a bogus argument and assign a value that is valid, but not what you

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -176,7 +176,7 @@ jump in.flow
 <P>All of the above examples work whether you are running on 1 or
 multiple processors, but assumed you are running SPARTA on a single
 partition of processors.  SPARTA can be run on multiple partitions via
-the "-partition" command-line switch as described in <A HREF = "Section_start.html#start_6">Section
+the "-partition" command-line switch as described in <A HREF = "Section_start.html#start_7">Section
 2.5</A> of the manual.
 </P>
 <P>In the last 2 examples, if SPARTA were run on 3 partitions, the same
@@ -490,7 +490,7 @@ void sparta_file(void *, char *);
 char *sparta_command(void *, char *); 
 </PRE>
 <P>The sparta_open() function is used to initialize SPARTA, passing in a
-list of strings as if they were <A HREF = "Section_start.html#start_6">command-line
+list of strings as if they were <A HREF = "Section_start.html#start_7">command-line
 arguments</A> when SPARTA is run in
 stand-alone mode from the command line, and a MPI communicator for
 SPARTA to run under.  It returns a ptr to the SPARTA object that is

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -173,7 +173,7 @@ All of the above examples work whether you are running on 1 or
 multiple processors, but assumed you are running SPARTA on a single
 partition of processors.  SPARTA can be run on multiple partitions via
 the "-partition" command-line switch as described in "Section
-2.5"_Section_start.html#start_6 of the manual.
+2.5"_Section_start.html#start_7 of the manual.
 
 In the last 2 examples, if SPARTA were run on 3 partitions, the same
 scripts could be used if the "index" and "loop" variables were
@@ -481,7 +481,7 @@ char *sparta_command(void *, char *); :pre
 
 The sparta_open() function is used to initialize SPARTA, passing in a
 list of strings as if they were "command-line
-arguments"_Section_start.html#start_6 when SPARTA is run in
+arguments"_Section_start.html#start_7 when SPARTA is run in
 stand-alone mode from the command line, and a MPI communicator for
 SPARTA to run under.  It returns a ptr to the SPARTA object that is
 created, and which is used in subsequent library calls.  The

--- a/doc/Section_packages.html
+++ b/doc/Section_packages.html
@@ -115,7 +115,7 @@ CPUs, KNLs, or GPUs.  All the styles have a "kk" as a suffix in their
 style name.  <A HREF = "Section_accelerate.html#acc_3">Section 5.3</A> gives details
 of what hardware and software is required on your system, and how to
 build and use this package.  Its styles can be invoked at run time via
-the "-sf kk" or "-suffix kk" <A HREF = "Section_start.html#start_6">command-line
+the "-sf kk" or "-suffix kk" <A HREF = "Section_start.html#start_7">command-line
 switches</A>.
 </P>
 <P>You must have a C++17 compatible compiler to use this package.
@@ -212,9 +212,9 @@ make
 <LI>lib/kokkos/README
 <LI>the <A HREF = "Section_accelerate.html#acc_3">Accelerating SPARTA</A> section
 <LI><A HREF = "Section_accelerate.html#acc_3">Section 5.3</A>
-<LI><A HREF = "Section_start.html#start_6">Section 2.6 -k on ...</A>
-<LI><A HREF = "Section_start.html#start_6">Section 2.6 -sf kk</A>
-<LI><A HREF = "Section_start.html#start_6">Section 2.6 -pk kokkos</A>
+<LI><A HREF = "Section_start.html#start_7">Section 2.6 -k on ...</A>
+<LI><A HREF = "Section_start.html#start_7">Section 2.6 -sf kk</A>
+<LI><A HREF = "Section_start.html#start_7">Section 2.6 -pk kokkos</A>
 <LI><A HREF = "package.html">package kokkos</A>
 <LI><A HREF = "https://sparta.github.io/bench.html">Benchmarks page</A> of web site 
 </UL>

--- a/doc/Section_packages.txt
+++ b/doc/Section_packages.txt
@@ -111,7 +111,7 @@ style name.  "Section 5.3"_Section_accelerate.html#acc_3 gives details
 of what hardware and software is required on your system, and how to
 build and use this package.  Its styles can be invoked at run time via
 the "-sf kk" or "-suffix kk" "command-line
-switches"_Section_start.html#start_6.
+switches"_Section_start.html#start_7.
 
 You must have a C++17 compatible compiler to use this package.
 
@@ -207,8 +207,8 @@ src/KOKKOS/README
 lib/kokkos/README
 the "Accelerating SPARTA"_Section_accelerate.html#acc_3 section
 "Section 5.3"_Section_accelerate.html#acc_3
-"Section 2.6 -k on ..."_Section_start.html#start_6
-"Section 2.6 -sf kk"_Section_start.html#start_6
-"Section 2.6 -pk kokkos"_Section_start.html#start_6
+"Section 2.6 -k on ..."_Section_start.html#start_7
+"Section 2.6 -sf kk"_Section_start.html#start_7
+"Section 2.6 -pk kokkos"_Section_start.html#start_7
 "package kokkos"_package.html
 "Benchmarks page"_https://sparta.github.io/bench.html of web site :ul

--- a/doc/collide.html
+++ b/doc/collide.html
@@ -218,7 +218,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/collide.txt
+++ b/doc/collide.txt
@@ -211,7 +211,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_boundary.html
+++ b/doc/compute_boundary.html
@@ -250,7 +250,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_boundary.txt
+++ b/doc/compute_boundary.txt
@@ -241,7 +241,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_count.html
+++ b/doc/compute_count.html
@@ -90,7 +90,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_count.txt
+++ b/doc/compute_count.txt
@@ -83,7 +83,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_distsurf_grid.html
+++ b/doc/compute_distsurf_grid.html
@@ -143,7 +143,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.htmls#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_distsurf_grid.txt
+++ b/doc/compute_distsurf_grid.txt
@@ -133,7 +133,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.htmls#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_dt_grid.html
+++ b/doc/compute_dt_grid.html
@@ -146,7 +146,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_dt_grid.txt
+++ b/doc/compute_dt_grid.txt
@@ -134,7 +134,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_eflux_grid.html
+++ b/doc/compute_eflux_grid.html
@@ -167,7 +167,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_eflux_grid.txt
+++ b/doc/compute_eflux_grid.txt
@@ -157,7 +157,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_fft_grid.html
+++ b/doc/compute_fft_grid.html
@@ -211,7 +211,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_fft_grid.txt
+++ b/doc/compute_fft_grid.txt
@@ -199,7 +199,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_grid.html
+++ b/doc/compute_grid.html
@@ -333,7 +333,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_grid.txt
+++ b/doc/compute_grid.txt
@@ -321,7 +321,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_ke_particle.html
+++ b/doc/compute_ke_particle.html
@@ -68,7 +68,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_ke_particle.txt
+++ b/doc/compute_ke_particle.txt
@@ -65,7 +65,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_lambda_grid.html
+++ b/doc/compute_lambda_grid.html
@@ -219,7 +219,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_lambda_grid.txt
+++ b/doc/compute_lambda_grid.txt
@@ -212,7 +212,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_pflux_grid.html
+++ b/doc/compute_pflux_grid.html
@@ -176,7 +176,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_pflux_grid.txt
+++ b/doc/compute_pflux_grid.txt
@@ -166,7 +166,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_property_grid.html
+++ b/doc/compute_property_grid.html
@@ -127,7 +127,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_property_grid.txt
+++ b/doc/compute_property_grid.txt
@@ -119,7 +119,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_sonine_grid.html
+++ b/doc/compute_sonine_grid.html
@@ -187,7 +187,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_sonine_grid.txt
+++ b/doc/compute_sonine_grid.txt
@@ -177,7 +177,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_surf.html
+++ b/doc/compute_surf.html
@@ -426,7 +426,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_surf.txt
+++ b/doc/compute_surf.txt
@@ -413,7 +413,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_temp.html
+++ b/doc/compute_temp.html
@@ -66,7 +66,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_temp.txt
+++ b/doc/compute_temp.txt
@@ -63,7 +63,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/compute_thermal_grid.html
+++ b/doc/compute_thermal_grid.html
@@ -178,7 +178,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/compute_thermal_grid.txt
+++ b/doc/compute_thermal_grid.txt
@@ -168,7 +168,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/create_grid.html
+++ b/doc/create_grid.html
@@ -111,7 +111,7 @@ of each processor's sub-block of cells.
 <P>The product of Px, Py, Pz must equal P, the total # of processors
 SPARTA is running on.  For a 2d simulation, Pz must equal 1. If
 multiple partitions are being used then P is the number of processors
-in this partition; see <A HREF = "Section_start.html#start_6">Section 2.6</A> for an
+in this partition; see <A HREF = "Section_start.html#start_7">Section 2.6</A> for an
 explanation of the -partition command-line switch.
 </P>
 <P>Note that if you run on a large, prime number of processors P, then a

--- a/doc/create_grid.txt
+++ b/doc/create_grid.txt
@@ -104,7 +104,7 @@ of each processor's sub-block of cells.
 The product of Px, Py, Pz must equal P, the total # of processors
 SPARTA is running on.  For a 2d simulation, Pz must equal 1. If
 multiple partitions are being used then P is the number of processors
-in this partition; see "Section 2.6"_Section_start.html#start_6 for an
+in this partition; see "Section 2.6"_Section_start.html#start_7 for an
 explanation of the -partition command-line switch.
 
 Note that if you run on a large, prime number of processors P, then a

--- a/doc/create_particles.html
+++ b/doc/create_particles.html
@@ -354,7 +354,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/create_particles.txt
+++ b/doc/create_particles.txt
@@ -345,7 +345,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/echo.html
+++ b/doc/echo.html
@@ -29,7 +29,7 @@ command to the screen and/or log file as it is read and processed.  If
 an input script has errors, it can be useful to look at echoed output
 to see the last command processed.
 </P>
-<P>The <A HREF = "Section_start.html#start_6">command-line switch</A> -echo can be used
+<P>The <A HREF = "Section_start.html#start_7">command-line switch</A> -echo can be used
 in place of this command.
 </P>
 <P><B>Restrictions:</B> none

--- a/doc/echo.txt
+++ b/doc/echo.txt
@@ -26,7 +26,7 @@ command to the screen and/or log file as it is read and processed.  If
 an input script has errors, it can be useful to look at echoed output
 to see the last command processed.
 
-The "command-line switch"_Section_start.html#start_6 -echo can be used
+The "command-line switch"_Section_start.html#start_7 -echo can be used
 in place of this command.
 
 [Restrictions:] none

--- a/doc/fix_adapt.html
+++ b/doc/fix_adapt.html
@@ -105,7 +105,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_adapt.txt
+++ b/doc/fix_adapt.txt
@@ -102,7 +102,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_ambipolar.html
+++ b/doc/fix_ambipolar.html
@@ -104,7 +104,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_ambipolar.txt
+++ b/doc/fix_ambipolar.txt
@@ -101,7 +101,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_ave_grid.html
+++ b/doc/fix_ave_grid.html
@@ -257,7 +257,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_ave_grid.txt
+++ b/doc/fix_ave_grid.txt
@@ -244,7 +244,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_ave_histo.html
+++ b/doc/fix_ave_histo.html
@@ -371,7 +371,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_ave_histo.txt
+++ b/doc/fix_ave_histo.txt
@@ -353,7 +353,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_balance.html
+++ b/doc/fix_balance.html
@@ -220,7 +220,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_balance.txt
+++ b/doc/fix_balance.txt
@@ -208,7 +208,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_emit_face.html
+++ b/doc/fix_emit_face.html
@@ -243,7 +243,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_emit_face.txt
+++ b/doc/fix_emit_face.txt
@@ -233,7 +233,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_grid_check.html
+++ b/doc/fix_grid_check.html
@@ -93,7 +93,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_grid_check.txt
+++ b/doc/fix_grid_check.txt
@@ -83,7 +83,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_move_surf.html
+++ b/doc/fix_move_surf.html
@@ -93,7 +93,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_move_surf.txt
+++ b/doc/fix_move_surf.txt
@@ -90,7 +90,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/fix_temp_rescale.html
+++ b/doc/fix_temp_rescale.html
@@ -125,7 +125,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/fix_temp_rescale.txt
+++ b/doc/fix_temp_rescale.txt
@@ -115,7 +115,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/jump.html
+++ b/doc/jump.html
@@ -43,12 +43,12 @@ e.g.
 </PRE>
 <P>since the SELF option invokes the C-library rewind() call, which may
 not be supported for stdin on some systems or by some MPI
-implementations.  This can be worked around by using the <A HREF = "Section_start.html#start_6">-in
+implementations.  This can be worked around by using the <A HREF = "Section_start.html#start_7">-in
 command-line argument</A>, e.g.
 </P>
 <PRE>spa_g++ -in in.script 
 </PRE>
-<P>or by using the <A HREF = "Section_start.html#start_6">-var command-line
+<P>or by using the <A HREF = "Section_start.html#start_7">-var command-line
 argument</A> to pass the script name as a
 variable to the input script.  In the latter case, a
 <A HREF = "variable.html">variable</A> called "fname" could be used in place of

--- a/doc/jump.txt
+++ b/doc/jump.txt
@@ -41,12 +41,12 @@ spa_g++ < in.script :pre
 since the SELF option invokes the C-library rewind() call, which may
 not be supported for stdin on some systems or by some MPI
 implementations.  This can be worked around by using the "-in
-command-line argument"_Section_start.html#start_6, e.g.
+command-line argument"_Section_start.html#start_7, e.g.
 
 spa_g++ -in in.script :pre
 
 or by using the "-var command-line
-argument"_Section_start.html#start_6 to pass the script name as a
+argument"_Section_start.html#start_7 to pass the script name as a
 variable to the input script.  In the latter case, a
 "variable"_variable.html called "fname" could be used in place of
 SELF, e.g.

--- a/doc/log.html
+++ b/doc/log.html
@@ -38,7 +38,7 @@ the same log file.
 </P>
 <P>The file "log.sparta" is the default log file for a SPARTA run.  The
 name of the initial log file can also be set by the command-line
-switch -log.  See <A HREF = "Section_start.html#start_6">Section 2.6</A> for
+switch -log.  See <A HREF = "Section_start.html#start_7">Section 2.6</A> for
 details.
 </P>
 <P><B>Restrictions:</B> none

--- a/doc/log.txt
+++ b/doc/log.txt
@@ -34,7 +34,7 @@ the same log file.
 
 The file "log.sparta" is the default log file for a SPARTA run.  The
 name of the initial log file can also be set by the command-line
-switch -log.  See "Section 2.6"_Section_start.html#start_6 for
+switch -log.  See "Section 2.6"_Section_start.html#start_7 for
 details.
 
 [Restrictions:] none

--- a/doc/next.html
+++ b/doc/next.html
@@ -69,7 +69,7 @@ next value (for each variable) is assigned to whichever processor
 partition executes the command first.  All processors in the partition
 are assigned the same value(s).  Running SPARTA on multiple partitions
 of processors via the "-partition" command-line switch is described in
-<A HREF = "Section_start.html#start_6">Section 2.6</A> of the manual.  <I>Universe</I>-
+<A HREF = "Section_start.html#start_7">Section 2.6</A> of the manual.  <I>Universe</I>-
 and <I>uloop</I>-style variables are incremented using the files
 "tmp.sparta.variable" and "tmp.sparta.variable.lock" which you will
 see in your directory during and after such a SPARTA run.

--- a/doc/next.txt
+++ b/doc/next.txt
@@ -66,7 +66,7 @@ next value (for each variable) is assigned to whichever processor
 partition executes the command first.  All processors in the partition
 are assigned the same value(s).  Running SPARTA on multiple partitions
 of processors via the "-partition" command-line switch is described in
-"Section 2.6"_Section_start.html#start_6 of the manual.  {Universe}-
+"Section 2.6"_Section_start.html#start_7 of the manual.  {Universe}-
 and {uloop}-style variables are incremented using the files
 "tmp.sparta.variable" and "tmp.sparta.variable.lock" which you will
 see in your directory during and after such a SPARTA run.

--- a/doc/package.html
+++ b/doc/package.html
@@ -53,7 +53,7 @@ is because it specifies settings that the accelerator package used in
 its initialization, before a simulation is defined.
 </P>
 <P>This command can also be specified from the command-line when
-launching SPARTA, using the "-pk" <A HREF = "Section_start.html#start_6">command-line
+launching SPARTA, using the "-pk" <A HREF = "Section_start.html#start_7">command-line
 switch</A>.  The syntax is exactly the same as
 when used in an input script.
 </P>
@@ -62,13 +62,13 @@ to be specified, if the package is to be used in a simulation (SPARTA
 can be built with the accelerator package without using it in a
 particular simulation).  However, a default version of the command is
 typically invoked by other accelerator settings. For example, the
-KOKKOS package requires a "-k on" <A HREF = "Section_start.html#start_6">command-line
+KOKKOS package requires a "-k on" <A HREF = "Section_start.html#start_7">command-line
 switch</A> respectively, which invokes a
 "package kokkos" command with default settings.
 </P>
 <P>NOTE: A package command for a particular style can be invoked multiple
 times when a simulation is setup, e.g. by the "-k on", "-sf", and
-"-pk" <A HREF = "Section_start.html#start_6">command-line switches</A>, and by using
+"-pk" <A HREF = "Section_start.html#start_7">command-line switches</A>, and by using
 this command in an input script.  Each time it is used all of the
 style options are set, either to default values or to specified
 settings.  I.e. settings from previous invocations do not persist
@@ -136,7 +136,7 @@ SPARTA</A> section for more info.
 </P>
 <P><B>Related commands:</B>
 </P>
-<P><A HREF = "suffix.html">suffix</A>, "-pk" <A HREF = "Section_start.html#start_6">command-line
+<P><A HREF = "suffix.html">suffix</A>, "-pk" <A HREF = "Section_start.html#start_7">command-line
 setting</A>
 </P>
 <P><B>Default:</B>
@@ -144,9 +144,9 @@ setting</A>
 <P>For the KOKKOS package, the option defaults are react/extra = 1.1,
 react/retry = no, and gpu/aware yes. For CPUs: comm = serial, and for
 GPUs: comm = threaded.  These settings are made automatically by the
-required "-k on" <A HREF = "Section_start.html#start_6">command-line switch</A>. You
+required "-k on" <A HREF = "Section_start.html#start_7">command-line switch</A>. You
 can change them by using the package kokkos command in your input script
-or via the "-pk kokkos" <A HREF = "Section_start.html#start_6">command-line
+or via the "-pk kokkos" <A HREF = "Section_start.html#start_7">command-line
 switch</A>. 
 </P>
 </HTML>

--- a/doc/package.txt
+++ b/doc/package.txt
@@ -48,7 +48,7 @@ its initialization, before a simulation is defined.
 
 This command can also be specified from the command-line when
 launching SPARTA, using the "-pk" "command-line
-switch"_Section_start.html#start_6.  The syntax is exactly the same as
+switch"_Section_start.html#start_7.  The syntax is exactly the same as
 when used in an input script.
 
 Note that the KOKKOS accelerator package requires the package command
@@ -57,12 +57,12 @@ can be built with the accelerator package without using it in a
 particular simulation).  However, a default version of the command is
 typically invoked by other accelerator settings. For example, the
 KOKKOS package requires a "-k on" "command-line
-switch"_Section_start.html#start_6 respectively, which invokes a
+switch"_Section_start.html#start_7 respectively, which invokes a
 "package kokkos" command with default settings.
 
 NOTE: A package command for a particular style can be invoked multiple
 times when a simulation is setup, e.g. by the "-k on", "-sf", and
-"-pk" "command-line switches"_Section_start.html#start_6, and by using
+"-pk" "command-line switches"_Section_start.html#start_7, and by using
 this command in an input script.  Each time it is used all of the
 style options are set, either to default values or to specified
 settings.  I.e. settings from previous invocations do not persist
@@ -131,14 +131,14 @@ SPARTA"_Section_start.html#start_3 section for more info.
 [Related commands:]
 
 "suffix"_suffix.html, "-pk" "command-line
-setting"_Section_start.html#start_6
+setting"_Section_start.html#start_7
 
 [Default:]
 
 For the KOKKOS package, the option defaults are react/extra = 1.1,
 react/retry = no, and gpu/aware yes. For CPUs: comm = serial, and for
 GPUs: comm = threaded.  These settings are made automatically by the
-required "-k on" "command-line switch"_Section_start.html#start_6. You
+required "-k on" "command-line switch"_Section_start.html#start_7. You
 can change them by using the package kokkos command in your input script
 or via the "-pk kokkos" "command-line
-switch"_Section_start.html#start_6. 
+switch"_Section_start.html#start_7. 

--- a/doc/partition.html
+++ b/doc/partition.html
@@ -30,7 +30,7 @@ partition yes 6* fix all nvt temp 1.0 1.0 0.1
 </P>
 <P>This command invokes the specified command on a subset of the
 partitions of processors you have defined via the -partition
-command-line switch.  See <A HREF = "Section_start.html#start_6">Section 2.6</A> of
+command-line switch.  See <A HREF = "Section_start.html#start_7">Section 2.6</A> of
 the manual for an explanation of the switch.
 </P>
 <P>Normally, every input script command in your script is invoked by
@@ -51,7 +51,7 @@ will be invoked on all the partitions which do not match the Np
 argument.
 </P>
 <P>Partitions are numbered from 1 to Np, where Np is the number of
-partitions specified by the <A HREF = "Section_start.html#start_6">-partition command-line
+partitions specified by the <A HREF = "Section_start.html#start_7">-partition command-line
 switch</A>.
 </P>
 <P><I>N</I> can be specified in one of two ways.  An explicit numeric value

--- a/doc/partition.txt
+++ b/doc/partition.txt
@@ -27,7 +27,7 @@ partition yes 6* fix all nvt temp 1.0 1.0 0.1 :pre
 
 This command invokes the specified command on a subset of the
 partitions of processors you have defined via the -partition
-command-line switch.  See "Section 2.6"_Section_start.html#start_6 of
+command-line switch.  See "Section 2.6"_Section_start.html#start_7 of
 the manual for an explanation of the switch.
 
 Normally, every input script command in your script is invoked by
@@ -49,7 +49,7 @@ argument.
 
 Partitions are numbered from 1 to Np, where Np is the number of
 partitions specified by the "-partition command-line
-switch"_Section_start.html#start_6.
+switch"_Section_start.html#start_7.
 
 {N} can be specified in one of two ways.  An explicit numeric value
 can be used, as in the 1st example above.  Or a wild-card asterisk can

--- a/doc/react.html
+++ b/doc/react.html
@@ -334,7 +334,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/react.txt
+++ b/doc/react.txt
@@ -329,7 +329,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/suffix.html
+++ b/doc/suffix.html
@@ -26,7 +26,7 @@ suffix kk
 <P><B>Description:</B>
 </P>
 <P>This command allows you to use variants of various styles if they
-exist.  In that respect it operates the same as the <A HREF = "Section_start.html#start_6">-suffix
+exist.  In that respect it operates the same as the <A HREF = "Section_start.html#start_7">-suffix
 command-line switch</A>.  It also has options
 to turn off or back on any suffix setting made via the command line.
 </P>
@@ -60,7 +60,7 @@ commands in your input script.
 </P>
 <P><B>Related commands:</B>
 </P>
-<P><A HREF = "Section_start.html#start_6">Command-line switch -suffix</A>
+<P><A HREF = "Section_start.html#start_7">Command-line switch -suffix</A>
 </P>
 <P><B>Default:</B> none
 </P>

--- a/doc/suffix.txt
+++ b/doc/suffix.txt
@@ -24,7 +24,7 @@ suffix kk :pre
 
 This command allows you to use variants of various styles if they
 exist.  In that respect it operates the same as the "-suffix
-command-line switch"_Section_start.html#start_6.  It also has options
+command-line switch"_Section_start.html#start_7.  It also has options
 to turn off or back on any suffix setting made via the command line.
 
 The specified style {kk} refers to the optional KOKKOS package that
@@ -57,6 +57,6 @@ commands in your input script.
 
 [Related commands:]
 
-"Command-line switch -suffix"_Section_start.html#start_6
+"Command-line switch -suffix"_Section_start.html#start_7
 
 [Default:] none

--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -589,7 +589,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -577,7 +577,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/surf_react.html
+++ b/doc/surf_react.html
@@ -257,7 +257,7 @@ enabled if SPARTA was built with that package.  See the <A HREF = "Section_start
 SPARTA</A> section for more info.
 </P>
 <P>You can specify the accelerated styles explicitly in your input script
-by including their suffix, or you can use the <A HREF = "Section_start.html#start_6">-suffix command-line
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
 switch</A> when you invoke SPARTA, or you can
 use the <A HREF = "suffix.html">suffix</A> command in your input script.
 </P>

--- a/doc/surf_react.txt
+++ b/doc/surf_react.txt
@@ -250,7 +250,7 @@ SPARTA"_Section_start.html#start_3 section for more info.
 
 You can specify the accelerated styles explicitly in your input script
 by including their suffix, or you can use the "-suffix command-line
-switch"_Section_start.html#start_6 when you invoke SPARTA, or you can
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
 use the "suffix"_suffix.html command in your input script.
 
 See the "Accelerating SPARTA"_Section_accelerate.html section of the

--- a/doc/variable.html
+++ b/doc/variable.html
@@ -143,7 +143,7 @@ is ignored.  This means variables can NOT be re-defined in an input
 script (with 2 exceptions, read further).  This is to allow an input
 script to be processed multiple times without resetting the variables;
 see the <A HREF = "jump.html">jump</A> or <A HREF = "include.html">include</A> commands.  It also
-means that using the <A HREF = "Section_start.html#start_6">command-line switch</A>
+means that using the <A HREF = "Section_start.html#start_7">command-line switch</A>
 -var will override a corresponding index variable setting in the input
 script.
 </P>
@@ -210,7 +210,7 @@ string is assigned.  All processors assign the same string to the
 variable.
 </P>
 <P><I>Index</I> style variables with a single string value can also be set by
-using the command-line switch -var; see <A HREF = "Section_start.html#start_6">Section
+using the command-line switch -var; see <A HREF = "Section_start.html#start_7">Section
 2.6</A> of the manual for details.
 </P>
 <P>The <I>loop</I> style is identical to the <I>index</I> style except that the
@@ -226,7 +226,7 @@ inclusive, and the string N1 is initially assigned to the variable.
 N1 <= N2 and N2 >= 0 is required.
 </P>
 <P>For the <I>world</I> style, one or more strings are specified.  There must
-be one string for each processor partition or "world".  See <A HREF = "Section_start.html#start_6">Section
+be one string for each processor partition or "world".  See <A HREF = "Section_start.html#start_7">Section
 2.6</A> of the manual for information on
 running SPARTA with multiple partitions via the "-partition"
 command-line switch.  This variable command assigns one string to each
@@ -237,7 +237,7 @@ you wish to run different simulations on different partitions.
 </P>
 <P>For the <I>universe</I> style, one or more strings are specified.  There
 must be at least as many strings as there are processor partitions or
-"worlds".  See <A HREF = "Section_start.html#start_6">this page</A> for information
+"worlds".  See <A HREF = "Section_start.html#start_7">this page</A> for information
 on running SPARTA with multiple partitions via the "-partition"
 command-line switch.  This variable command initially assigns one
 string to each world.  When a <A HREF = "next.html">next</A> command is encountered

--- a/doc/variable.txt
+++ b/doc/variable.txt
@@ -137,7 +137,7 @@ is ignored.  This means variables can NOT be re-defined in an input
 script (with 2 exceptions, read further).  This is to allow an input
 script to be processed multiple times without resetting the variables;
 see the "jump"_jump.html or "include"_include.html commands.  It also
-means that using the "command-line switch"_Section_start.html#start_6
+means that using the "command-line switch"_Section_start.html#start_7
 -var will override a corresponding index variable setting in the input
 script.
 
@@ -205,7 +205,7 @@ variable.
 
 {Index} style variables with a single string value can also be set by
 using the command-line switch -var; see "Section
-2.6"_Section_start.html#start_6 of the manual for details.
+2.6"_Section_start.html#start_7 of the manual for details.
 
 The {loop} style is identical to the {index} style except that the
 strings are the integers from 1 to N inclusive, if only one argument N
@@ -221,7 +221,7 @@ N1 <= N2 and N2 >= 0 is required.
 
 For the {world} style, one or more strings are specified.  There must
 be one string for each processor partition or "world".  See "Section
-2.6"_Section_start.html#start_6 of the manual for information on
+2.6"_Section_start.html#start_7 of the manual for information on
 running SPARTA with multiple partitions via the "-partition"
 command-line switch.  This variable command assigns one string to each
 world.  All processors in the world are assigned the same string.  The
@@ -231,7 +231,7 @@ you wish to run different simulations on different partitions.
 
 For the {universe} style, one or more strings are specified.  There
 must be at least as many strings as there are processor partitions or
-"worlds".  See "this page"_Section_start.html#start_6 for information
+"worlds".  See "this page"_Section_start.html#start_7 for information
 on running SPARTA with multiple partitions via the "-partition"
 command-line switch.  This variable command initially assigns one
 string to each world.  When a "next"_next.html command is encountered


### PR DESCRIPTION
## Purpose

Fix the numbering for subsections in the Section start chapter of the manual, so that links from the Manual home page are correct.  Also update references to these changed subsection numbers in other doc pages.

## Author(s)

Steve

## Backward Compatibility

_Please state whether any changes in the pull request break backward compatibility for inputs, and - if yes - explain what has been changed and why_

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


