### PR TITLE
Add more info on how per-surf temperatures can be assigned to the surf_collide command doc page

### DIFF
--- a/doc/surf_collide.html
+++ b/doc/surf_collide.html
@@ -151,7 +151,12 @@ specify a time-dependent temperature.
 a different temperature for each surface element, e.g. a temperature
 which depends on the geometric location of the center point of the
 surface element.  The calculation can also be time-dependent if
-desired.
+desired.  A surf-style variable can also access a compute or fix which
+outputs per-surf quantities.  For example the <A HREF = "compute_surf.html">compute
+surf</A> and <A HREF = "fix_ave_surf.html">fix ave/surf</A> commands
+can tally or average energy transfer from particles to surface
+elements, which could be used to infer a temperature for each surface
+element.
 </P>
 <P>Note that the frequency at which the equal-style or surf-style
 variable is evaluated can be set using the optional <I>temp/freq</I>

--- a/doc/surf_collide.txt
+++ b/doc/surf_collide.txt
@@ -139,7 +139,12 @@ The second is a surf-style variable with a formula which can calculate
 a different temperature for each surface element, e.g. a temperature
 which depends on the geometric location of the center point of the
 surface element.  The calculation can also be time-dependent if
-desired.
+desired.  A surf-style variable can also access a compute or fix which
+outputs per-surf quantities.  For example the "compute
+surf"_compute_surf.html and "fix ave/surf"_fix_ave_surf.html commands
+can tally or average energy transfer from particles to surface
+elements, which could be used to infer a temperature for each surface
+element.
 
 Note that the frequency at which the equal-style or surf-style
 variable is evaluated can be set using the optional {temp/freq}


### PR DESCRIPTION
## Purpose

Enhance the doc page for the surf_collide command, for how to use surf-style variables.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


