### PR TITLE
Correct grid ID calculation description in the Howto doc page

### DIFF
--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -744,10 +744,10 @@ numbered from 1 to 2000 with the x-dimension varying fastest, then y,
 and finally the z-dimension slowest.  Consider the 376th level 1 cell.
 It would be the 6th cell in the x direction of the grid, 8th cell in
 y, and 4th cell in z.  I.e. 376 = (z-1)*100 + (y-1)*10 + (x-1) + 1.
-Now consider that level 2 cells use 2x2x2 sub-division (8 cells) of
-level 1 cells and consider the 4th cell within level 2 of the 376th
-cell.  This would be the 2nd cell in x, 2nd cell in y, and 1st cell in
-z.  I.e. 4 = (z-1)*4 + (y-1)*2 + (x-1) + 1.
+Now consider the case where level 2 cells use a 2x2x2 sub-division (8
+cells) of level 1 cells and consider the 4th level 2 cell within the
+376th level 1 cell.  This would be the 2nd cell in x, 2nd cell in y,
+and 1st cell in z.  I.e. 4 = (z-1)*4 + (y-1)*2 + (x-1) + 1.
 </P>
 <P>This level 2 cell could itself be a parent cell if it were further
 sub-divided, or a child cell if not.  In either case its ID is the

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -739,19 +739,28 @@ property/grid</A>.
 </P>
 <P>Here is how a grid cell ID is computed by SPARTA, either for parent or
 child cells.  Say the level 1 grid is a 10x10x20 sub-division (2000
-cells) of the root cell.  The level 1 cells are numbered from 1 to
-2000 with the x-dimension varying fastest, then y, and finally the
-z-dimension slowest.  Now say the 374th (out of 2000, 14 in x, 19 in
-y, 1 in z) level 1 cell has a 2x2x2 sub-division (8 cells), and
-consider the 4th level 2 cell (2 in x, 2 in y, 1 in z) within the
-374th cell.  It could be a parent cell if it is further sub-divided,
-or a child cell if not.  In either case its ID is the same.  The
-rightmost 11 bits of the integer ID are encoded with 374.  This is
-because it requires 11 bits to represent 2000 cells (1 to 2000) at
-level 1.  The next 4 bits are used to encode 1 to 8, specifically 4 in
-the case of this cell.  Thus the cell ID in integer format is 4*2048 +
-374 = 8566.  In string format it will be printed as 4-374, with dashes
-separating the levels.
+cells) of the root cell (simulation box).  The level 1 cells are
+numbered from 1 to 2000 with the x-dimension varying fastest, then y,
+and finally the z-dimension slowest.  Consider the 376th level 1 cell.
+It would be the 6th cell in the x direction of the grid, 8th cell in
+y, and 4th cell in z.  I.e. 376 = (z-1)*100 + (y-1)*10 + (x-1) + 1.
+Now consider that level 2 cells use 2x2x2 sub-division (8 cells) of
+level 1 cells and consider the 4th cell within level 2 of the 376th
+cell.  This would be the 2nd cell in x, 2nd cell in y, and 1st cell in
+z.  I.e. 4 = (z-1)*4 + (y-1)*2 + (x-1) + 1.
+</P>
+<P>This level 2 cell could itself be a parent cell if it were further
+sub-divided, or a child cell if not.  In either case its ID is the
+same and is calcluated as follows.  The rightmost 11 bits of the
+integer ID are encoded with 376.  This is because it requires 11 bits
+to represent 2000 cells (1 to 2000) at level 1.  The next 4 bits are
+encoded with 4, because it requires 4 bits to represent 8 cells (1 to
+8) at level 2.  Thus the level 2 cell ID in integer format is 4*2048 +
+376 = 8568.  In string format it would be 376-4, with dashes
+separating each of the levels.  Either of these formats (integer or
+string) can be specified as id or idstr for output of grid cell info
+with the <A HREF = "dump_grid.html">dump grid</A> command; see its doc page for more
+details.
 </P>
 <P>Note that a child cell has the same ID whether it is unsplit, cut, or
 split.  Currently, sub cells of a split cell also have the same ID,

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -734,10 +734,10 @@ numbered from 1 to 2000 with the x-dimension varying fastest, then y,
 and finally the z-dimension slowest.  Consider the 376th level 1 cell.
 It would be the 6th cell in the x direction of the grid, 8th cell in
 y, and 4th cell in z.  I.e. 376 = (z-1)*100 + (y-1)*10 + (x-1) + 1.
-Now consider that level 2 cells use 2x2x2 sub-division (8 cells) of
-level 1 cells and consider the 4th cell within level 2 of the 376th
-cell.  This would be the 2nd cell in x, 2nd cell in y, and 1st cell in
-z.  I.e. 4 = (z-1)*4 + (y-1)*2 + (x-1) + 1.
+Now consider the case where level 2 cells use a 2x2x2 sub-division (8
+cells) of level 1 cells and consider the 4th level 2 cell within the
+376th level 1 cell.  This would be the 2nd cell in x, 2nd cell in y,
+and 1st cell in z.  I.e. 4 = (z-1)*4 + (y-1)*2 + (x-1) + 1.
 
 This level 2 cell could itself be a parent cell if it were further
 sub-divided, or a child cell if not.  In either case its ID is the

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -729,19 +729,28 @@ property/grid"_compute_property_grid.html.
 
 Here is how a grid cell ID is computed by SPARTA, either for parent or
 child cells.  Say the level 1 grid is a 10x10x20 sub-division (2000
-cells) of the root cell.  The level 1 cells are numbered from 1 to
-2000 with the x-dimension varying fastest, then y, and finally the
-z-dimension slowest.  Now say the 374th (out of 2000, 14 in x, 19 in
-y, 1 in z) level 1 cell has a 2x2x2 sub-division (8 cells), and
-consider the 4th level 2 cell (2 in x, 2 in y, 1 in z) within the
-374th cell.  It could be a parent cell if it is further sub-divided,
-or a child cell if not.  In either case its ID is the same.  The
-rightmost 11 bits of the integer ID are encoded with 374.  This is
-because it requires 11 bits to represent 2000 cells (1 to 2000) at
-level 1.  The next 4 bits are used to encode 1 to 8, specifically 4 in
-the case of this cell.  Thus the cell ID in integer format is 4*2048 +
-374 = 8566.  In string format it will be printed as 4-374, with dashes
-separating the levels.
+cells) of the root cell (simulation box).  The level 1 cells are
+numbered from 1 to 2000 with the x-dimension varying fastest, then y,
+and finally the z-dimension slowest.  Consider the 376th level 1 cell.
+It would be the 6th cell in the x direction of the grid, 8th cell in
+y, and 4th cell in z.  I.e. 376 = (z-1)*100 + (y-1)*10 + (x-1) + 1.
+Now consider that level 2 cells use 2x2x2 sub-division (8 cells) of
+level 1 cells and consider the 4th cell within level 2 of the 376th
+cell.  This would be the 2nd cell in x, 2nd cell in y, and 1st cell in
+z.  I.e. 4 = (z-1)*4 + (y-1)*2 + (x-1) + 1.
+
+This level 2 cell could itself be a parent cell if it were further
+sub-divided, or a child cell if not.  In either case its ID is the
+same and is calcluated as follows.  The rightmost 11 bits of the
+integer ID are encoded with 376.  This is because it requires 11 bits
+to represent 2000 cells (1 to 2000) at level 1.  The next 4 bits are
+encoded with 4, because it requires 4 bits to represent 8 cells (1 to
+8) at level 2.  Thus the level 2 cell ID in integer format is 4*2048 +
+376 = 8568.  In string format it would be 376-4, with dashes
+separating each of the levels.  Either of these formats (integer or
+string) can be specified as id or idstr for output of grid cell info
+with the "dump grid"_dump_grid.html command; see its doc page for more
+details.
 
 Note that a child cell has the same ID whether it is unsplit, cut, or
 split.  Currently, sub cells of a split cell also have the same ID,


### PR DESCRIPTION
## Purpose

The section of the Howto doc page describing how multilevel grid cell IDs are calculated was wrong for the specific example discussed. This PR fixes it.

## Author(s)

Steve.  And thanks to Pradyumnan R on the SPARTA mail list for calling attention to the issue.

## Backward Compatibility

N/A - just a doc page change

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


