### PR TITLE
Add dump_modify gridgroup and surfgroup keywords to dump image

### DIFF
--- a/doc/dump_image.html
+++ b/doc/dump_image.html
@@ -222,8 +222,10 @@ assigning colors to particles and other image features.
 </H4>
 <P>Particles are drawn by default using the <I>color</I> and <I>diameter</I>
 settings.  The <I>particle</I> keyword allow you to turn off the drawing of
-all particles, if the specified value is <I>no</I>.  Only particles in a
-geometric region can be drawn using the <A HREF = "dump_modify.html">dump_modify
+all particles, if the specified value is <I>no</I>.
+</P>
+<P>Only particles in the specified mixture ID (mix-ID) are drawn.  Only
+particles in a geometric region can be drawn using the <A HREF = "dump_modify.html">dump_modify
 region</A> command.
 </P>
 <P>The <I>color</I> and <I>diameter</I> settings determine the color and size of
@@ -296,8 +298,10 @@ rectangle that is infinitely thin in the z dimension, which allows you
 to still see the particles in the grid cell.  For 3d, the grid cell is
 drawn as a solid brick, which will obscure the particles inside it.
 </P>
-<P>Only grid cells in a geometric region can be drawn using the
-<A HREF = "dump_modify.html">dump_modify region</A> command.
+<P>Only grid cells in a grid group can be drawn using the <A HREF = "dump_modify.html">dump_modify
+gridgroup</A> command.  Only grid cells in a geometric
+region can be drawn using the <A HREF = "dump_modify.html">dump_modify region</A>
+command.
 </P>
 <P>The <I>gridx</I> and <I>gridy</I> and <I>gridz</I> keywords turn on the drawing of of
 a 2d plane of grid cells at the specified coordinate.  This is a way
@@ -360,8 +364,10 @@ setting is ignored.  The entire surface is rendered, which in 3d will
 hide any grid cells (or fractions of a grid cell) that are inside the
 surface.
 </P>
-<P>The <A HREF = "dump_modify.html">dump_modify region</A> command does not apply to
-surface element drawing.
+<P>Only surface elements in a surface group can be drawn using the
+<A HREF = "dump_modify.html">dump_modify surfgroup</A> command.  The <A HREF = "dump_modify.html">dump_modify
+region</A> command does not apply to surface element
+drawing.
 </P>
 <P>If <I>one</I> is specified for the <I>color</I> setting, then the color of every
 surface element is drawn with the color specified by the <A HREF = "dump_modify.html">dump_modify

--- a/doc/dump_image.txt
+++ b/doc/dump_image.txt
@@ -207,8 +207,10 @@ Rendering of particles :h4
 
 Particles are drawn by default using the {color} and {diameter}
 settings.  The {particle} keyword allow you to turn off the drawing of
-all particles, if the specified value is {no}.  Only particles in a
-geometric region can be drawn using the "dump_modify
+all particles, if the specified value is {no}.
+
+Only particles in the specified mixture ID (mix-ID) are drawn.  Only
+particles in a geometric region can be drawn using the "dump_modify
 region"_dump_modify.html command.
 
 The {color} and {diameter} settings determine the color and size of
@@ -281,8 +283,10 @@ rectangle that is infinitely thin in the z dimension, which allows you
 to still see the particles in the grid cell.  For 3d, the grid cell is
 drawn as a solid brick, which will obscure the particles inside it.
 
-Only grid cells in a geometric region can be drawn using the
-"dump_modify region"_dump_modify.html command.
+Only grid cells in a grid group can be drawn using the "dump_modify
+gridgroup"_dump_modify.html command.  Only grid cells in a geometric
+region can be drawn using the "dump_modify region"_dump_modify.html
+command.
 
 The {gridx} and {gridy} and {gridz} keywords turn on the drawing of of
 a 2d plane of grid cells at the specified coordinate.  This is a way
@@ -345,8 +349,10 @@ setting is ignored.  The entire surface is rendered, which in 3d will
 hide any grid cells (or fractions of a grid cell) that are inside the
 surface.
 
-The "dump_modify region"_dump_modify.html command does not apply to
-surface element drawing.
+Only surface elements in a surface group can be drawn using the
+"dump_modify surfgroup"_dump_modify.html command.  The "dump_modify
+region"_dump_modify.html command does not apply to surface element
+drawing.
 
 If {one} is specified for the {color} setting, then the color of every
 surface element is drawn with the color specified by the "dump_modify

--- a/doc/dump_modify.html
+++ b/doc/dump_modify.html
@@ -86,6 +86,8 @@
     color = name of color or color1/color2/...
   <I>glinecolor</I> arg = color
     color = name of color for grid cell outlines
+  <I>gridgroup</I> arg = group-ID
+    group-ID = name of a user-defined grid group, see the <A HREF = "group.html">group</A> command
   <I>pcolor</I> args = type color
     type = particle type or range of types or proc ID or range of IDs (see below)
     color = name of color or color1/color2/...
@@ -98,6 +100,8 @@
   <I>slinecolor</I> arg = color
     color = name of color for surface element outlines 
 </PRE>
+  <I>surfgroup</I> arg = group-ID
+    group-ID = name of a user-defined surf group, see the <A HREF = "group.html">group</A> command
 
 </UL>
 <P><B>Examples:</B>
@@ -513,6 +517,14 @@ a color name defined by the dump_modify color option.
 </P>
 <HR>
 
+<P>The <I>gridgroup</I> keyword can be used with the <A HREF = "dump_image.html">dump
+image</A> command to only draw a subset of the grid cells
+in the simulation.  By default all the grid cells are rendered.  The
+group-ID argument can be any valid grid group name, as defined by the
+<A HREF = "group.html">group grid</A> command.
+</P>
+<HR>
+
 <P>The <I>pcolor</I> keyword can be used one or more times with the <A HREF = "dump_image.html">dump
 image</A> command, only when its particle color setting is
 <I>type</I> or <I>procs</I>, to set the color that particles will be drawn in
@@ -602,6 +614,14 @@ option.
 </P>
 <HR>
 
+<P>The <I>surfgroup</I> keyword can be used with the <A HREF = "dump_image.html">dump
+image</A> command to only draw a subset of the surface
+elements in the simulation.  By default all the surface elements are
+rendered.  The group-ID argument can be any valid surf group name, as
+defined by the <A HREF = "group.html">group surf</A> command.
+</P>
+<HR>
+
 <P><B>Restrictions:</B> none
 </P>
 <P><B>Related commands:</B>
@@ -625,6 +645,7 @@ option.
 <LI>format = %d and %g for each integer or floating point value
 <LI>gcolor = * red/green/blue/yellow/aqua/cyan
 <LI>glinecolor = white
+<LI>gridgroup = all
 <LI>nfile = 1
 <LI>pad = 0
 <LI>pcolor = * red/green/blue/yellow/aqua/cyan
@@ -632,6 +653,7 @@ option.
 <LI>region = none
 <LI>scolor = * gray
 <LI>slinecolor = white
+<LI>surfgroup = all
 <LI>thresh = none 
 </UL>
 <HR>

--- a/doc/dump_modify.txt
+++ b/doc/dump_modify.txt
@@ -76,6 +76,8 @@ keyword = {bcolor} or {bdiam} or {backcolor} or {bitrate} or {boxcolor} or {cmap
     color = name of color or color1/color2/...
   {glinecolor} arg = color
     color = name of color for grid cell outlines
+  {gridgroup} arg = group-ID
+    group-ID = name of a user-defined grid group, see the "group"_group.html command
   {pcolor} args = type color
     type = particle type or range of types or proc ID or range of IDs (see below)
     color = name of color or color1/color2/...
@@ -87,6 +89,8 @@ keyword = {bcolor} or {bdiam} or {backcolor} or {bitrate} or {boxcolor} or {cmap
     color = name of color for surf one option
   {slinecolor} arg = color
     color = name of color for surface element outlines :pre
+  {surfgroup} arg = group-ID
+    group-ID = name of a user-defined surf group, see the "group"_group.html command
 :ule
 
 [Examples:]
@@ -500,6 +504,14 @@ a color name defined by the dump_modify color option.
 
 :line
 
+The {gridgroup} keyword can be used with the "dump
+image"_dump_image.html command to only draw a subset of the grid cells
+in the simulation.  By default all the grid cells are rendered.  The
+group-ID argument can be any valid grid group name, as defined by the
+"group grid"_group.html command.
+
+:line
+
 The {pcolor} keyword can be used one or more times with the "dump
 image"_dump_image.html command, only when its particle color setting is
 {type} or {procs}, to set the color that particles will be drawn in
@@ -589,6 +601,14 @@ option.
 
 :line
 
+The {surfgroup} keyword can be used with the "dump
+image"_dump_image.html command to only draw a subset of the surface
+elements in the simulation.  By default all the surface elements are
+rendered.  The group-ID argument can be any valid surf group name, as
+defined by the "group surf"_group.html command.
+
+:line
+
 [Restrictions:] none
 
 [Related commands:]
@@ -612,6 +632,7 @@ flush = yes
 format = %d and %g for each integer or floating point value
 gcolor = * red/green/blue/yellow/aqua/cyan
 glinecolor = white
+gridgroup = all
 nfile = 1
 pad = 0
 pcolor = * red/green/blue/yellow/aqua/cyan
@@ -619,6 +640,7 @@ pdiam = * 1.0
 region = none
 scolor = * gray
 slinecolor = white
+surfgroup = all
 thresh = none :ul
 
 :line

--- a/src/dump_image.h
+++ b/src/dump_image.h
@@ -69,7 +69,8 @@ class DumpImage : public DumpParticle {
   char *idgrid;                    // ID of compute, fix, variable
   int gridindex;                   // index of compute, fix, variable
   int gridcol;                     // column of compute/fix array, 0 for vector
-
+  int grid_groupbit;               // bit mask for dump_modify gridgroup
+  
   double *gcolorproc;              // grid color for me
 
   // grid plane drawing
@@ -102,6 +103,7 @@ class DumpImage : public DumpParticle {
   char *idsurf;                    // ID of compute, fix, variable
   int surfindex;                   // index of compute, fix, variable
   int surfcol;                     // column of compute/fix array, 0 vor vector
+  int surf_groupbit;               // bit mask for dump_modify surfgroup
 
   double *scolorproc;              // surf color for me
 


### PR DESCRIPTION
## Purpose

Allow creation of on-the-fly images (and movies) which only visualize a subset of the grid cells or surface elements.  This is based on new keywords for the dump_modify command: gridgroup and surfgroup.  The specified groups determine the subset of visualizaed grid cells or surface elements.  This can be useful for tailoring the image or for debugging an input script.  E.g. which surface elements are in a specified group.

## Author(s)

Steve

## Backward Compatibility

N/A.  This is a new option.  The default is still to viz all the grid cells or surface elements.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


