### PR TITLE
Add fix emit/face modulate option for insertion of time-varying flows

### DIFF
--- a/doc/fix_emit_face.html
+++ b/doc/fix_emit_face.html
@@ -27,12 +27,14 @@
 
 <LI>zero or more keyword/value(s) pairs may be appended 
 
-<LI>keyword = <I>n</I> or <I>nevery</I> or <I>perspecies</I> or <I>region</I> or <I>subsonic</I> or <I>twopass</I> 
+<LI>keyword = <I>n</I> or <I>nevery</I> or <I>perspecies</I> or <I>region</I> or <I>modulate</I> or <I>subsonic</I> or <I>twopass</I> 
 
 <PRE>  <I>n</I> value = Np = number of particles to create
   <I>nevery</I> value = Nstep = add particles every this many timesteps
   <I>perspecies</I> value = <I>yes</I> or <I>no</I>
-  <I>region</I> value = region-ID 
+  <I>region</I> value = region-ID
+  <I>modulate</I> value = v_name
+    name = name of equal-style variable which modulates inflow of particles
   <I>subsonic</I> values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
@@ -46,6 +48,9 @@
 fix in emit/face mymix xlo yhi n 1000 nevery 10 region circle
 fix in emit/face air xlo subsonic 0.1 300
 fix in emit/face air xhi subsonic 0.05 NULL twopass 
+</PRE>
+<PRE>variable mod equal "1.0 + sin(step/10000*2*PI)"
+fix in emit/face air all modulate v_mod 
 </PRE>
 <P><B>Description:</B>
 </P>
@@ -169,6 +174,16 @@ Particles those grid cells attempt to add are included in the count
 for N, even if some or all of the particle insertions are rejected due
 to not being inside the region.
 </P>
+<P>The <I>modulate</I> keyword can be used to multiple the count of particles
+inserted at each timestep by a prefactor.  The prefactor is calcalated
+at each insertion timestep by invoking the equal-style variable whose
+name is speficied as <I>v_name</I>.  A value of 1.0 will not modulate the
+count of inserted particles (on that timestep).  A value of 0.5 (or
+2.0) will insert half (or twice) the unmodulated count of particles.
+Note that the formula used for an equal-style variable can include the
+current timestep, so this is a simple way to insert a time-varying
+flow of particles.
+</P>
 <P>The <I>subsonic</I> keyword uses the method of Fang and Liou
 <A HREF = "#Fang02">(Fang02)</A> to determine the number of particles to insert in
 each grid cell on the emitting face(s).  They used the method of
@@ -259,8 +274,9 @@ effectively.
 Particles cannot be emitted from <I>z</I> faces of the simluation box for a
 2d simulation.
 </P>
-<P>A <I>n</I> setting of <I>Np</I> > 0 can only be used with a <I>perspecies</I> setting
-of <I>no</I>.
+<P>A <I>perspecies</I> setting of <I>yes</I> can only be used with an <I>n</I> setting
+of <I>Np</I> = 0.  Likewise, the <I>modulate</I> keyword can only be used with
+an <I>n</I> setting of <I>Np</I> = 0.
 </P>
 <P>A warning will be issued if a specified face has an inward normal in a
 direction opposing the streaming velocity.  Particles will still be
@@ -279,7 +295,7 @@ emit/face/file</A>
 <P><B>Default:</B>
 </P>
 <P>The keyword defaults are n = 0, nevery = 1, perspecies = yes, region =
-none, no subsonic settings, no twopass setting.
+none, no modulate setting, no subsonic settings, no twopass setting.
 </P>
 <HR>
 

--- a/doc/fix_emit_face.txt
+++ b/doc/fix_emit_face.txt
@@ -33,7 +33,6 @@ keyword = {n} or {nevery} or {perspecies} or {region} or {modulate} or {subsonic
 
 [Examples:]
 
-
 fix in emit/face air all
 fix in emit/face mymix xlo yhi n 1000 nevery 10 region circle
 fix in emit/face air xlo subsonic 0.1 300

--- a/doc/fix_emit_face.txt
+++ b/doc/fix_emit_face.txt
@@ -18,11 +18,13 @@ emit/face = style name of this fix command :l
 mix-ID = ID of mixture to use when creating particles :l
 face1,face2,... = one or more of {all} or {xlo} or {xhi} or {ylo} or {yhi} or {zlo} or {zhi} :l
 zero or more keyword/value(s) pairs may be appended :l
-keyword = {n} or {nevery} or {perspecies} or {region} or {subsonic} or {twopass} :l
+keyword = {n} or {nevery} or {perspecies} or {region} or {modulate} or {subsonic} or {twopass} :l
   {n} value = Np = number of particles to create
   {nevery} value = Nstep = add particles every this many timesteps
   {perspecies} value = {yes} or {no}
-  {region} value = region-ID 
+  {region} value = region-ID
+  {modulate} value = v_name
+    name = name of equal-style variable which modulates inflow of particles
   {subsonic} values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
@@ -31,10 +33,14 @@ keyword = {n} or {nevery} or {perspecies} or {region} or {subsonic} or {twopass}
 
 [Examples:]
 
+
 fix in emit/face air all
 fix in emit/face mymix xlo yhi n 1000 nevery 10 region circle
 fix in emit/face air xlo subsonic 0.1 300
 fix in emit/face air xhi subsonic 0.05 NULL twopass :pre
+
+variable mod equal "1.0 + sin(step/10000*2*PI)"
+fix in emit/face air all modulate v_mod :pre
 
 [Description:]
 
@@ -158,6 +164,16 @@ Particles those grid cells attempt to add are included in the count
 for N, even if some or all of the particle insertions are rejected due
 to not being inside the region.
 
+The {modulate} keyword can be used to multiple the count of particles
+inserted at each timestep by a prefactor.  The prefactor is calcalated
+at each insertion timestep by invoking the equal-style variable whose
+name is speficied as {v_name}.  A value of 1.0 will not modulate the
+count of inserted particles (on that timestep).  A value of 0.5 (or
+2.0) will insert half (or twice) the unmodulated count of particles.
+Note that the formula used for an equal-style variable can include the
+current timestep, so this is a simple way to insert a time-varying
+flow of particles.
+
 The {subsonic} keyword uses the method of Fang and Liou
 "(Fang02)"_#Fang02 to determine the number of particles to insert in
 each grid cell on the emitting face(s).  They used the method of
@@ -248,8 +264,9 @@ Particles cannot be emitted from periodic faces of the simulation box.
 Particles cannot be emitted from {z} faces of the simluation box for a
 2d simulation.
 
-A {n} setting of {Np} > 0 can only be used with a {perspecies} setting
-of {no}.
+A {perspecies} setting of {yes} can only be used with an {n} setting
+of {Np} = 0.  Likewise, the {modulate} keyword can only be used with
+an {n} setting of {Np} = 0.
 
 A warning will be issued if a specified face has an inward normal in a
 direction opposing the streaming velocity.  Particles will still be
@@ -268,7 +285,7 @@ emit/face/file"_fix_emit_face_file.html
 [Default:]
 
 The keyword defaults are n = 0, nevery = 1, perspecies = yes, region =
-none, no subsonic settings, no twopass setting.
+none, no modulate setting, no subsonic settings, no twopass setting.
 
 :line
 

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -33,6 +33,7 @@
 #include "kokkos_type.h"
 #include "particle_kokkos.h"
 #include "sparta_masks.h"
+#include "variable.h"
 #include "Kokkos_Random.hpp"
 
 using namespace SPARTA_NS;
@@ -155,6 +156,14 @@ void FixEmitFaceKokkos::perform_task()
   if (subsonic)
     error->one(FLERR,"Cannot yet use fix emit/face/kk with subsonic emission");
   //if (subsonic) subsonic_inflow(); ////////////////////////
+
+  // if modulate variable set, evaluate it as prefactor for this timestep
+
+  prefactor = 1.0;
+  if (modvar) {
+    prefactor = input->variable->compute_equal(imodvar);
+    if (prefactor < 0.0) error->all(FLERR,"Fix emit/face modulation < 0.0");
+  }
 
   // insert particles for each task = cell/face pair
   // ntarget/ninsert is either perspecies or for all species
@@ -351,13 +360,13 @@ void FixEmitFaceKokkos::operator()(TagFixEmitFace_ninsert, const int &i) const
 
   if (perspecies) {
     for (int isp = 0; isp < nspecies; isp++) {
-      auto ntarget = d_ntargetsp(i,isp)+rand_gen.drand();
+      auto ntarget = prefactor*d_ntargetsp(i,isp) + rand_gen.drand();
       ninsert = static_cast<int> (ntarget);
       d_ninsert(i * nspecies + isp) = ninsert;
     }
   } else {
     if (np == 0) {
-      auto ntarget = d_tasks(i).ntarget+rand_gen.drand();
+      auto ntarget = prefactor*d_tasks(i).ntarget + rand_gen.drand();
       ninsert = static_cast<int> (ntarget);
     } else {
       ninsert = npertask;

--- a/src/KOKKOS/fix_emit_face_kokkos.h
+++ b/src/KOKKOS/fix_emit_face_kokkos.h
@@ -59,6 +59,8 @@ class FixEmitFaceKokkos : public FixEmitFace {
 #endif
 
  private:
+  int prefactor;
+
   KKCopy<ParticleKokkos> particle_kk_copy;
 
   typedef Kokkos::DualView<Task*, DeviceType::array_layout, DeviceType> tdual_task_1d;

--- a/src/fix_emit_face.cpp
+++ b/src/fix_emit_face.cpp
@@ -26,6 +26,7 @@
 #include "modify.h"
 #include "geometry.h"
 #include "input.h"
+#include "variable.h"
 #include "random_knuth.h"
 #include "math_const.h"
 #include "memory.h"
@@ -79,6 +80,7 @@ FixEmitFace::FixEmitFace(SPARTA *sparta, int narg, char **arg) :
   // optional args
 
   np = 0;
+  modvar = NULL;
   subsonic = 0;
   subsonic_style = NOSUBSONIC;
   subsonic_warning = 0;
@@ -98,7 +100,9 @@ FixEmitFace::FixEmitFace(SPARTA *sparta, int narg, char **arg) :
     error->all(FLERR,"Cannot use fix emit/face n > 0 with perspecies yes");
   if (np > 0 && subsonic)
     error->all(FLERR,"Cannot use fix emit/face n > 0 with subsonic");
-
+  if (np > 0 && modvar)
+    error->all(FLERR,"Cannot use fix emit/face n > 0 with modulate option");
+    
   // task list and subsonic data structs
 
   tasks = NULL;
@@ -114,6 +118,8 @@ FixEmitFace::~FixEmitFace()
 {
   if (copymode) return;
 
+  delete [] modvar;
+  
   if (tasks) {
     for (int i = 0; i < ntaskmax; i++) {
       delete [] tasks[i].ntargetsp;
@@ -142,6 +148,14 @@ void FixEmitFace::init()
   fraction = particle->mixture[imix]->fraction;
   cummulative = particle->mixture[imix]->cummulative;
 
+  // set current index for modvar variable
+
+  if (modvar) {
+    imodvar = input->variable->find(modvar);
+    if (imodvar < 0)
+      error->all(FLERR,"Fix emit/face modulate variable does not exist");
+  }
+  
   // subsonic prefactor
 
   tprefactor = update->mvv2e / (3.0*update->boltz);
@@ -476,6 +490,14 @@ void FixEmitFace::perform_task_onepass()
 
   if (subsonic) subsonic_inflow();
 
+  // if modulate variable set, evaluate it as prefactor for this timestep
+
+  double prefactor = 1.0;
+  if (modvar) {
+    prefactor = input->variable->compute_equal(imodvar);
+    if (prefactor < 0.0) error->all(FLERR,"Fix emit/face modulation < 0.0");
+  }
+
   // insert particles for each task = cell/face pair
   // ntarget/ninsert is either perspecies or for all species
   // for one particle:
@@ -516,7 +538,7 @@ void FixEmitFace::perform_task_onepass()
     if (perspecies) {
       for (isp = 0; isp < nspecies; isp++) {
         ispecies = species[isp];
-        ntarget = tasks[i].ntargetsp[isp]+random->uniform();
+        ntarget = prefactor*tasks[i].ntargetsp[isp] + random->uniform();
         ninsert = static_cast<int> (ntarget);
         scosine = indot / vscale[isp];
 
@@ -565,7 +587,7 @@ void FixEmitFace::perform_task_onepass()
 
     } else {
       if (np == 0) {
-        ntarget = tasks[i].ntarget+random->uniform();
+        ntarget = prefactor*tasks[i].ntarget + random->uniform();
         ninsert = static_cast<int> (ntarget);
       } else {
         ninsert = npertask;
@@ -647,6 +669,14 @@ void FixEmitFace::perform_task_twopass()
 
   if (subsonic) subsonic_inflow();
 
+  // if modulate variable set, evaluate it as prefactor for this timestep
+
+  double prefactor = 1.0;
+  if (modvar) {
+    prefactor = input->variable->compute_equal(imodvar);
+    if (prefactor < 0.0) error->all(FLERR,"Fix emit/face modulation < 0.0");
+  }
+
   // insert particles for each task = cell/face pair
   // ntarget/ninsert is either perspecies or for all species
   // for one particle:
@@ -672,13 +702,13 @@ void FixEmitFace::perform_task_twopass()
   for (int i = 0; i < ntask; i++) {
     if (perspecies) {
       for (isp = 0; isp < nspecies; isp++) {
-        ntarget = tasks[i].ntargetsp[isp]+random->uniform();
+        ntarget = prefactor*tasks[i].ntargetsp[isp] + random->uniform();
         ninsert = static_cast<int> (ntarget);
         ninsert_values[i][isp] = ninsert;
       }
     } else {
       if (np == 0) {
-        ntarget = tasks[i].ntarget+random->uniform();
+        ntarget = prefactor*tasks[i].ntarget + random->uniform();
         ninsert = static_cast<int> (ntarget);
       } else {
         ninsert = npertask;
@@ -1132,6 +1162,21 @@ int FixEmitFace::option(int narg, char **arg)
     if (2 > narg) error->all(FLERR,"Illegal fix emit/face command");
     np = atoi(arg[1]);
     if (np <= 0) error->all(FLERR,"Illegal fix emit/face command");
+    return 2;
+  }
+
+  if (strcmp(arg[0],"modulate") == 0) {
+    if (2 > narg) error->all(FLERR,"Illegal fix emit/face command");
+    if (strncmp(arg[1],"v_",2) == 0) {
+      int n = strlen(arg[1]);
+      modvar = new char[n];
+      strcpy(modvar,&arg[1][2]);
+      n = input->variable->find(modvar);
+      if (n < 0)
+        error->all(FLERR,"Could not find fix emit/face modulate variable name");
+      if (input->variable->equal_style(n) == 0)
+        error->all(FLERR,"Fix emit/face modulate variable is not equal-style");
+    } else error->all(FLERR,"Invalid fix emit/face modulate variable syntax");
     return 2;
   }
 

--- a/src/fix_emit_face.h
+++ b/src/fix_emit_face.h
@@ -68,6 +68,9 @@ class FixEmitFace : public FixEmit {
   double psubsonic,tsubsonic,nsubsonic;
   double tprefactor,soundspeed_mixture;
 
+  int imodvar;
+  char *modvar;
+  
   // copies of data from other classes
 
   int dimension,nspecies;


### PR DESCRIPTION
## Purpose

Add a modulate option to the fix emit/face command.  It specifies an equal-style variable which is evaluated at each insertion timestep,  The value is used as a prefactor on the count of particles inserted.  Defining a variable that is a function of the current timestep thus allows modulation of the input flux as a function of time.

## Author(s)

Steve

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


