### PR TITLE
Add options to the create_particles command to use custom per-grid attributes to affect properties of the created particles

### DIFF
--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -1653,13 +1653,21 @@ Each custom attribute has a name, which allows them to be specified in
 input scripts as arguments to various commands.  The values each
 attricute stores can be either integer or floating point numbers.
 </P>
-<P>Here are lists of current commands (as of August 2023) which use custom
-attributes in various ways:
+<P>The <A HREF = "custom.html">custom</A> command can create and set/reset custom
+attribute values for all 3 flavors of attributes.  Either by invoking
+per-particle, per-grid, or per-surf variables, or by reading a file.
+The <A HREF = "fix_custom.html">fix custom</A> command can do the same thing
+periodically as a simulation runs.  <A HREF = "dump.html">Dump</A> commands can
+output all 3 flavors of attributes.
+</P>
+<P>Here are lists of current commands which use custom attributes in
+various ways:
 </P>
 <P><B>Per-particle custom attributes:</B>
 </P>
 <UL><LI><A HREF = "compute_reduce.html">compute reduce</A> - reduce a per-particle attribute to a scalar value
-<LI><A HREF = "custom.html">custom</A> - set the values of a per-particle attribute and optionally create it
+<LI><A HREF = "custom.html">custom</A> - create or set ore remove the values of a per-particle attribute
+<LI><A HREF = "fix_custom.html">fix custom</A> - reset the values of a per-particle attribute during a simulation
 <LI><A HREF = "dump.html">dump particle</A> - output per-particle attributes to a dump file
 <LI><A HREF = "fix_ambipolar.html">fix ambipolar</A> - use a per-particle vector and array for ambipolar quantities
 <LI><A HREF = "variable.html">variable</A> - use a per-particle attribute in a particle-style variable formula 
@@ -1667,7 +1675,9 @@ attributes in various ways:
 <P><B>Per-grid custom attributes:</B>
 </P>
 <UL><LI><A HREF = "compute_reduce.html">compute reduce</A> - reduce a per-grid attribute to a scalar value
-<LI><A HREF = "custom.html">custom</A> - set the values of a per-grid attribute and optionally create it
+<LI><A HREF = "create_particles.html">create_particles</A> - create particles based on per-grid attributes
+<LI><A HREF = "custom.html">custom</A> - create or set or remove the values of a per-grid attribute
+<LI><A HREF = "fix_custom.html">fix custom</A> - reset the values of a per-grid attribute during a simulation
 <LI><A HREF = "dump.html">dump grid</A> - output per-grid attributes to a dump file
 <LI><A HREF = "fix_ave_grid.html">fix ave/grid</A> - time-average a per-grid attribute
 <LI><A HREF = "read_grid.html">read_grid</A> - define and initialize per-grid attributes
@@ -1678,10 +1688,12 @@ attributes in various ways:
 <P><B>Per-surf custom attributes:</B>
 </P>
 <UL><LI><A HREF = "compute_reduce.html">compute reduce</A> - reduce a per-surf attribute to a scalar value
-<LI><A HREF = "custom.html">custom</A> - set the values of a per-surf attribute and optionally create it
+<LI><A HREF = "custom.html">custom</A> - create or set or remove the values of a per-surf attribute
+<LI><A HREF = "fix_custom.html">fix custom</A> - reset the values of a per-surf attribute during a simulation
 <LI><A HREF = "dump.html">dump surf</A> - output per-surf attributes to a dump file
 <LI><A HREF = "fix_ave_surf.html">fix ave/surf</A> - time-average a per-surf attribute
-<LI><A HREF = "fix_surf_temp.html">fix surf/temp</A> - use a per-surf vector for temperature
+<LI><A HREF = "fix_emit_surf.html">fix emit/surf</A> - use per-surf attributes to varu particle emission from each surf
+<LI><A HREF = "fix_surf_temp.html">fix surf/temp</A> - set the temperature of each surf based on gas collisions
 <LI><A HREF = "read_surf.html">read_surf</A> - define and initialize per-surf attributes
 <LI><A HREF = "surf_collide.html">surf_collide</A> - use a per-surf attribute as temperature for particle/surf collisions
 <LI><A HREF = "surf_react_adsorb.html">surf_react adsorb</A> - use per-surf vectors and an array to store chemical state
@@ -1693,7 +1705,7 @@ explicit/distributed surface elements, as set by the <A HREF = "global.html">glo
 surfs</A> comand.  But they cannot be used for implicit
 surface elements.  Conceptually, implicit surfaces are defined on a
 per-grid cell basis, so per-grid custom attributes can be used instead
-for attributes of those implicit surfaces.
+to define attributes of implicit surfaces.
 </P>
 <P>Note that in some cases the name for a custom attribute is specified
 by the user, e.g. for the <A HREF = "read_grid.html">read_grid</A> or
@@ -1712,9 +1724,12 @@ once every N steps from the energy flux which colliding particles
 impart to each surface element, also stored in a custom per-surf
 vector.
 </P>
-<P>In both cases, the custom per-surf vector can be passed to the
-<A HREF = "surf_collide.html">surf_collide diffuse</A> command to each timestep when
-particle/surface element collisions take place.
+<P>In both cases, the custom per-surf temperature can be used by the
+<A HREF = "surf_collide.html">surf_collide diffuse</A> command to use the current
+surface temperature for performing particle/surface element
+collisions.  Likewise the <A HREF = "fix_emit_surf.html">fix emit/surf</A> command
+can use the current custom per-surf temperature to alter the emission
+properties of each surface elemnt.
 </P>
 <P>Another use of dynamic custom attributes is by the <A HREF = "fix_ambipolar.html">fix
 ambipolar</A> and <A HREF = "surf_react.html">surf_react adsorb</A>
@@ -1748,15 +1763,15 @@ advance the solution locally. The benefit of the global timestep
 calculation is that it will automatically reduce the timestep if the
 intial value is too large, leading to higher accuracy, and it will
 automatically increase the timestep if the initial value is too small,
-speeding up the simulation. The overhead of using the variable timestep
-option is the computational time involved in computing the cell-based
-time quantities and performing parallel reductions over the grid to
-construct the global minimum and average cell timesteps needed for the
-global timestep calculation. For scenarios where ensembles of similar
-problems are being run, one strategy to mitigate this cost is to
-determine an optimal timestep using the variable timestep option for
-the first run and then to utilize this timestep as a user-specified
-value for the subsequent runs.
+speeding up the simulation. The overhead of using the variable
+timestep option is the computational time involved in computing the
+cell-based time quantities and performing parallel reductions over the
+grid to construct the global minimum and average cell timesteps needed
+for the global timestep calculation. For scenarios where ensembles of
+similar problems are being run, one strategy to mitigate this cost is
+to determine an optimal timestep using the variable timestep option
+for the first run and then to utilize this timestep as a
+user-specified value for the subsequent runs.
 </P>
 <P>The <A HREF = "compute_dt_grid.html">compute dt/grid</A> command is used to
 calculate the cell-based timesteps, and the <A HREF = "fix_dt_reset.html">fix

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -1643,13 +1643,21 @@ Each custom attribute has a name, which allows them to be specified in
 input scripts as arguments to various commands.  The values each
 attricute stores can be either integer or floating point numbers.
 
-Here are lists of current commands (as of August 2023) which use custom
-attributes in various ways:
+The "custom"_custom.html command can create and set/reset custom
+attribute values for all 3 flavors of attributes.  Either by invoking
+per-particle, per-grid, or per-surf variables, or by reading a file.
+The "fix custom"_fix_custom.html command can do the same thing
+periodically as a simulation runs.  "Dump"_dump.html commands can
+output all 3 flavors of attributes.
+
+Here are lists of current commands which use custom attributes in
+various ways:
 
 [Per-particle custom attributes:]
 
 "compute reduce"_compute_reduce.html - reduce a per-particle attribute to a scalar value
-"custom"_custom.html - set the values of a per-particle attribute and optionally create it
+"custom"_custom.html - create or set ore remove the values of a per-particle attribute
+"fix custom"_fix_custom.html - reset the values of a per-particle attribute during a simulation
 "dump particle"_dump.html - output per-particle attributes to a dump file
 "fix ambipolar"_fix_ambipolar.html - use a per-particle vector and array for ambipolar quantities
 "variable"_variable.html - use a per-particle attribute in a particle-style variable formula :ul
@@ -1657,7 +1665,9 @@ attributes in various ways:
 [Per-grid custom attributes:]
 
 "compute reduce"_compute_reduce.html - reduce a per-grid attribute to a scalar value
-"custom"_custom.html - set the values of a per-grid attribute and optionally create it
+"create_particles"_create_particles.html - create particles based on per-grid attributes
+"custom"_custom.html - create or set or remove the values of a per-grid attribute
+"fix custom"_fix_custom.html - reset the values of a per-grid attribute during a simulation
 "dump grid"_dump.html - output per-grid attributes to a dump file
 "fix ave/grid"_fix_ave_grid.html - time-average a per-grid attribute
 "read_grid"_read_grid.html - define and initialize per-grid attributes
@@ -1668,10 +1678,12 @@ surf_react implicit - use per-grid vectors and an array to store chemical state 
 [Per-surf custom attributes:]
 
 "compute reduce"_compute_reduce.html - reduce a per-surf attribute to a scalar value
-"custom"_custom.html - set the values of a per-surf attribute and optionally create it
+"custom"_custom.html - create or set or remove the values of a per-surf attribute
+"fix custom"_fix_custom.html - reset the values of a per-surf attribute during a simulation
 "dump surf"_dump.html - output per-surf attributes to a dump file
 "fix ave/surf"_fix_ave_surf.html - time-average a per-surf attribute
-"fix surf/temp"_fix_surf_temp.html - use a per-surf vector for temperature
+"fix emit/surf"_fix_emit_surf.html - use per-surf attributes to varu particle emission from each surf
+"fix surf/temp"_fix_surf_temp.html - set the temperature of each surf based on gas collisions
 "read_surf"_read_surf.html - define and initialize per-surf attributes
 "surf_collide"_surf_collide.html - use a per-surf attribute as temperature for particle/surf collisions
 "surf_react adsorb"_surf_react_adsorb.html - use per-surf vectors and an array to store chemical state
@@ -1683,7 +1695,7 @@ explicit/distributed surface elements, as set by the "global
 surfs"_global.html comand.  But they cannot be used for implicit
 surface elements.  Conceptually, implicit surfaces are defined on a
 per-grid cell basis, so per-grid custom attributes can be used instead
-for attributes of those implicit surfaces.
+to define attributes of implicit surfaces.
 
 Note that in some cases the name for a custom attribute is specified
 by the user, e.g. for the "read_grid"_read_grid.html or
@@ -1702,9 +1714,12 @@ once every N steps from the energy flux which colliding particles
 impart to each surface element, also stored in a custom per-surf
 vector.
 
-In both cases, the custom per-surf vector can be passed to the
-"surf_collide diffuse"_surf_collide.html command to each timestep when
-particle/surface element collisions take place.
+In both cases, the custom per-surf temperature can be used by the
+"surf_collide diffuse"_surf_collide.html command to use the current
+surface temperature for performing particle/surface element
+collisions.  Likewise the "fix emit/surf"_fix_emit_surf.html command
+can use the current custom per-surf temperature to alter the emission
+properties of each surface elemnt.
 
 Another use of dynamic custom attributes is by the "fix
 ambipolar"_fix_ambipolar.html and "surf_react adsorb"_surf_react.html
@@ -1738,15 +1753,15 @@ advance the solution locally. The benefit of the global timestep
 calculation is that it will automatically reduce the timestep if the
 intial value is too large, leading to higher accuracy, and it will
 automatically increase the timestep if the initial value is too small,
-speeding up the simulation. The overhead of using the variable timestep
-option is the computational time involved in computing the cell-based
-time quantities and performing parallel reductions over the grid to
-construct the global minimum and average cell timesteps needed for the
-global timestep calculation. For scenarios where ensembles of similar
-problems are being run, one strategy to mitigate this cost is to
-determine an optimal timestep using the variable timestep option for
-the first run and then to utilize this timestep as a user-specified
-value for the subsequent runs.
+speeding up the simulation. The overhead of using the variable
+timestep option is the computational time involved in computing the
+cell-based time quantities and performing parallel reductions over the
+grid to construct the global minimum and average cell timesteps needed
+for the global timestep calculation. For scenarios where ensembles of
+similar problems are being run, one strategy to mitigate this cost is
+to determine an optimal timestep using the variable timestep option
+for the first run and then to utilize this timestep as a
+user-specified value for the subsequent runs.
 
 The "compute dt/grid"_compute_dt_grid.html command is used to
 calculate the cell-based timesteps, and the "fix

--- a/doc/create_particles.html
+++ b/doc/create_particles.html
@@ -279,22 +279,23 @@ spatially-dependent thermal temperature variation.  The specified
 <I>tvar</I> is the name of an <A HREF = "variable.html">equal-style variable</A> whose
 formula should evaluate to a positive value.  The formula for the
 <I>tvar</I> variable can use one or two or three variables which will store
-the x, y, or z coordinates of the geometric center point of a grid
-cell.  If used, these other variables must be <A HREF = "variable.html">internal-style
+the x, y, or z coordinates of the particle that is being created. If
+used, these other variables must be <A HREF = "variable.html">internal-style
 variables</A> defined in the input script; their initial
 numeric values can by anything.  Their names are specified as <I>xvar</I>,
 <I>yvar</I>, and <I>zvar</I>.  If any of them is not used in the <I>tvar</I> formula,
 it can be specified as NULL.
 </P>
-<P>When particles are added to a grid cell, its center point coordinates
-are stored in <I>xvar</I>, <I>yvar</I>, <I>zvar</I> if they are defined.  The <I>tvar</I>
-variable is then evaluated.  The returned value is used as a scale
-factor on the thermal temperature number for particles created in that
-grid cell.  Thus a value of 0.5 would create particles with a thermal
-temperature half of what would otherwise be the case, due to the
-mixture <I>temp</I> setting which defines the thermal temperature, as
+<P>When a particle is added to a grid cell, its coordinates are stored in
+<I>xvar</I>, <I>yvar</I>, <I>zvar</I> if they are defined.  The <I>tvar</I> variable is
+then evaluated.  The returned value is used as a scale factor on the 3
+mixture temperatures for thermal, rotational, and vibrational
+temperature.  Thus a value of 0.5 would create a particle with a
+thermal temperature half of what would otherwise be the case, due to
+the mixture <I>temp</I> setting which defines the thermal temperature, as
 explained above.  A value of 1.2 would create particles with a 20%
-higher thermal temperature.
+higher thermal temperature.  Ditto for the rotational and vibrational
+temperature of the created particle.
 </P>
 <P>As an example, these commands can be used in a 2d simulation, to
 create a thermal temperature gradient in x, where the temperature on

--- a/doc/create_particles.html
+++ b/doc/create_particles.html
@@ -30,7 +30,7 @@
 </PRE>
 <LI>zero or more keyword/value pairs may be appended 
 
-<LI>keyword = <I>cut</I> or <I>global</I> or <I>region</I> or <I>species</I> or <I>density</I> or <I>temperature</I> or <I>velocity</I> or <I>twopass</I> 
+<LI>keyword = <I>cut</I> or <I>global</I> or <I>region</I> or <I>species</I> or <I>density</I> or <I>temperature</I> or <I>velocity</I> or <I>custom</I> or <I>twopass</I> 
 
 <PRE>  <I>cut</I> value = <I>yes</I> or <I>no</I>
   <I>global</I> value = <I>yes</I> or <I>no</I>
@@ -47,6 +47,9 @@
   <I>velocity</I> values = vxvar vyvar vzvar xvar yvar zvar
     vxvar,vyvar,vzvar = names of equal-style variables for vx,vy,vz
     xvar,yvar,zvar = names of internal-style variables for x,y,z
+  <I>custom</I> values = attribute g_name
+    attribute = <I>density</I> or <I>temperature</I>
+    g_name = custom per-grid vector with name
   <I>twopass</I> values = none 
 </PRE>
 
@@ -59,6 +62,7 @@ create_particles air n 100000 global yes
 create_particles air single 3 5.0 6.0 5.4 10.0 -1.0 0.0
 create_particles air n 0 species mySpecies xpos NULL zpos
 create_particles air n 0 density myDens xgrid ygrid NULL
+create_particles air n 0 custom density g_dens
 create_particles air n 0 temperature myTemp xgrid ygrid zgrid
 create_particles air n 0 velocity myVx NULL myVz xpos ypos NULL twopass 
 </PRE>
@@ -90,17 +94,21 @@ particles is calculated by SPARTA as a function of the global <I>fnum</I>
 value, the mixture number density, and the flow volume of the
 simulation domain.
 </P>
-<P>The <I>fnum</I> value is set by the <A HREF = "global.html">global fnum</A> command.  The
-mixture <I>nrho</I> is set by the <A HREF = "mixture.html">mixture</A> command.  The flow
-volume of the simulation is the total volume of the simulation domain
-as specified by the <A HREF = "create_box.html">create_box</A> command, minus any
-volume that is interior to surfaces defined by the
-<A HREF = "read_surf.html">read_surf</A> command.  Note that the flow volume
-includes volume contributions from grid cells cut by surfaces.
-However particles are only created in grid cells entirely external to
-surfaces.  This means that particles may be created in external cells
-at a (slightly) higher density to compensate for no particles being
-created in cut cells that still contribute to the overall flow volume.
+<P>The <I>fnum</I> value is set by the <A HREF = "global.html">global fnum</A> command and
+is the ratio of real, physical moleclules to simulation particles.
+The mixture <I>nrho</I> is set by the <A HREF = "mixture.html">mixture</A> command.  The
+flow volume of the simulation is the total volume of the simulation
+domain as specified by the <A HREF = "create_box.html">create_box</A> command, minus
+any volume that is interior to surfaces defined by the
+<A HREF = "read_surf.html">read_surf</A> command.
+</P>
+<P>Note that the flow volume includes volume contributions from grid
+cells cut by surfaces.  Depending on the value of the optional <I>cut</I>
+keyword, particles may be created in the entire volume external to
+surface, or only created in grid cells entirely external to surfaces.
+In the latter case, particles may be created in external cells at a
+(slightly) higher density to compensate for no particles being created
+in cut cells that contribute to the overall flow volume.
 </P>
 <P>If the <I>n</I> style is used with a non-zero <I>Np</I>, then exactly <I>Np</I>
 particles are created, which can be useful for debugging or
@@ -179,6 +187,17 @@ the bounding box that encloses the region.  Particles those grid cells
 attempt to add are included in the count for N, even if some or all of
 the particle insertions are rejected due to not being inside the
 region.
+</P>
+<HR>
+
+<P>The <I>species</I>, <I>density</I>, <I>temperature</I>, and <I>velocity</I> keywords
+enable creation of particles whose properties vary spatially across
+the simulation domain.  They do this by using variable formulas which
+are functions of the position of a created particle or the center
+point of the grid cell the created particles are in.
+</P>
+<P>Note that the <I>custom</I> keyword explained below can also do something
+similar.
 </P>
 <P>The <I>species</I> keyword can be used to create particles with a
 spatially-dependent separation of species.  The specified <I>svar</I> is
@@ -326,6 +345,53 @@ create_particles air n 10000 velocity vx vy NULL x y NULL
 </PRE>
 <CENTER><A HREF = "JPG/velocity_variation.gif"><IMG SRC = "JPG/velocity_variation_small.jpg"></A>
 </CENTER>
+<HR>
+
+<P>The <I>custom</I> keyword enables creation of particles whose properties
+vary spatially across the simulation domain.  This is done by using
+custom per-grid vectors defined by other commands.  E.g. the
+<A HREF = "read_grid.html">read_grid</A> command which can read per-grid attributes
+included in the grid data file.  Or the custom command which allows
+for definition of custom per-grid vectors and their initialization by
+use of <A HREF = "variable.html">grid-style variables</A> or by reading the values
+from a file.  See <A HREF = "Section_howto.html#howto_17">Section Howto 6.17</A> for
+a discussion of custom per-grid attributes.
+</P>
+<P>Note that the <I>species</I>, <I>density</I>, <I>temperature</I>, and <I>velocity</I>
+keywords explained above can also do something similar.
+</P>
+<P>The <I>attribute</I> value of the <I>custom</I> keyword can be any of the
+following:
+</P>
+<P>NOTE: should these be absolute values or scale factors ?
+</P>
+<UL><LI>density = number density (# per length^3 units) = per-grid vector
+<LI>temperature = temperature (temperature units) = per-grid vector 
+</UL>
+<P>The <I>g_name</I> value of the <I>custom</I> keyword is the name of the custom
+per-grid vector or array.  It must store floating-point values and be
+a vector or array, as indicated in the list above.  NOTE: only
+per-grid vectors are currently included as attributes for the <I>custom</I>
+keyword.
+</P>
+<P>The <I>g_name</I> for the <I>attribute density</I> keyword specifies a per-grid
+vector which stores a scale factor on the number of particles to
+create in each grid cell.  Thus a value of 0.5 would create half as
+many particles in that grid cell as would otherwise be the case, due
+to the global <I>fnum</I> and mixture <I>nrho</I> settings that define the
+density, as explained above.  A value of 1.2 would create 20% more
+particles in that grid cell.
+</P>
+<P>The <I>g_name</I> for the <I>attribute temperature</I> keyword specifies a
+per-grid vector which stores a scale factor on the thermal temperature
+of particles to create in each grid cell.  Thus a value of 0.5 would
+create particles with a thermal temperature half of what would
+otherwise be the case, due to the mixture <I>temp</I> setting which defines
+the thermal temperature, as explained above.  A value of 1.2 would
+create particles with a 20% higher thermal temperature.
+</P>
+<HR>
+
 <P>The <I>twopass</I> keyword does not require a value.  If used, the
 creation procedure will loop over the creation grid cells twice, the
 same as the KOKKOS package version of this command does, so that it can

--- a/doc/create_particles.html
+++ b/doc/create_particles.html
@@ -30,27 +30,28 @@
 </PRE>
 <LI>zero or more keyword/value pairs may be appended 
 
-<LI>keyword = <I>cut</I> or <I>global</I> or <I>region</I> or <I>species</I> or <I>density</I> or <I>temperature</I> or <I>velocity</I> or <I>custom</I> or <I>twopass</I> 
+<LI>keyword = <I>cut</I> or <I>global</I> or <I>region</I> or <I>species</I> or <I>density</I> or <I>temperature</I> or <I>vstream</I> or <I>custom</I> or <I>twopass</I> 
 
 <PRE>  <I>cut</I> value = <I>yes</I> or <I>no</I>
   <I>global</I> value = <I>yes</I> or <I>no</I>
   <I>region</I> value = region-ID
   <I>species</I> values = svar xvar yvar zvar
-    svar = name of equal-style variable for species
+    svar = name of equal-style variable for species type
     xvar,yvar,zvar = names of internal-style variables for x,y,z
   <I>density</I> values = dvar xvar yvar zvar
     svar = name of equal-style variable for density
     xvar,yvar,zvar = names of internal-style variables for x,y,z
   <I>temperature</I> values = tvar xvar yvar zvar
-    svar = name of equal-style variable for temperature
+    tvar = name of equal-style variable for temperature
     xvar,yvar,zvar = names of internal-style variables for x,y,z
-  <I>velocity</I> values = vxvar vyvar vzvar xvar yvar zvar
+  <I>vstream</I> values = vxvar vyvar vzvar xvar yvar zvar
     vxvar,vyvar,vzvar = names of equal-style variables for vx,vy,vz
     xvar,yvar,zvar = names of internal-style variables for x,y,z
   <I>custom</I> values = attribute g_name
-    attribute = <I>density</I> or <I>temperature</I>
-    g_name = custom per-grid vector with name
-  <I>twopass</I> values = none 
+    attribute = <I>nrho</I> or <I>temp</I> or <I>temp</I> or <I>vstream</I> or <I>fractions</I>
+    g_name = custom per-grid vector or array with name 
+</PRE>
+<PRE>  <I>twopass</I> values = none 
 </PRE>
 
 </UL>
@@ -62,7 +63,6 @@ create_particles air n 100000 global yes
 create_particles air single 3 5.0 6.0 5.4 10.0 -1.0 0.0
 create_particles air n 0 species mySpecies xpos NULL zpos
 create_particles air n 0 density myDens xgrid ygrid NULL
-create_particles air n 0 custom density g_dens
 create_particles air n 0 temperature myTemp xgrid ygrid zgrid
 create_particles air n 0 velocity myVx NULL myVz xpos ypos NULL twopass 
 </PRE>
@@ -94,21 +94,17 @@ particles is calculated by SPARTA as a function of the global <I>fnum</I>
 value, the mixture number density, and the flow volume of the
 simulation domain.
 </P>
-<P>The <I>fnum</I> value is set by the <A HREF = "global.html">global fnum</A> command and
-is the ratio of real, physical moleclules to simulation particles.
-The mixture <I>nrho</I> is set by the <A HREF = "mixture.html">mixture</A> command.  The
-flow volume of the simulation is the total volume of the simulation
-domain as specified by the <A HREF = "create_box.html">create_box</A> command, minus
-any volume that is interior to surfaces defined by the
-<A HREF = "read_surf.html">read_surf</A> command.
-</P>
-<P>Note that the flow volume includes volume contributions from grid
-cells cut by surfaces.  Depending on the value of the optional <I>cut</I>
-keyword, particles may be created in the entire volume external to
-surface, or only created in grid cells entirely external to surfaces.
-In the latter case, particles may be created in external cells at a
-(slightly) higher density to compensate for no particles being created
-in cut cells that contribute to the overall flow volume.
+<P>The <I>fnum</I> value is set by the <A HREF = "global.html">global fnum</A> command.  The
+mixture <I>nrho</I> is set by the <A HREF = "mixture.html">mixture</A> command.  The flow
+volume of the simulation is the total volume of the simulation domain
+as specified by the <A HREF = "create_box.html">create_box</A> command, minus any
+volume that is interior to surfaces defined by the
+<A HREF = "read_surf.html">read_surf</A> command.  Note that the flow volume
+includes volume contributions from grid cells cut by surfaces.
+However particles are only created in grid cells entirely external to
+surfaces.  This means that particles may be created in external cells
+at a (slightly) higher density to compensate for no particles being
+created in cut cells that still contribute to the overall flow volume.
 </P>
 <P>If the <I>n</I> style is used with a non-zero <I>Np</I>, then exactly <I>Np</I>
 particles are created, which can be useful for debugging or
@@ -135,7 +131,9 @@ velocity sampled from the thermal temperature of the mixture.  Both
 the streaming velocity and thermal temperature are also set by the
 <A HREF = "mixture.html">mixture</A> command.  The internal rotational and
 vibrational energies of the particle are also set based on the <I>trot</I>
-and <I>tvib</I> settings for the mixture, as explained above.
+and <I>tvib</I> settings for the mixture, as explained above.  These
+default values based on the mixture properties can be overridden by
+keywords explained below.
 </P>
 <P>The <I>single</I> style creates a single particle.  This can be useful for
 debugging purposes, e.g. to advect a single particle towards a
@@ -143,10 +141,11 @@ surface.  A single particle of the specified species is inserted at
 the specified position and with the specified velocity.  In this case
 the <I>mix-ID</I> is ignored.
 </P>
+<P>The meaning of the optional keywords are described in the subsequent
+sub-sections.
+</P>
 <HR>
 
-<P>This is the meaning of the other allowed keywords.
-</P>
 <P>The <I>cut</I> keyword controls how grid cells cut by surfaces are treated.
 If <I>yes</I> is specified (the default) then particles are added to the
 flow portion of those cells (outside the surfaces).  If <I>no</I> is
@@ -190,19 +189,34 @@ region.
 </P>
 <HR>
 
-<P>The <I>species</I>, <I>density</I>, <I>temperature</I>, and <I>velocity</I> keywords
-enable creation of particles whose properties vary spatially across
-the simulation domain.  They do this by using variable formulas which
-are functions of the position of a created particle or the center
-point of the grid cell the created particles are in.
+<P>The <I>species</I>, <I>density</I>, <I>temp</I>, and <I>vstream</I> keywords can be used
+to create particles with properties which are spatially dependent.
+This is done by defined <A HREF = "variable.html">equal-style variables</A> with
+formulas that include the coordinates of the created particle or the
+coordinates of the grid cell containing the particle.
 </P>
-<P>Note that the <I>custom</I> keyword explained below can also do something
-similar.
+<P>The formulas for these 4 keywords should be in the following form,
+where (x,y,z) are the coordinates of the created particle, and
+(cx,cy,cz) are the coordinates of the center point of the grid cell
+the particle is in.
+</P>
+<UL><LI>species formula = f(x,y,z) produces an integer from 1 to Nspecies
+<LI>density = f(cx,cy,cz) produces a unitless scale factor
+<LI>temp = f(x,y,z) = produces a unitless scale factor
+<LI>vstream = 3 formulas for vx,vy,vz = vx(x,y,z) (and vy,vz) produces a value in velocity units 
+</UL>
+<P>Note that the <I>species</I>, <I>temp</I>, <I>vstream</I> keywords define particle
+attributes based on the position of an individual particle.  This is
+in contrast to the <I>custom nrho</I>, <I>custom temp</I>, <I>custom vstream</I>, and
+<I>custom fractions</I> keywords described below, which define particle
+attributes at the resolution of individual grid cells.  The <I>density</I>
+keyword is similar to the <I>custom nrho</I> keyword, in that it operates
+on individual grid cells.
 </P>
 <P>The <I>species</I> keyword can be used to create particles with a
 spatially-dependent separation of species.  The specified <I>svar</I> is
 the name of an <A HREF = "variable.html">equal-style variable</A> whose formula
-should evaluate to a species number, i.e. an integer from 1 to Nsp,
+should evaluate to a species type, i.e. an integer from 1 to Nsp,
 where Nsp is the number of species in the mixture with mix-ID.  Since
 equal-style variables evaluate to floating-point values, this value is
 truncated to an integer value.  The formula for the species variable
@@ -279,23 +293,22 @@ spatially-dependent thermal temperature variation.  The specified
 <I>tvar</I> is the name of an <A HREF = "variable.html">equal-style variable</A> whose
 formula should evaluate to a positive value.  The formula for the
 <I>tvar</I> variable can use one or two or three variables which will store
-the x, y, or z coordinates of the particle that is being created. If
-used, these other variables must be <A HREF = "variable.html">internal-style
+the x, y, or z coordinates of the geometric center point of a grid
+cell.  If used, these other variables must be <A HREF = "variable.html">internal-style
 variables</A> defined in the input script; their initial
 numeric values can by anything.  Their names are specified as <I>xvar</I>,
 <I>yvar</I>, and <I>zvar</I>.  If any of them is not used in the <I>tvar</I> formula,
 it can be specified as NULL.
 </P>
-<P>When a particle is added to a grid cell, its coordinates are stored in
-<I>xvar</I>, <I>yvar</I>, <I>zvar</I> if they are defined.  The <I>tvar</I> variable is
-then evaluated.  The returned value is used as a scale factor on the 3
-mixture temperatures for thermal, rotational, and vibrational
-temperature.  Thus a value of 0.5 would create a particle with a
-thermal temperature half of what would otherwise be the case, due to
-the mixture <I>temp</I> setting which defines the thermal temperature, as
+<P>When particles are added to a grid cell, its center point coordinates
+are stored in <I>xvar</I>, <I>yvar</I>, <I>zvar</I> if they are defined.  The <I>tvar</I>
+variable is then evaluated.  The returned value is used as a scale
+factor on the thermal temperature number for particles created in that
+grid cell.  Thus a value of 0.5 would create particles with a thermal
+temperature half of what would otherwise be the case, due to the
+mixture <I>temp</I> setting which defines the thermal temperature, as
 explained above.  A value of 1.2 would create particles with a 20%
-higher thermal temperature.  Ditto for the rotational and vibrational
-temperature of the created particle.
+higher thermal temperature.
 </P>
 <P>As an example, these commands can be used in a 2d simulation, to
 create a thermal temperature gradient in x, where the temperature on
@@ -306,14 +319,14 @@ the right side is 3x larger.
 variable t equal "1.0 + 2.0*(v_x-xlo)/(xhi-xlo)"
 create_particles air n 10000 temperature t x NULL NULL 
 </PRE>
-<P>The <I>velocity</I> keyword can be used to create particles with a
+<P>The <I>vstream</I> keyword can be used to create particles with a
 spatially-dependent streaming velocity.  The specified <I>vxvar</I>,
 <I>vyvar</I>, <I>vzvar</I> are the names of <A HREF = "variable.html">equal-style
 variables</A> whose formulas should evaluate to the
 corresponding component of the streaming velocity.  If any of them are
 specified as NULL, then that streaming velocity component is set by
-the corresponding global or mixture streaming velocity component, the
-same as if the <I>velocity</I> keyword were not used.
+the corresponding mixture streaming velocity component, the same as if
+the <I>vstream</I> keyword were not used.
 </P>
 <P>The formulas for the <I>vxvar</I>, <I>vyvar</I>, <I>vzvar</I> variables can use one
 or two or three variables which will store the x, y, or z coordinates
@@ -328,8 +341,8 @@ NULL.
 <I>yvar</I>, <I>zvar</I> if they are defined.  The <I>vxvar</I>, <I>vyvar</I>, <I>vzvar</I>
 variables are then evaluated.  The returned values are used to set the
 streaming velocity of that particle.  A thermal velocity is also added
-to the particle, using the the global or mixture temperature, as
-described above.
+to the particle, using the temperature set by the mixture or <I>temp</I>
+keyword, as described above.
 </P>
 <P>As an example, these commands can be used in a 2d simulation, to give
 particles an initial velocity pointing towards the upper right corner
@@ -348,48 +361,71 @@ create_particles air n 10000 velocity vx vy NULL x y NULL
 </CENTER>
 <HR>
 
-<P>The <I>custom</I> keyword enables creation of particles whose properties
-vary spatially across the simulation domain.  This is done by using
-custom per-grid vectors defined by other commands.  E.g. the
-<A HREF = "read_grid.html">read_grid</A> command which can read per-grid attributes
-included in the grid data file.  Or the custom command which allows
-for definition of custom per-grid vectors and their initialization by
-use of <A HREF = "variable.html">grid-style variables</A> or by reading the values
-from a file.  See <A HREF = "Section_howto.html#howto_17">Section Howto 6.17</A> for
-a discussion of custom per-grid attributes.
+<P>The <I>custom</I> keyword can be used one or more times to tailor the
+attributes of created particles within individual grid cells.  This is
+done by using custom per-grid vectors or arrays defined by other
+commands.
 </P>
-<P>Note that the <I>species</I>, <I>density</I>, <I>temperature</I>, and <I>velocity</I>
-keywords explained above can also do something similar.
+<P>For example, the <A HREF = "read_grid.html">read_grid</A> command can read per-grid
+attributes included in a grid data file.  The <A HREF = "custom.html">custom</A>
+command allows for definition of custom per-grid vectors or arrays and
+their initialization by use of <A HREF = "variable.html">grid-style variables</A> or
+by reading the values from a file.
 </P>
-<P>The <I>attribute</I> value of the <I>custom</I> keyword can be any of the
+<P>See <A HREF = "Section_howto.html#howto_17">Section Howto 6.17</A> for a discussion
+of custom per-grid attributes.
+</P>
+<P>The <I>attribute</I> values of the <I>custom</I> keyword can be any of the
 following:
 </P>
-<P>NOTE: should these be absolute values or scale factors ?
-</P>
-<UL><LI>density = number density (# per length^3 units) = per-grid vector
-<LI>temperature = temperature (temperature units) = per-grid vector 
+<UL><LI>nrho = number density (# per volume or area units) = per-grid vector
+<LI>temp = temperature (temperature units) = per-grid vector
+<LI>vstream = 3-component streaming velocity (velocity units) = per-grid array with 3 columns
+<LI>fractions = species fractions (unitless) = per-grid array 
 </UL>
 <P>The <I>g_name</I> value of the <I>custom</I> keyword is the name of the custom
 per-grid vector or array.  It must store floating-point values and be
-a vector or array, as indicated in the list above.  NOTE: only
-per-grid vectors are currently included as attributes for the <I>custom</I>
-keyword.
+a vector or array, as indicated in the list above.
 </P>
-<P>The <I>g_name</I> for the <I>attribute density</I> keyword specifies a per-grid
-vector which stores a scale factor on the number of particles to
-create in each grid cell.  Thus a value of 0.5 would create half as
-many particles in that grid cell as would otherwise be the case, due
-to the global <I>fnum</I> and mixture <I>nrho</I> settings that define the
-density, as explained above.  A value of 1.2 would create 20% more
-particles in that grid cell.
+<P>Note that the <I>custom</I> keyword defines particle attributes at the
+resolution of individual grid cells.  This is in contrast to the
+<I>species</I>, <I>temp</I>, <I>vstream</I> keywords described above, which can
+define particle attributes based on the position of an individual
+particle.  The <I>custom density</I> keyword is similar to the <I>nrho</I>
+keyword, in that it operates on individual grid cells.
 </P>
-<P>The <I>g_name</I> for the <I>attribute temperature</I> keyword specifies a
-per-grid vector which stores a scale factor on the thermal temperature
-of particles to create in each grid cell.  Thus a value of 0.5 would
-create particles with a thermal temperature half of what would
-otherwise be the case, due to the mixture <I>temp</I> setting which defines
-the thermal temperature, as explained above.  A value of 1.2 would
-create particles with a 20% higher thermal temperature.
+<P>The <I>custom</I> attribute <I>nrho</I> sets a number density for each grid cell
+from a per-grid custom vector.  The values are used to calculate the
+count of particles created within each grid cell.  The nrho values
+should be in per-volume units = per-length^3 for 3d models or
+axisymmetric models.  The values should be in per-area units =
+per-length^2 for 2d models.
+</P>
+<P>The <I>custom</I> attribute <I>temp</I> sets a temperature for each grid cell
+from a per-grid vector.  This temperature is used as the thermal
+temeperature for each created particle which means it affects its
+thermal velocity components as well as its rotational and vibrational
+energies.
+</P>
+<P>The <I>custom</I> attribute <I>vstream</I> sets a streaming velocity for each
+grid cell from a 3-column per-grid cusstom array.
+</P>
+<P>The <I>custom</I> attribute <I>fractions</I> sets the relative species fractions
+for grid cell from an N-column per-grid custom array, where N is the
+number of species in the mixture specified with this command.  For
+each grid cell, the N values will be used to set the relative
+fractions of created particles in that cell.
+</P>
+<P>For each grid cell, the N per-species fractional values must sum to
+1.0.  However, one or more of the numeric values can be < zero, say M
+of them.  In this case, each of the M values will be reset to (1 -
+sum)/M, where sum is the sum of the N-M values which are >= zero.
+</P>
+<P>Note that the ordering of species within the N columns of the custom
+per-grid array, is the same as the order of species within the mix-ID
+mixture.  This is determined by the <A HREF = "mixture.html">mixture</A> command.
+It is the order the gas species names were listed when the mixture
+command was specified (one or more times).
 </P>
 <HR>
 
@@ -431,7 +467,13 @@ effectively.
 </P>
 <HR>
 
-<P><B>Restrictions:</B> none
+<P><B>Restrictions:</B>
+</P>
+<P>The keywords <I>density</I> and <I>custom nrho</I> cannot both be used.  This is
+because they are both methods for setting the number of particles
+created.  Ditto for <I>temperature</I> amd <I>custom temp</I>.  Ditto for
+<I>vstream</I> and <I>custom vstream</I>.  Ditto for <I>species</I> and <I>custom
+fractions</I>.
 </P>
 <P><B>Related commands:</B>
 </P>

--- a/doc/create_particles.html
+++ b/doc/create_particles.html
@@ -80,14 +80,15 @@ particles.
 <P>IMPORTANT NOTE: When a particle is created at a specified temperature
 (as set by the <A HREF = "mixture.html">mixture</A> command), it's rotational and
 vibrational energy will also be initialized, consistent with the
-mixture temperatures.  The <I>rotate</I> and <I>vibrate</I> options of the
-<A HREF = "collide_modify.html">collide_modify</A> command determine how internal
-energy modes are initialized.  If the <A HREF = "collide.html">collide</A> command
-has not yet been specified, then no rotational or vibrational energy
-will be assigned to created particles.  Thus if you wish to create
-particles with non-zero internal energy, the <A HREF = "collide.html">collide</A>
-and (optionally) <A HREF = "collide_modify.html">collide_modify</A> commands must be
-used before this command.
+corresponding mixture temperatures.  The <I>rotate</I> and <I>vibrate</I>
+options of the <A HREF = "collide_modify.html">collide_modify</A> command determine
+how internal energy modes are initialized.  If the
+<A HREF = "collide.html">collide</A> command has not yet been specified, then no
+rotational or vibrational energy will be assigned to created
+particles.  Thus if you wish to create particles with non-zero
+internal energy, the <A HREF = "collide.html">collide</A> and (optionally)
+<A HREF = "collide_modify.html">collide_modify</A> commands must be used before this
+command.
 </P>
 <P>If the <I>n</I> style is used with <I>Np</I> = 0, then the number of created
 particles is calculated by SPARTA as a function of the global <I>fnum</I>
@@ -269,9 +270,10 @@ are stored in <I>xvar</I>, <I>yvar</I>, <I>zvar</I> if they are defined.  The <I
 variable is then evaluated.  The returned value is used as a scale
 factor on the number of particles to create in that grid cell.  Thus a
 value of 0.5 would create half as many particles in that grid cell as
-would otherwise be the case, due to the global <I>fnum</I> and mixture
-<I>nrho</I> settings that define the density, as explained above.  A value
-of 1.2 would create 20% more particles in that grid cell.
+would otherwise be the case, due either to the global <I>fnum</I> and
+mixture <I>nrho</I> settings that define the density or due to the
+specified <I>Np > 0</I> value, as explained above.  A value of 1.2 would
+create 20% more particles in that grid cell.
 </P>
 <P>As an example, these commands can be used in a 2d simulation, to
 create more particles towards the upper right corner of the domain and
@@ -300,15 +302,14 @@ numeric values can by anything.  Their names are specified as <I>xvar</I>,
 <I>yvar</I>, and <I>zvar</I>.  If any of them is not used in the <I>tvar</I> formula,
 it can be specified as NULL.
 </P>
-<P>When particles are added to a grid cell, its center point coordinates
-are stored in <I>xvar</I>, <I>yvar</I>, <I>zvar</I> if they are defined.  The <I>tvar</I>
-variable is then evaluated.  The returned value is used as a scale
-factor on the thermal temperature number for particles created in that
-grid cell.  Thus a value of 0.5 would create particles with a thermal
-temperature half of what would otherwise be the case, due to the
-mixture <I>temp</I> setting which defines the thermal temperature, as
-explained above.  A value of 1.2 would create particles with a 20%
-higher thermal temperature.
+<P>When a particle is created, its coordinates are stored in <I>xvar</I>,
+<I>yvar</I>, <I>zvar</I> if they are defined.  The <I>tvar</I> variable is then
+evaluated.  The returned value is used as a scale factor on all 3
+mixture temperatures (thermal, rotational, vibrational) used to
+initialize the particle's velocity and internal energies, as explained
+above.  Thus a value of 0.5 would create particles using temperatures
+half of what the mixture specifies.  A value of 1.2 would create
+particles using 20% higher temperatures.
 </P>
 <P>As an example, these commands can be used in a 2d simulation, to
 create a thermal temperature gradient in x, where the temperature on
@@ -332,9 +333,9 @@ the <I>vstream</I> keyword were not used.
 or two or three variables which will store the x, y, or z coordinates
 of the particle that is being created.  If used, these other variables
 must be <A HREF = "variable.html">internal-style variables</A> defined in the input
-script; their initial numerica values can by anything.  Their names
-are specified as <I>xvar</I>, <I>yvar</I>, and <I>zvar</I>.  If any of them is not
-used in the <I>vxvar</I>, <I>vyvar</I>, <I>vzvar</I> formulas, it can be specified as
+script; their initial numeric values can by anything.  Their names are
+specified as <I>xvar</I>, <I>yvar</I>, and <I>zvar</I>.  If any of them is not used
+in the <I>vxvar</I>, <I>vyvar</I>, <I>vzvar</I> formulas, it can be specified as
 NULL.
 </P>
 <P>When a particle is added, its coordinates are stored in <I>xvar</I>,
@@ -401,18 +402,32 @@ should be in per-volume units = per-length^3 for 3d models or
 axisymmetric models.  The values should be in per-area units =
 per-length^2 for 2d models.
 </P>
-<P>The <I>custom</I> attribute <I>temp</I> sets a temperature for each grid cell
-from a per-grid vector.  This temperature is used as the thermal
-temeperature for each created particle which means it affects its
-thermal velocity components as well as its rotational and vibrational
-energies.
+<P>Note that if <I>Np</I> = 0, then the custom <I>nrho</I> value effectively
+increases or decreases the number of particles created in a cell by
+the scale factor custom_rho/mixture_nrho.  As compared to the number
+created if the <I>custom nrho</I> keyword were not used.  If <I>Np</I> > 0, the
+number of particles created in a cell is increased or decreased by the
+same scale factor custom_nrho/mixture_nrho, only now the scale factor
+is applied to the count of particles for the grid cell calculated as
+explained above when <I>Np</I> > 0.
 </P>
-<P>The <I>custom</I> attribute <I>vstream</I> sets a streaming velocity for each
-grid cell from a 3-column per-grid cusstom array.
+<P>The <I>custom</I> attribute <I>temp</I> sets a temperature for each grid cell
+from a per-grid vector.  This temperature is divided by the mixture
+thermal temperature to calculate a scale factor.  The scale factor is
+applied to all 3 mixture temperatures (thermal, rotational,
+vibrational) used to initialize the velocity and internal energies, as
+explained above, for each particle created in the grid cell.  Thus a
+scale factor of 0.5 would create particles using temperatures half of
+what the mixture specifies.  A value of 1.2 would create particles
+using 20% higher temperatures.
+</P>
+<P>The <I>custom</I> attribute <I>vstream</I> sets a streaming velocity for
+particles created in each grid cell from a 3-column per-grid custom
+array.
 </P>
 <P>The <I>custom</I> attribute <I>fractions</I> sets the relative species fractions
-for grid cell from an N-column per-grid custom array, where N is the
-number of species in the mixture specified with this command.  For
+for each grid cell from an N-column per-grid custom array, where N is
+the number of species in the mixture specified with this command.  For
 each grid cell, the N values will be used to set the relative
 fractions of created particles in that cell.
 </P>

--- a/doc/create_particles.txt
+++ b/doc/create_particles.txt
@@ -291,15 +291,14 @@ numeric values can by anything.  Their names are specified as {xvar},
 {yvar}, and {zvar}.  If any of them is not used in the {tvar} formula,
 it can be specified as NULL.
 
-When particles are added to a grid cell, its center point coordinates
-are stored in {xvar}, {yvar}, {zvar} if they are defined.  The {tvar}
-variable is then evaluated.  The returned value is used as a scale
-factor on the thermal temperature number for particles created in that
-grid cell.  Thus a value of 0.5 would create particles with a thermal
-temperature half of what would otherwise be the case, due to the
-mixture {temp} setting which defines the thermal temperature, as
-explained above.  A value of 1.2 would create particles with a 20%
-higher thermal temperature.
+When a particle is created, its coordinates are stored in {xvar},
+{yvar}, {zvar} if they are defined.  The {tvar} variable is then
+evaluated.  The returned value is used as a scale factor on all 3
+mixture temperatures (thermal, rotational, vibrational) used to
+initialize the particle's velocity and internal energies, as explained
+above.  Thus a value of 0.5 would create particles using temperatures
+half of what the mixture specifies.  A value of 1.2 would create
+particles using 20% higher temperatures.
 
 As an example, these commands can be used in a 2d simulation, to
 create a thermal temperature gradient in x, where the temperature on
@@ -323,9 +322,9 @@ The formulas for the {vxvar}, {vyvar}, {vzvar} variables can use one
 or two or three variables which will store the x, y, or z coordinates
 of the particle that is being created.  If used, these other variables
 must be "internal-style variables"_variable.html defined in the input
-script; their initial numerical values can by anything.  Their names
-are specified as {xvar}, {yvar}, and {zvar}.  If any of them is not
-used in the {vxvar}, {vyvar}, {vzvar} formulas, it can be specified as
+script; their initial numeric values can by anything.  Their names are
+specified as {xvar}, {yvar}, and {zvar}.  If any of them is not used
+in the {vxvar}, {vyvar}, {vzvar} formulas, it can be specified as
 NULL.
 
 When a particle is added, its coordinates are stored in {xvar},
@@ -392,18 +391,32 @@ should be in per-volume units = per-length^3 for 3d models or
 axisymmetric models.  The values should be in per-area units =
 per-length^2 for 2d models.
 
-The {custom} attribute {temp} sets a temperature for each grid cell
-from a per-grid vector.  This temperature is used as the thermal
-temeperature for each created particle which means it affects its
-thermal velocity components as well as its rotational and vibrational
-energies.
+Note that if {Np} = 0, then the custom {nrho} value effectively
+increases or decreases the number of particles created in a cell by
+the scale factor custom_rho/mixture_nrho.  As compared to the number
+created if the {custom nrho} keyword were not used.  If {Np} > 0, the
+number of particles created in a cell is increased or decreased by the
+same scale factor custom_nrho/mixture_nrho, only now the scale factor
+is applied to the count of particles for the grid cell calculated as
+explained above when {Np} > 0.
 
-The {custom} attribute {vstream} sets a streaming velocity for each
-grid cell from a 3-column per-grid cusstom array.
+The {custom} attribute {temp} sets a temperature for each grid cell
+from a per-grid vector.  This temperature is divided by the mixture
+thermal temperature to calculate a scale factor.  The scale factor is
+applied to all 3 mixture temperatures (thermal, rotational,
+vibrational) used to initialize the velocity and internal energies, as
+explained above, for each particle created in the grid cell.  Thus a
+scale factor of 0.5 would create particles using temperatures half of
+what the mixture specifies.  A value of 1.2 would create particles
+using 20% higher temperatures.
+
+The {custom} attribute {vstream} sets a streaming velocity for
+particles created in each grid cell from a 3-column per-grid custom
+array.
 
 The {custom} attribute {fractions} sets the relative species fractions
-for grid cell from an N-column per-grid custom array, where N is the
-number of species in the mixture specified with this command.  For
+for each grid cell from an N-column per-grid custom array, where N is
+the number of species in the mixture specified with this command.  For
 each grid cell, the N values will be used to set the relative
 fractions of created particles in that cell.
 

--- a/doc/create_particles.txt
+++ b/doc/create_particles.txt
@@ -22,25 +22,25 @@ style = {n} or {single} :l
     x,y,z = position of particle (distance units)
     vx,vy,vz = velocity of particle (velocity units) :pre
 zero or more keyword/value pairs may be appended :l
-keyword = {cut} or {global} or {region} or {species} or {density} or {temperature} or {velocity} or {custom} or {twopass} :l
+keyword = {cut} or {global} or {region} or {species} or {density} or {temperature} or {vstream} or {custom} or {twopass} :l
   {cut} value = {yes} or {no}
   {global} value = {yes} or {no}
   {region} value = region-ID
   {species} values = svar xvar yvar zvar
-    svar = name of equal-style variable for species
+    svar = name of equal-style variable for species type
     xvar,yvar,zvar = names of internal-style variables for x,y,z
   {density} values = dvar xvar yvar zvar
     svar = name of equal-style variable for density
     xvar,yvar,zvar = names of internal-style variables for x,y,z
   {temperature} values = tvar xvar yvar zvar
-    svar = name of equal-style variable for temperature
+    tvar = name of equal-style variable for temperature
     xvar,yvar,zvar = names of internal-style variables for x,y,z
-  {velocity} values = vxvar vyvar vzvar xvar yvar zvar
+  {vstream} values = vxvar vyvar vzvar xvar yvar zvar
     vxvar,vyvar,vzvar = names of equal-style variables for vx,vy,vz
     xvar,yvar,zvar = names of internal-style variables for x,y,z
   {custom} values = attribute g_name
-    attribute = {density} or {temperature}
-    g_name = custom per-grid vector with name
+    attribute = {nrho} or {temp} or {temp} or {vstream} or {fractions}
+    g_name = custom per-grid vector or array with name :pre
   {twopass} values = none :pre
 :ule
 
@@ -52,7 +52,6 @@ create_particles air n 100000 global yes
 create_particles air single 3 5.0 6.0 5.4 10.0 -1.0 0.0
 create_particles air n 0 species mySpecies xpos NULL zpos
 create_particles air n 0 density myDens xgrid ygrid NULL
-create_particles air n 0 custom density g_dens
 create_particles air n 0 temperature myTemp xgrid ygrid zgrid
 create_particles air n 0 velocity myVx NULL myVz xpos ypos NULL twopass :pre
 
@@ -84,21 +83,17 @@ particles is calculated by SPARTA as a function of the global {fnum}
 value, the mixture number density, and the flow volume of the
 simulation domain.
 
-The {fnum} value is set by the "global fnum"_global.html command and
-is the ratio of real, physical moleclules to simulation particles.
-The mixture {nrho} is set by the "mixture"_mixture.html command.  The
-flow volume of the simulation is the total volume of the simulation
-domain as specified by the "create_box"_create_box.html command, minus
-any volume that is interior to surfaces defined by the
-"read_surf"_read_surf.html command.
-
-Note that the flow volume includes volume contributions from grid
-cells cut by surfaces.  Depending on the value of the optional {cut}
-keyword, particles may be created in the entire volume external to
-surface, or only created in grid cells entirely external to surfaces.
-In the latter case, particles may be created in external cells at a
-(slightly) higher density to compensate for no particles being created
-in cut cells that contribute to the overall flow volume.
+The {fnum} value is set by the "global fnum"_global.html command.  The
+mixture {nrho} is set by the "mixture"_mixture.html command.  The flow
+volume of the simulation is the total volume of the simulation domain
+as specified by the "create_box"_create_box.html command, minus any
+volume that is interior to surfaces defined by the
+"read_surf"_read_surf.html command.  Note that the flow volume
+includes volume contributions from grid cells cut by surfaces.
+However particles are only created in grid cells entirely external to
+surfaces.  This means that particles may be created in external cells
+at a (slightly) higher density to compensate for no particles being
+created in cut cells that still contribute to the overall flow volume.
 
 If the {n} style is used with a non-zero {Np}, then exactly {Np}
 particles are created, which can be useful for debugging or
@@ -125,7 +120,9 @@ velocity sampled from the thermal temperature of the mixture.  Both
 the streaming velocity and thermal temperature are also set by the
 "mixture"_mixture.html command.  The internal rotational and
 vibrational energies of the particle are also set based on the {trot}
-and {tvib} settings for the mixture, as explained above.
+and {tvib} settings for the mixture, as explained above.  These
+default values based on the mixture properties can be overridden by
+keywords explained below.
 
 The {single} style creates a single particle.  This can be useful for
 debugging purposes, e.g. to advect a single particle towards a
@@ -133,9 +130,10 @@ surface.  A single particle of the specified species is inserted at
 the specified position and with the specified velocity.  In this case
 the {mix-ID} is ignored.
 
-:line
+The meaning of the optional keywords are described in the subsequent
+sub-sections.
 
-This is the meaning of the other allowed keywords.
+:line
 
 The {cut} keyword controls how grid cells cut by surfaces are treated.
 If {yes} is specified (the default) then particles are added to the
@@ -180,19 +178,34 @@ region.
 
 :line
 
-The {species}, {density}, {temperature}, and {velocity} keywords
-enable creation of particles whose properties vary spatially across
-the simulation domain.  They do this by using variable formulas which
-are functions of the position of a created particle or the center
-point of the grid cell the created particles are in.
+The {species}, {density}, {temp}, and {vstream} keywords can be used
+to create particles with properties which are spatially dependent.
+This is done by defined "equal-style variables"_variable.html with
+formulas that include the coordinates of the created particle or the
+coordinates of the grid cell containing the particle.
 
-Note that the {custom} keyword explained below can also do something
-similar.
+The formulas for these 4 keywords should be in the following form,
+where (x,y,z) are the coordinates of the created particle, and
+(cx,cy,cz) are the coordinates of the center point of the grid cell
+the particle is in.
+
+species formula = f(x,y,z) produces an integer from 1 to Nspecies
+density = f(cx,cy,cz) produces a unitless scale factor
+temp = f(x,y,z) = produces a unitless scale factor
+vstream = 3 formulas for vx,vy,vz = vx(x,y,z) (and vy,vz) produces a value in velocity units :ul
+
+Note that the {species}, {temp}, {vstream} keywords define particle
+attributes based on the position of an individual particle.  This is
+in contrast to the {custom nrho}, {custom temp}, {custom vstream}, and
+{custom fractions} keywords described below, which define particle
+attributes at the resolution of individual grid cells.  The {density}
+keyword is similar to the {custom nrho} keyword, in that it operates
+on individual grid cells.
 
 The {species} keyword can be used to create particles with a
 spatially-dependent separation of species.  The specified {svar} is
 the name of an "equal-style variable"_variable.html whose formula
-should evaluate to a species number, i.e. an integer from 1 to Nsp,
+should evaluate to a species type, i.e. an integer from 1 to Nsp,
 where Nsp is the number of species in the mixture with mix-ID.  Since
 equal-style variables evaluate to floating-point values, this value is
 truncated to an integer value.  The formula for the species variable
@@ -269,23 +282,22 @@ spatially-dependent thermal temperature variation.  The specified
 {tvar} is the name of an "equal-style variable"_variable.html whose
 formula should evaluate to a positive value.  The formula for the
 {tvar} variable can use one or two or three variables which will store
-the x, y, or z coordinates of the particle that is being created. If
-used, these other variables must be "internal-style
+the x, y, or z coordinates of the geometric center point of a grid
+cell.  If used, these other variables must be "internal-style
 variables"_variable.html defined in the input script; their initial
 numeric values can by anything.  Their names are specified as {xvar},
 {yvar}, and {zvar}.  If any of them is not used in the {tvar} formula,
 it can be specified as NULL.
 
-When a particle is added to a grid cell, its coordinates are stored in
-{xvar}, {yvar}, {zvar} if they are defined.  The {tvar} variable is
-then evaluated.  The returned value is used as a scale factor on the 3
-mixture temperatures for thermal, rotational, and vibrational
-temperature.  Thus a value of 0.5 would create a particle with a
-thermal temperature half of what would otherwise be the case, due to
-the mixture {temp} setting which defines the thermal temperature, as
+When particles are added to a grid cell, its center point coordinates
+are stored in {xvar}, {yvar}, {zvar} if they are defined.  The {tvar}
+variable is then evaluated.  The returned value is used as a scale
+factor on the thermal temperature number for particles created in that
+grid cell.  Thus a value of 0.5 would create particles with a thermal
+temperature half of what would otherwise be the case, due to the
+mixture {temp} setting which defines the thermal temperature, as
 explained above.  A value of 1.2 would create particles with a 20%
-higher thermal temperature.  Ditto for the rotational and vibrational
-temperature of the created particle.
+higher thermal temperature.
 
 As an example, these commands can be used in a 2d simulation, to
 create a thermal temperature gradient in x, where the temperature on
@@ -296,14 +308,14 @@ variable x internal 0
 variable t equal "1.0 + 2.0*(v_x-xlo)/(xhi-xlo)"
 create_particles air n 10000 temperature t x NULL NULL :pre
 
-The {velocity} keyword can be used to create particles with a
+The {vstream} keyword can be used to create particles with a
 spatially-dependent streaming velocity.  The specified {vxvar},
 {vyvar}, {vzvar} are the names of "equal-style
 variables"_variable.html whose formulas should evaluate to the
 corresponding component of the streaming velocity.  If any of them are
 specified as NULL, then that streaming velocity component is set by
-the corresponding global or mixture streaming velocity component, the
-same as if the {velocity} keyword were not used.
+the corresponding mixture streaming velocity component, the same as if
+the {vstream} keyword were not used.
 
 The formulas for the {vxvar}, {vyvar}, {vzvar} variables can use one
 or two or three variables which will store the x, y, or z coordinates
@@ -318,8 +330,8 @@ When a particle is added, its coordinates are stored in {xvar},
 {yvar}, {zvar} if they are defined.  The {vxvar}, {vyvar}, {vzvar}
 variables are then evaluated.  The returned values are used to set the
 streaming velocity of that particle.  A thermal velocity is also added
-to the particle, using the the global or mixture temperature, as
-described above.
+to the particle, using the temperature set by the mixture or {temp}
+keyword, as described above.
 
 As an example, these commands can be used in a 2d simulation, to give
 particles an initial velocity pointing towards the upper right corner
@@ -338,48 +350,71 @@ create_particles air n 10000 velocity vx vy NULL x y NULL :pre
 
 :line
 
-The {custom} keyword enables creation of particles whose properties
-vary spatially across the simulation domain.  This is done by using
-custom per-grid vectors defined by other commands.  E.g. the
-"read_grid"_read_grid.html command which can read per-grid attributes
-included in the grid data file.  Or the custom command which allows
-for definition of custom per-grid vectors and their initialization by
-use of "grid-style variables"_variable.html or by reading the values
-from a file.  See "Section Howto 6.17"_Section_howto.html#howto_17 for
-a discussion of custom per-grid attributes.
+The {custom} keyword can be used one or more times to tailor the
+attributes of created particles within individual grid cells.  This is
+done by using custom per-grid vectors or arrays defined by other
+commands.
 
-Note that the {species}, {density}, {temperature}, and {velocity}
-keywords explained above can also do something similar.
+For example, the "read_grid"_read_grid.html command can read per-grid
+attributes included in a grid data file.  The "custom"_custom.html
+command allows for definition of custom per-grid vectors or arrays and
+their initialization by use of "grid-style variables"_variable.html or
+by reading the values from a file.
 
-The {attribute} value of the {custom} keyword can be any of the
+See "Section Howto 6.17"_Section_howto.html#howto_17 for a discussion
+of custom per-grid attributes.
+
+The {attribute} values of the {custom} keyword can be any of the
 following:
 
-NOTE: should these be absolute values or scale factors ?
-
-density = number density (# per length^3 units) = per-grid vector
-temperature = temperature (temperature units) = per-grid vector :ul
+nrho = number density (# per volume or area units) = per-grid vector
+temp = temperature (temperature units) = per-grid vector
+vstream = 3-component streaming velocity (velocity units) = per-grid array with 3 columns
+fractions = species fractions (unitless) = per-grid array :ul
 
 The {g_name} value of the {custom} keyword is the name of the custom
 per-grid vector or array.  It must store floating-point values and be
-a vector or array, as indicated in the list above.  NOTE: only
-per-grid vectors are currently included as attributes for the {custom}
-keyword.
+a vector or array, as indicated in the list above.
 
-The {g_name} for the {attribute density} keyword specifies a per-grid
-vector which stores a scale factor on the number of particles to
-create in each grid cell.  Thus a value of 0.5 would create half as
-many particles in that grid cell as would otherwise be the case, due
-to the global {fnum} and mixture {nrho} settings that define the
-density, as explained above.  A value of 1.2 would create 20% more
-particles in that grid cell.
+Note that the {custom} keyword defines particle attributes at the
+resolution of individual grid cells.  This is in contrast to the
+{species}, {temp}, {vstream} keywords described above, which can
+define particle attributes based on the position of an individual
+particle.  The {custom density} keyword is similar to the {nrho}
+keyword, in that it operates on individual grid cells.
 
-The {g_name} for the {attribute temperature} keyword specifies a
-per-grid vector which stores a scale factor on the thermal temperature
-of particles to create in each grid cell.  Thus a value of 0.5 would
-create particles with a thermal temperature half of what would
-otherwise be the case, due to the mixture {temp} setting which defines
-the thermal temperature, as explained above.  A value of 1.2 would
-create particles with a 20% higher thermal temperature.
+The {custom} attribute {nrho} sets a number density for each grid cell
+from a per-grid custom vector.  The values are used to calculate the
+count of particles created within each grid cell.  The nrho values
+should be in per-volume units = per-length^3 for 3d models or
+axisymmetric models.  The values should be in per-area units =
+per-length^2 for 2d models.
+
+The {custom} attribute {temp} sets a temperature for each grid cell
+from a per-grid vector.  This temperature is used as the thermal
+temeperature for each created particle which means it affects its
+thermal velocity components as well as its rotational and vibrational
+energies.
+
+The {custom} attribute {vstream} sets a streaming velocity for each
+grid cell from a 3-column per-grid cusstom array.
+
+The {custom} attribute {fractions} sets the relative species fractions
+for grid cell from an N-column per-grid custom array, where N is the
+number of species in the mixture specified with this command.  For
+each grid cell, the N values will be used to set the relative
+fractions of created particles in that cell.
+
+For each grid cell, the N per-species fractional values must sum to
+1.0.  However, one or more of the numeric values can be < zero, say M
+of them.  In this case, each of the M values will be reset to (1 -
+sum)/M, where sum is the sum of the N-M values which are >= zero.
+
+Note that the ordering of species within the N columns of the custom
+per-grid array, is the same as the order of species within the mix-ID
+mixture.  This is determined by the "mixture"_mixture.html command.
+It is the order the gas species names were listed when the mixture
+command was specified (one or more times).
 
 :line
 
@@ -421,7 +456,13 @@ effectively.
 
 :line
 
-[Restrictions:] none
+[Restrictions:]
+
+The keywords {density} and {custom nrho} cannot both be used.  This is
+because they are both methods for setting the number of particles
+created.  Ditto for {temperature} amd {custom temp}.  Ditto for
+{vstream} and {custom vstream}.  Ditto for {species} and {custom
+fractions}.
 
 [Related commands:]
 

--- a/doc/create_particles.txt
+++ b/doc/create_particles.txt
@@ -269,22 +269,23 @@ spatially-dependent thermal temperature variation.  The specified
 {tvar} is the name of an "equal-style variable"_variable.html whose
 formula should evaluate to a positive value.  The formula for the
 {tvar} variable can use one or two or three variables which will store
-the x, y, or z coordinates of the geometric center point of a grid
-cell.  If used, these other variables must be "internal-style
+the x, y, or z coordinates of the particle that is being created. If
+used, these other variables must be "internal-style
 variables"_variable.html defined in the input script; their initial
 numeric values can by anything.  Their names are specified as {xvar},
 {yvar}, and {zvar}.  If any of them is not used in the {tvar} formula,
 it can be specified as NULL.
 
-When particles are added to a grid cell, its center point coordinates
-are stored in {xvar}, {yvar}, {zvar} if they are defined.  The {tvar}
-variable is then evaluated.  The returned value is used as a scale
-factor on the thermal temperature number for particles created in that
-grid cell.  Thus a value of 0.5 would create particles with a thermal
-temperature half of what would otherwise be the case, due to the
-mixture {temp} setting which defines the thermal temperature, as
+When a particle is added to a grid cell, its coordinates are stored in
+{xvar}, {yvar}, {zvar} if they are defined.  The {tvar} variable is
+then evaluated.  The returned value is used as a scale factor on the 3
+mixture temperatures for thermal, rotational, and vibrational
+temperature.  Thus a value of 0.5 would create a particle with a
+thermal temperature half of what would otherwise be the case, due to
+the mixture {temp} setting which defines the thermal temperature, as
 explained above.  A value of 1.2 would create particles with a 20%
-higher thermal temperature.
+higher thermal temperature.  Ditto for the rotational and vibrational
+temperature of the created particle.
 
 As an example, these commands can be used in a 2d simulation, to
 create a thermal temperature gradient in x, where the temperature on

--- a/doc/create_particles.txt
+++ b/doc/create_particles.txt
@@ -69,14 +69,15 @@ particles.
 IMPORTANT NOTE: When a particle is created at a specified temperature
 (as set by the "mixture"_mixture.html command), it's rotational and
 vibrational energy will also be initialized, consistent with the
-mixture temperatures.  The {rotate} and {vibrate} options of the
-"collide_modify"_collide_modify.html command determine how internal
-energy modes are initialized.  If the "collide"_collide.html command
-has not yet been specified, then no rotational or vibrational energy
-will be assigned to created particles.  Thus if you wish to create
-particles with non-zero internal energy, the "collide"_collide.html
-and (optionally) "collide_modify"_collide_modify.html commands must be
-used before this command.
+corresponding mixture temperatures.  The {rotate} and {vibrate}
+options of the "collide_modify"_collide_modify.html command determine
+how internal energy modes are initialized.  If the
+"collide"_collide.html command has not yet been specified, then no
+rotational or vibrational energy will be assigned to created
+particles.  Thus if you wish to create particles with non-zero
+internal energy, the "collide"_collide.html and (optionally)
+"collide_modify"_collide_modify.html commands must be used before this
+command.
 
 If the {n} style is used with {Np} = 0, then the number of created
 particles is calculated by SPARTA as a function of the global {fnum}
@@ -258,9 +259,10 @@ are stored in {xvar}, {yvar}, {zvar} if they are defined.  The {dvar}
 variable is then evaluated.  The returned value is used as a scale
 factor on the number of particles to create in that grid cell.  Thus a
 value of 0.5 would create half as many particles in that grid cell as
-would otherwise be the case, due to the global {fnum} and mixture
-{nrho} settings that define the density, as explained above.  A value
-of 1.2 would create 20% more particles in that grid cell.
+would otherwise be the case, due either to the global {fnum} and
+mixture {nrho} settings that define the density or due to the
+specified {Np > 0} value, as explained above.  A value of 1.2 would
+create 20% more particles in that grid cell.
 
 As an example, these commands can be used in a 2d simulation, to
 create more particles towards the upper right corner of the domain and
@@ -321,7 +323,7 @@ The formulas for the {vxvar}, {vyvar}, {vzvar} variables can use one
 or two or three variables which will store the x, y, or z coordinates
 of the particle that is being created.  If used, these other variables
 must be "internal-style variables"_variable.html defined in the input
-script; their initial numerica values can by anything.  Their names
+script; their initial numerical values can by anything.  Their names
 are specified as {xvar}, {yvar}, and {zvar}.  If any of them is not
 used in the {vxvar}, {vyvar}, {vzvar} formulas, it can be specified as
 NULL.

--- a/doc/create_particles.txt
+++ b/doc/create_particles.txt
@@ -22,7 +22,7 @@ style = {n} or {single} :l
     x,y,z = position of particle (distance units)
     vx,vy,vz = velocity of particle (velocity units) :pre
 zero or more keyword/value pairs may be appended :l
-keyword = {cut} or {global} or {region} or {species} or {density} or {temperature} or {velocity} or {twopass} :l
+keyword = {cut} or {global} or {region} or {species} or {density} or {temperature} or {velocity} or {custom} or {twopass} :l
   {cut} value = {yes} or {no}
   {global} value = {yes} or {no}
   {region} value = region-ID
@@ -38,6 +38,9 @@ keyword = {cut} or {global} or {region} or {species} or {density} or {temperatur
   {velocity} values = vxvar vyvar vzvar xvar yvar zvar
     vxvar,vyvar,vzvar = names of equal-style variables for vx,vy,vz
     xvar,yvar,zvar = names of internal-style variables for x,y,z
+  {custom} values = attribute g_name
+    attribute = {density} or {temperature}
+    g_name = custom per-grid vector with name
   {twopass} values = none :pre
 :ule
 
@@ -49,6 +52,7 @@ create_particles air n 100000 global yes
 create_particles air single 3 5.0 6.0 5.4 10.0 -1.0 0.0
 create_particles air n 0 species mySpecies xpos NULL zpos
 create_particles air n 0 density myDens xgrid ygrid NULL
+create_particles air n 0 custom density g_dens
 create_particles air n 0 temperature myTemp xgrid ygrid zgrid
 create_particles air n 0 velocity myVx NULL myVz xpos ypos NULL twopass :pre
 
@@ -80,17 +84,21 @@ particles is calculated by SPARTA as a function of the global {fnum}
 value, the mixture number density, and the flow volume of the
 simulation domain.
 
-The {fnum} value is set by the "global fnum"_global.html command.  The
-mixture {nrho} is set by the "mixture"_mixture.html command.  The flow
-volume of the simulation is the total volume of the simulation domain
-as specified by the "create_box"_create_box.html command, minus any
-volume that is interior to surfaces defined by the
-"read_surf"_read_surf.html command.  Note that the flow volume
-includes volume contributions from grid cells cut by surfaces.
-However particles are only created in grid cells entirely external to
-surfaces.  This means that particles may be created in external cells
-at a (slightly) higher density to compensate for no particles being
-created in cut cells that still contribute to the overall flow volume.
+The {fnum} value is set by the "global fnum"_global.html command and
+is the ratio of real, physical moleclules to simulation particles.
+The mixture {nrho} is set by the "mixture"_mixture.html command.  The
+flow volume of the simulation is the total volume of the simulation
+domain as specified by the "create_box"_create_box.html command, minus
+any volume that is interior to surfaces defined by the
+"read_surf"_read_surf.html command.
+
+Note that the flow volume includes volume contributions from grid
+cells cut by surfaces.  Depending on the value of the optional {cut}
+keyword, particles may be created in the entire volume external to
+surface, or only created in grid cells entirely external to surfaces.
+In the latter case, particles may be created in external cells at a
+(slightly) higher density to compensate for no particles being created
+in cut cells that contribute to the overall flow volume.
 
 If the {n} style is used with a non-zero {Np}, then exactly {Np}
 particles are created, which can be useful for debugging or
@@ -169,6 +177,17 @@ the bounding box that encloses the region.  Particles those grid cells
 attempt to add are included in the count for N, even if some or all of
 the particle insertions are rejected due to not being inside the
 region.
+
+:line
+
+The {species}, {density}, {temperature}, and {velocity} keywords
+enable creation of particles whose properties vary spatially across
+the simulation domain.  They do this by using variable formulas which
+are functions of the position of a created particle or the center
+point of the grid cell the created particles are in.
+
+Note that the {custom} keyword explained below can also do something
+similar.
 
 The {species} keyword can be used to create particles with a
 spatially-dependent separation of species.  The specified {svar} is
@@ -315,6 +334,53 @@ variable vy equal (yhi-v_y)/(1000*7.0e-9)
 create_particles air n 10000 velocity vx vy NULL x y NULL :pre
 
 :c,image(JPG/velocity_variation_small.jpg,JPG/velocity_variation.gif)
+
+:line
+
+The {custom} keyword enables creation of particles whose properties
+vary spatially across the simulation domain.  This is done by using
+custom per-grid vectors defined by other commands.  E.g. the
+"read_grid"_read_grid.html command which can read per-grid attributes
+included in the grid data file.  Or the custom command which allows
+for definition of custom per-grid vectors and their initialization by
+use of "grid-style variables"_variable.html or by reading the values
+from a file.  See "Section Howto 6.17"_Section_howto.html#howto_17 for
+a discussion of custom per-grid attributes.
+
+Note that the {species}, {density}, {temperature}, and {velocity}
+keywords explained above can also do something similar.
+
+The {attribute} value of the {custom} keyword can be any of the
+following:
+
+NOTE: should these be absolute values or scale factors ?
+
+density = number density (# per length^3 units) = per-grid vector
+temperature = temperature (temperature units) = per-grid vector :ul
+
+The {g_name} value of the {custom} keyword is the name of the custom
+per-grid vector or array.  It must store floating-point values and be
+a vector or array, as indicated in the list above.  NOTE: only
+per-grid vectors are currently included as attributes for the {custom}
+keyword.
+
+The {g_name} for the {attribute density} keyword specifies a per-grid
+vector which stores a scale factor on the number of particles to
+create in each grid cell.  Thus a value of 0.5 would create half as
+many particles in that grid cell as would otherwise be the case, due
+to the global {fnum} and mixture {nrho} settings that define the
+density, as explained above.  A value of 1.2 would create 20% more
+particles in that grid cell.
+
+The {g_name} for the {attribute temperature} keyword specifies a
+per-grid vector which stores a scale factor on the thermal temperature
+of particles to create in each grid cell.  Thus a value of 0.5 would
+create particles with a thermal temperature half of what would
+otherwise be the case, due to the mixture {temp} setting which defines
+the thermal temperature, as explained above.  A value of 1.2 would
+create particles with a 20% higher thermal temperature.
+
+:line
 
 The {twopass} keyword does not require a value.  If used, the
 creation procedure will loop over the creation grid cells twice, the

--- a/src/create_particles.cpp
+++ b/src/create_particles.cpp
@@ -1091,7 +1091,6 @@ double CreateParticles::density_variable(double *lo, double *hi)
 
 double CreateParticles::temperature_variable(double *x)
 {
-
   if (txstr) input->variable->internal_set(txvar,x[0]);
   if (tystr) input->variable->internal_set(tyvar,x[1]);
   if (tzstr) input->variable->internal_set(tzvar,x[2]);

--- a/src/create_particles.cpp
+++ b/src/create_particles.cpp
@@ -780,8 +780,8 @@ void CreateParticles::create_local()
       particle->add_particle(id,ispecies,icell,x,v,erot,evib);
 
       if (nfix_update_custom)
-        modify->update_custom(particle->nlocal-1,temp_thermal,
-                             temp_rot,temp_vib,vstream);
+        modify->update_custom(particle->nlocal-1,tempscale*temp_thermal,
+                             tempscale*temp_rot,tempscale*temp_vib,vstream);
     }
 
     // increment count without effect of density variation
@@ -1081,8 +1081,8 @@ void CreateParticles::create_local_twopass()
       particle->add_particle(id,ispecies,icell,x,v,erot,evib);
 
       if (nfix_update_custom)
-        modify->update_custom(particle->nlocal-1,temp_thermal,
-                             temp_rot,temp_vib,vstream);
+        modify->update_custom(particle->nlocal-1,tempscale*temp_thermal,
+                              tempscale*temp_rot,tempscale*temp_vib,vstream);
     }
   }
 

--- a/src/create_particles.h
+++ b/src/create_particles.h
@@ -53,6 +53,11 @@ class CreateParticles : protected Pointers {
   char *txstr_copy,*tystr_copy,*tzstr_copy;
   char *vstrx_copy,*vstry_copy,*vstrz_copy;
 
+  int density_custom_flag,temp_custom_flag;
+  char *density_custom_id,*temp_custom_id;
+  int density_custom_index,temp_custom_index;
+  double *density_custom,*temp_custom;
+
   virtual void create_single();
   void create_local();
   void create_local_twopass();

--- a/src/create_particles.h
+++ b/src/create_particles.h
@@ -39,7 +39,7 @@ class CreateParticles : protected Pointers {
   double xp,yp,zp,vx,vy,vz;
   class Region *region;
 
-  int speciesflag,densflag,velflag,tempflag,normflag;
+  int speciesflag,densflag,vstreamflag,tempflag,normflag;
   char *sstr,*sxstr,*systr,*szstr;
   char *dstr,*dxstr,*dystr,*dzstr;
   char *tstr,*txstr,*tystr,*tzstr;
@@ -53,18 +53,13 @@ class CreateParticles : protected Pointers {
   char *txstr_copy,*tystr_copy,*tzstr_copy;
   char *vstrx_copy,*vstry_copy,*vstrz_copy;
 
-  int density_custom_flag,temp_custom_flag;
-  char *density_custom_id,*temp_custom_id;
-  int density_custom_index,temp_custom_index;
-  double *density_custom,*temp_custom;
-
   virtual void create_single();
   void create_local();
   void create_local_twopass();
   int species_variable(double *);
   double density_variable(double *, double *);
   double temperature_variable(double *);
-  void velocity_variable(double *, double *, double *);
+  void vstream_variable(double *, double *, double *);
   int outside_region(int, double *, double *);
 };
 

--- a/src/create_particles.h
+++ b/src/create_particles.h
@@ -53,6 +53,12 @@ class CreateParticles : protected Pointers {
   char *txstr_copy,*tystr_copy,*tzstr_copy;
   char *vstrx_copy,*vstry_copy,*vstrz_copy;
 
+  int nrho_custom_flag,vstream_custom_flag,temp_custom_flag,fractions_custom_flag;
+  char *nrho_custom_id,*vstream_custom_id,*temp_custom_id,*fractions_custom_id;
+  int nrho_custom_index,vstream_custom_index,temp_custom_index,fractions_custom_index;
+  double *nrho_custom,*temp_custom;
+  double **vstream_custom,**fractions_custom;
+  
   virtual void create_single();
   void create_local();
   void create_local_twopass();
@@ -61,6 +67,7 @@ class CreateParticles : protected Pointers {
   double temperature_variable(double *);
   void vstream_variable(double *, double *, double *);
   int outside_region(int, double *, double *);
+  void fractions_to_cummulative(int, double *, double *);
 };
 
 }

--- a/src/mixture.cpp
+++ b/src/mixture.cpp
@@ -277,7 +277,7 @@ void Mixture::init()
 
 int Mixture::init_fraction(int *fflag, double *fuser, double *f, double *c)
 {
-  // sum = total frac for species with explicity set fractions
+  // sum = total frac for species with explicitly set fractions
   // nimplicit = number of unset species
 
   double sum = 0.0;


### PR DESCRIPTION
## Purpose

The create_particles command has options to use variables that are functions of a created particle's coordinates to alter their properties (temperature, species, streaming velocity, etc).  This enables spatially varying particle initialization.

This PR adds options to use per-grid custom attributes to do something similar.  The per-grid attributes can be read in from files or set by variables.  They are used to set attributes for each grid cell, which are applied when particles in that grid cell are created.  Thus it operates at grid cell resolution, rather than at the resolution of individual particles.

One use for this new feature is useful for creating SPARTA particles which match the flow field produced by a continuum code as output into a file that SPARTA inputs with per-grid attributes.

## Author(s)

Steve

## Backward Compatibility

Should not change existing behavior of other create_particles options.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


