### PR TITLE
Add python support via a new python command and python-style variables

### DIFF
--- a/lib/README
+++ b/lib/README
@@ -17,3 +17,5 @@ The libraries in this directory are the following:
 
 kokkos        Kokkos package for GPU and many-core acceleration
                 from Kokkos development team (Sandia)
+python        hooks to the system Python library, used by the PYTHON package
+                from the SPARTA development team

--- a/lib/python/Makefile.sparta
+++ b/lib/python/Makefile.sparta
@@ -1,0 +1,14 @@
+# Settings that the LAMMPS build will import when this package library is used
+# See the README file for more explanation
+ifeq ($(shell type python3 >/dev/null 2>&1; echo $$?), 0)
+PYTHON=python3
+PYTHONCONFIG = python3-config
+else
+PYTHONCONFIG = python-config
+PYTHON=python
+endif
+
+
+python_SYSINC = $(shell which $(PYTHONCONFIG) > /dev/null 2>&1 && $(PYTHONCONFIG) --includes || :)
+python_SYSLIB = $(shell which $(PYTHONCONFIG) > /dev/null 2>&1 && $(PYTHONCONFIG) --ldflags --embed > /dev/null 2>&1 && $(PYTHONCONFIG) --ldflags --embed || (which $(PYTHONCONFIG) > /dev/null 2>&1 && $(PYTHONCONFIG) --ldflags || :) )
+python_SYSPATH =

--- a/lib/python/Makefile.sparta
+++ b/lib/python/Makefile.sparta
@@ -1,4 +1,4 @@
-# Settings that the LAMMPS build will import when this package library is used
+# Settings that the SPARTA build will import when this package library is used
 # See the README file for more explanation
 ifeq ($(shell type python3 >/dev/null 2>&1; echo $$?), 0)
 PYTHON=python3

--- a/lib/python/Makefile.sparta.python3
+++ b/lib/python/Makefile.sparta.python3
@@ -1,0 +1,7 @@
+# Settings that the SPARTA build will import when this package library is used
+# See the README file for more explanation
+
+python_SYSINC = $(shell which python3-config > /dev/null 2>&1 && python3-config --includes || (which python-config > /dev/null 2>&1 && python-config --includes || :))
+python_SYSLIB = $(shell which python3-config > /dev/null 2>&1 && python3-config --ldflags --embed > /dev/null 2>&1 && python3-config --ldflags --embed || (which python3-config > /dev/null 2>&1 && python3-config --ldflags || (which python-config > /dev/null 2>&1 && python-config --ldflags || :) ) )
+python_SYSPATH =
+PYTHON=$(shell which python3 > /dev/null 2>&1 && echo python3 || echo python)

--- a/lib/python/Makefile.sparta.python3.13
+++ b/lib/python/Makefile.sparta.python3.13
@@ -1,0 +1,7 @@
+# Settings that the SPARTA build will import when this package library is used
+# See the README file for more explanation
+
+python_SYSINC = -I/usr/local/include/python2.7
+python_SYSLIB = -lpython2.7 -lnsl -ldl -lreadline -ltermcap -lpthread -lutil -lm -Xlinker -export-dynamic
+python_SYSPATH = 
+PYTHON=python2.7

--- a/lib/python/README
+++ b/lib/python/README
@@ -1,0 +1,60 @@
+The Makefile.sparta file in this directory is used when building
+SPARTA with its PYTHON package installed.  The file has several
+settings needed to compile and link SPARA with the Python library.
+
+The default Makefile.sparta will automatically choose the default
+python interpreter of your system and will infer the flags from
+the python-config utility, that is usually bundled with the python
+installation. If needed, you can copy one of the other provided
+Makefile.sparta.* files to to Makefile.sparta before building
+SPARTA itself.
+
+The file Makefile.sparta.python3 is similar to the default file, but
+meant for the case that both, python 2 and python 3, are installed
+simultaneously.  SPARTA only supports python 3.  If neither of these
+files work, you may have to create a custom Makefile.sparta file
+suitable for the version of Python on your system.  To illustrate, these
+are example settings from the Makefile.sparta.python3.13 file:
+
+python_SYSINC = -I/usr/local/include/python3.13
+python_SYSLIB = -lpython3.13 -ldl  -lm
+python_SYSPATH = -L/usr/lib64
+PYTHON=python3.13
+
+python_SYSINC refers to the directory where Python's Python.h file is
+found.  SPARTA includes this file.
+
+python_SYSLIB refers to the libraries needed to link to from an
+application (SPARTA in this case) to "embed" Python in the
+application.  The Python library itself is listed (-lpython3.13) are
+are several system libraries needed by Python.
+
+python_SYSPATH refers to the path (e.g. -L/usr/local/lib) where the
+Python library can be found.  You may not need this setting if the
+path is already included in your LIBRARY_PATH environment variable.
+
+PYTHON is the name of the python interpreter. It is used for
+installing the SPARTA python module with "make install-python"
+
+-------------------------
+
+Note that the trickiest issue to figure out for inclusion in
+Makefile.sparta is what system libraries are needed by your Python to
+run in embedded mode on your machine.
+
+Here is what this Python doc page says about it:
+
+https://docs.python.org/3/extending/embedding.html#compiling-and-linking-under-unix-like-systems
+
+"It is not necessarily trivial to find the right flags to pass to your
+compiler (and linker) in order to embed the Python interpreter into
+your application, particularly because Python needs to load library
+modules implemented as C dynamic extensions (.so files) linked against
+it.
+
+To find out the required compiler and linker flags, you can execute
+the pythonX.Y-config script which is generated as part of the
+installation process (a python-config script may also be available)."
+
+It then gives examples of how to use the pythonX.Y-config script
+and further instructions for what to do if that doesn't work.

--- a/src/MAKE/Makefile.mpi
+++ b/src/MAKE/Makefile.mpi
@@ -67,9 +67,14 @@ JPG_LIB =
 # build rules and dependencies
 # no need to edit this section
 
-EXTRA_INC = $(SPARTA_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC)
-EXTRA_PATH = $(MPI_PATH) $(FFT_PATH) $(JPG_PATH)
-EXTRA_LIB = $(MPI_LIB) $(FFT_LIB) $(JPG_LIB)
+include Makefile.package.settings
+include Makefile.package
+
+EXTRA_INC = $(SPARTA_INC) $(PKG_INC) $(MPI_INC) $(FFT_INC) $(JPG_INC) $(PKG_SYSINC)
+EXTRA_PATH = $(PKG_PATH) $(MPI_PATH) $(FFT_PATH) $(JPG_PATH) $(PKG_SYSPATH)
+EXTRA_LIB = $(PKG_LIB) $(MPI_LIB) $(FFT_LIB) $(JPG_LIB) $(PKG_SYSLIB)
+EXTRA_CPP_DEPENDS = $(PKG_CPP_DEPENDS)
+EXTRA_LINK_DEPENDS = $(PKG_LINK_DEPENDS)
 
 # Path to src files
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ endif
 
 # Package variables
 
-PACKAGE = fft kokkos
+PACKAGE = fft kokkos python
 
 PACKALL = $(PACKAGE)
 

--- a/src/PYTHON/Install.sh
+++ b/src/PYTHON/Install.sh
@@ -1,0 +1,71 @@
+# Install/unInstall package files in SPPARKS
+# mode = 0/1/2 for uninstall/install/update
+
+mode=$1
+
+# arg1 = file, arg2 = file it depends on
+
+# enforce using portable C locale
+LC_ALL=C
+export LC_ALL
+
+action () {
+  if (test $mode = 0) then
+    rm -f ../$1
+  elif (! cmp -s $1 ../$1) then
+    if (test -z "$2" || test -e ../$2) then
+      cp $1 ..
+      if (test $mode = 2) then
+        echo "  updating src/$1"
+      fi
+    fi
+  elif (test -n "$2") then
+    if (test ! -e ../$2) then
+      rm -f ../$1
+    fi
+  fi
+}
+
+# force rebuild of files using python header
+
+touch ../spapython.h
+
+# all package files with no dependencies
+
+for file in *.cpp *.h; do
+  test -f ${file} && action $file
+done
+
+# edit 2 Makefile.package files to include/exclude package info
+
+if (test $1 = 1) then
+
+  if (test -e ../Makefile.package) then
+    sed -i -e 's/[^ \t]*python[^ \t]* //' ../Makefile.package
+    sed -i -e 's/[^ \t]*PYTHON[^ \t]* //g' ../Makefile.package
+    sed -i -e 's|^PKG_INC =[ \t]*|&-DSPA_PYTHON |' ../Makefile.package
+    sed -i -e 's|^PKG_SYSINC =[ \t]*|&$(python_SYSINC) |' ../Makefile.package
+    sed -i -e 's|^PKG_SYSLIB =[ \t]*|&$(python_SYSLIB) |' ../Makefile.package
+    sed -i -e 's|^PKG_SYSPATH =[ \t]*|&$(python_SYSPATH) |' ../Makefile.package
+  fi
+
+  if (test -e ../Makefile.package.settings) then
+    sed -i -e '/^[ \t]*include.*python.*$/d' ../Makefile.package.settings
+    # multiline form needed for BSD sed on Macs
+    sed -i -e '4 i \
+include ..\/..\/lib\/python\/Makefile.sparta
+' ../Makefile.package.settings
+  fi
+
+elif (test $1 = 0) then
+
+  if (test -e ../Makefile.package) then
+    sed -i -e 's/[^ \t]*python[^ \t]* //' ../Makefile.package
+    sed -i -e 's/[^ \t]*PYTHON[^ \t]* //g' ../Makefile.package
+  fi
+
+  if (test -e ../Makefile.package.settings) then
+    sed -i -e '/^[ \t]*include.*python.*$/d' ../Makefile.package.settings
+  fi
+
+fi

--- a/src/PYTHON/Install.sh
+++ b/src/PYTHON/Install.sh
@@ -1,4 +1,4 @@
-# Install/unInstall package files in SPPARKS
+# Install/unInstall package files in SPPARTA
 # mode = 0/1/2 for uninstall/install/update
 
 mode=$1
@@ -43,7 +43,7 @@ if (test $1 = 1) then
   if (test -e ../Makefile.package) then
     sed -i -e 's/[^ \t]*python[^ \t]* //' ../Makefile.package
     sed -i -e 's/[^ \t]*PYTHON[^ \t]* //g' ../Makefile.package
-    sed -i -e 's|^PKG_INC =[ \t]*|&-DSPA_PYTHON |' ../Makefile.package
+    sed -i -e 's|^PKG_INC =[ \t]*|&-DSPARTA_PYTHON |' ../Makefile.package
     sed -i -e 's|^PKG_SYSINC =[ \t]*|&$(python_SYSINC) |' ../Makefile.package
     sed -i -e 's|^PKG_SYSLIB =[ \t]*|&$(python_SYSLIB) |' ../Makefile.package
     sed -i -e 's|^PKG_SYSPATH =[ \t]*|&$(python_SYSPATH) |' ../Makefile.package

--- a/src/PYTHON/python_compat.h
+++ b/src/PYTHON/python_compat.h
@@ -1,0 +1,35 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_PYTHON_COMPAT_H
+#define SPARTA_PYTHON_COMPAT_H
+
+#include <Python.h>
+
+#if PY_VERSION_HEX < 0x030600f0
+#error Python version 3.6 or later is required by SPARTA
+#endif
+
+// Wrap API differences between platforms using macros
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#define PY_INT_FROM_LONG(X) PyLong_FromLongLong(X)
+#define PY_INT_AS_LONG(X) PyLong_AsLongLong(X)
+#define PY_LONG_FROM_STRING(X) std::stoll(X)
+#else
+#define PY_INT_FROM_LONG(X) PyLong_FromLong(X)
+#define PY_INT_AS_LONG(X) PyLong_AsLong(X)
+#define PY_LONG_FROM_STRING(X) std::stol(X)
+#endif
+
+#endif

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -1,0 +1,562 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Richard Berger (LANL) and Axel Kohlmeyer (Temple U)
+------------------------------------------------------------------------- */
+
+#include "python_impl.h"
+
+#include "error.h"
+#include "input.h"
+#include "memory.h"
+#include "python_compat.h"
+#include "python_utils.h"
+#include "variable.h"
+
+#include <Python.h>    // IWYU pragma: export
+#include <cstring>
+
+using namespace SPARTA_NS;
+
+enum { NONE, INT, DOUBLE, STRING, PTR };
+
+/* ---------------------------------------------------------------------- */
+
+PythonImpl::PythonImpl(SPARTA *spa) : Pointers(spa)
+{
+  // pfuncs stores interface info for each Python function
+
+  nfunc = 0;
+  pfuncs = nullptr;
+
+#if PY_MAJOR_VERSION >= 3 && !defined(Py_LIMITED_API)
+  // check for PYTHONUNBUFFERED environment variable
+  const char *PYTHONUNBUFFERED = getenv("PYTHONUNBUFFERED");
+  // Force the stdout and stderr streams to be unbuffered.
+  bool unbuffered = PYTHONUNBUFFERED != nullptr && strcmp(PYTHONUNBUFFERED, "1") == 0;
+
+#if (PY_VERSION_HEX >= 0x030800f0)
+  PyConfig config;
+  PyConfig_InitPythonConfig(&config);
+  config.buffered_stdio = !unbuffered;
+#else
+  // Python Global configuration variable
+  Py_UnbufferedStdioFlag = unbuffered;
+#endif
+#endif
+
+#ifdef MLIAP_PYTHON
+  // cannot register mliappy module a second time
+  if (!Py_IsInitialized()) {
+    // Inform python intialization scheme of the mliappy module.
+    // This -must- happen before python is initialized.
+    int err = PyImport_AppendInittab("mliap_model_python_couple", PyInit_mliap_model_python_couple);
+    if (err) error->all(FLERR, "Could not register MLIAPPY embedded python module.");
+
+    err = PyImport_AppendInittab("mliap_unified_couple", PyInit_mliap_unified_couple);
+    if (err) error->all(FLERR, "Could not register MLIAPPY unified embedded python module.");
+
+#ifdef SPA_KOKKOS
+    // Inform python intialization scheme of the mliappy module.
+    // This -must- happen before python is initialized.
+    err = PyImport_AppendInittab("mliap_model_python_couple_kokkos",
+                                 PyInit_mliap_model_python_couple_kokkos);
+    if (err) error->all(FLERR, "Could not register MLIAPPY embedded python KOKKOS module.");
+
+    err = PyImport_AppendInittab("mliap_unified_couple_kokkos", PyInit_mliap_unified_couple_kokkos);
+    if (err) error->all(FLERR, "Could not register MLIAPPY unified embedded python KOKKOS module.");
+#endif
+  }
+#endif
+
+#if PY_VERSION_HEX >= 0x030800f0 && !defined(Py_LIMITED_API)
+  Py_InitializeFromConfig(&config);
+  PyConfig_Clear(&config);
+#else
+  Py_Initialize();
+#endif
+
+  // only needed for Python 2.x and Python 3 < 3.7
+  // With Python 3.7 this function is now called by Py_Initialize()
+  // Deprecated since version 3.9, will be removed in version 3.11
+#if PY_VERSION_HEX < 0x030700f0
+  if (!PyEval_ThreadsInitialized()) PyEval_InitThreads();
+#endif
+
+  PyUtils::GIL lock;
+
+  PyObject *pModule = PyImport_AddModule("__main__");
+  if (!pModule) error->all(FLERR, "Could not initialize embedded Python");
+
+  pyMain = (void *) pModule;
+}
+
+/* ---------------------------------------------------------------------- */
+
+PythonImpl::~PythonImpl()
+{
+  if (pyMain) {
+    // clean up
+    PyUtils::GIL lock;
+
+    for (int i = 0; i < nfunc; i++) {
+      delete[] pfuncs[i].name;
+      deallocate(i);
+      Py_CLEAR(pfuncs[i].pFunc);
+    }
+  }
+
+  memory->sfree(pfuncs);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void PythonImpl::command(int narg, char **arg)
+{
+  if (narg < 2) utils::missing_cmd_args(FLERR, "python", error);
+
+  // if invoke is only keyword, invoke the previously defined function
+
+  if (narg == 2 && strcmp(arg[1], "invoke") == 0) {
+    int ifunc = find(arg[0]);
+    if (ifunc < 0) error->all(FLERR, "Python invoke of unknown function: {}", arg[0]);
+
+    char *str = nullptr;
+    if (pfuncs[ifunc].noutput) {
+      str = input->variable->pythonstyle(pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
+      if (!str)
+        error->all(FLERR,
+                   "Python variable {} does not match variable {} "
+                   "registered with Python function {}",
+                   arg[0], pfuncs[ifunc].ovarname, pfuncs[ifunc].name);
+    }
+
+    invoke_function(ifunc, str);
+    return;
+  }
+
+  // if source is only keyword, execute the python code in file
+
+  if ((narg > 1) && (strcmp(arg[0], "source") == 0)) {
+    int err = -1;
+
+    if ((narg > 2) && (strcmp(arg[1], "here") == 0)) {
+      err = execute_string(arg[2]);
+    } else {
+      if (platform::file_is_readable(arg[1]))
+        err = execute_file(arg[1]);
+      else
+        error->all(FLERR, "Could not open python source file {} for processing", arg[1]);
+    }
+    if (err) error->all(FLERR, "Failure in python source command");
+
+    return;
+  }
+
+  // parse optional args, invoke is not allowed in this mode
+
+  int ninput = 0;
+  int noutput = 0;
+  char **istr = nullptr;
+  char *ostr = nullptr;
+  char *format = nullptr;
+  int length_longstr = 0;
+  char *pyfile = nullptr;
+  char *herestr = nullptr;
+  int existflag = 0;
+
+  int iarg = 1;
+  while (iarg < narg) {
+    if (strcmp(arg[iarg], "input") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python input", error);
+      ninput = utils::inumeric(FLERR, arg[iarg + 1], false, spa);
+      if (ninput < 0) error->all(FLERR, "Invalid number of python input arguments: {}", ninput);
+      iarg += 2;
+      delete[] istr;
+      istr = new char *[ninput];
+      if (iarg + ninput > narg) utils::missing_cmd_args(FLERR, "python input", error);
+      for (int i = 0; i < ninput; i++) istr[i] = arg[iarg + i];
+      iarg += ninput;
+    } else if (strcmp(arg[iarg], "return") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python return", error);
+      noutput = 1;
+      ostr = arg[iarg + 1];
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "format") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python format", error);
+      format = utils::strdup(arg[iarg + 1]);
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "length") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python length", error);
+      length_longstr = utils::inumeric(FLERR, arg[iarg + 1], false, spa);
+      if (length_longstr <= 0) error->all(FLERR, "Invalid python return value length");
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "file") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python file", error);
+      delete[] pyfile;
+      pyfile = utils::strdup(arg[iarg + 1]);
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "here") == 0) {
+      if (iarg + 2 > narg) utils::missing_cmd_args(FLERR, "python here", error);
+      herestr = arg[iarg + 1];
+      iarg += 2;
+    } else if (strcmp(arg[iarg], "exists") == 0) {
+      existflag = 1;
+      iarg++;
+    } else
+      error->all(FLERR, "Unknown python command keyword: {}", arg[iarg]);
+  }
+
+  if (pyfile && herestr)
+    error->all(FLERR, "Must not use python 'file' and 'here' keywords at the same time");
+  if (pyfile && existflag)
+    error->all(FLERR, "Must not use python 'file' and 'exists' keywords at the same time");
+  if (herestr && existflag)
+    error->all(FLERR, "Must not use python 'here' and 'exists' keywords at the same time");
+
+  // create or overwrite entry in pfuncs vector with name = arg[0]
+
+  int ifunc = create_entry(arg[0], ninput, noutput, length_longstr, istr, ostr, format);
+
+  PyUtils::GIL lock;
+
+  // send Python code to Python interpreter
+  // file: read the file via PyRun_SimpleFile()
+  // here: process the here string directly
+  // exist: do nothing, assume code has already been run
+
+  if (pyfile) {
+    FILE *fp = fopen(pyfile, "r");
+
+    if (fp == nullptr) {
+      PyUtils::Print_Errors();
+      error->all(FLERR, "Could not open Python file: {}", pyfile);
+    }
+
+    int err = PyRun_SimpleFile(fp, pyfile);
+    if (err) {
+      PyUtils::Print_Errors();
+      error->all(FLERR, "Could not process Python file: {}", pyfile);
+    }
+    fclose(fp);
+
+  } else if (herestr) {
+    int err = PyRun_SimpleString(herestr);
+    if (err) {
+      PyUtils::Print_Errors();
+      error->all(FLERR, "Could not process Python string: {}", herestr);
+    }
+  }
+
+  // pFunc = function object for requested function
+
+  auto pModule = (PyObject *) pyMain;
+  PyObject *pFunc = PyObject_GetAttrString(pModule, pfuncs[ifunc].name);
+
+  if (!pFunc) {
+    PyUtils::Print_Errors();
+    error->all(FLERR, "Could not find Python function {}", pfuncs[ifunc].name);
+  }
+
+  if (!PyCallable_Check(pFunc)) {
+    PyUtils::Print_Errors();
+    error->all(FLERR, "Python function {} is not callable", pfuncs[ifunc].name);
+  }
+
+  pfuncs[ifunc].pFunc = (void *) pFunc;
+
+  // clean-up input storage
+
+  delete[] istr;
+  delete[] format;
+  delete[] pyfile;
+}
+
+/* ------------------------------------------------------------------ */
+
+void PythonImpl::invoke_function(int ifunc, char *result)
+{
+  PyUtils::GIL lock;
+  PyObject *pValue;
+  char *str;
+
+  auto pFunc = (PyObject *) pfuncs[ifunc].pFunc;
+
+  // create Python tuple of input arguments
+
+  int ninput = pfuncs[ifunc].ninput;
+  PyObject *pArgs = PyTuple_New(ninput);
+
+  if (!pArgs)
+    error->all(FLERR, "Could not prepare arguments for Python function {}", pfuncs[ifunc].name);
+
+  for (int i = 0; i < ninput; i++) {
+    int itype = pfuncs[ifunc].itype[i];
+    if (itype == INT) {
+      if (pfuncs[ifunc].ivarflag[i]) {
+        str = input->variable->retrieve(pfuncs[ifunc].svalue[i]);
+        if (!str)
+          error->all(FLERR, "Could not evaluate Python function {} input variable: {}",
+                     pfuncs[ifunc].name, pfuncs[ifunc].svalue[i]);
+        pValue = PY_INT_FROM_LONG(PY_LONG_FROM_STRING(str));
+      } else {
+        pValue = PY_INT_FROM_LONG(pfuncs[ifunc].ivalue[i]);
+      }
+    } else if (itype == DOUBLE) {
+      if (pfuncs[ifunc].ivarflag[i]) {
+        str = input->variable->retrieve(pfuncs[ifunc].svalue[i]);
+        if (!str)
+          error->all(FLERR, "Could not evaluate Python function {} input variable: {}",
+                     pfuncs[ifunc].name, pfuncs[ifunc].svalue[i]);
+        pValue = PyFloat_FromDouble(std::stod(str));
+      } else {
+        pValue = PyFloat_FromDouble(pfuncs[ifunc].dvalue[i]);
+      }
+    } else if (itype == STRING) {
+      if (pfuncs[ifunc].ivarflag[i]) {
+        str = input->variable->retrieve(pfuncs[ifunc].svalue[i]);
+        if (!str)
+          error->all(FLERR, "Could not evaluate Python function {} input variable: {}",
+                     pfuncs[ifunc].name, pfuncs[ifunc].svalue[i]);
+        pValue = PyUnicode_FromString(str);
+      } else {
+        pValue = PyUnicode_FromString(pfuncs[ifunc].svalue[i]);
+      }
+    } else if (itype == PTR) {
+      pValue = PyCapsule_New((void *)spa, nullptr, nullptr);
+    } else {
+      error->all(FLERR, "Unsupported variable type: {}", itype);
+    }
+    PyTuple_SetItem(pArgs, i, pValue);
+  }
+
+  // call the Python function
+  // error check with one() since only some procs may fail
+
+  pValue = PyObject_CallObject(pFunc, pArgs);
+  Py_CLEAR(pArgs);
+
+  if (!pValue) {
+    PyUtils::Print_Errors();
+    error->one(FLERR, "Python evaluation of function {} failed", pfuncs[ifunc].name);
+  }
+
+  // function returned a value
+  // assign it to result string stored by python-style variable
+  // or if user specified a length, assign it to longstr
+
+  if (pfuncs[ifunc].noutput) {
+    int otype = pfuncs[ifunc].otype;
+    if (otype == INT) {
+      auto value = fmt::format("{}", PY_INT_AS_LONG(pValue));
+      strncpy(result, value.c_str(), Variable::VALUELENGTH - 1);
+    } else if (otype == DOUBLE) {
+      auto value = fmt::format("{:.15g}", PyFloat_AsDouble(pValue));
+      strncpy(result, value.c_str(), Variable::VALUELENGTH - 1);
+    } else if (otype == STRING) {
+      const char *pystr = PyUnicode_AsUTF8(pValue);
+      if (pfuncs[ifunc].longstr)
+        strncpy(pfuncs[ifunc].longstr, pystr, pfuncs[ifunc].length_longstr);
+      else
+        strncpy(result, pystr, Variable::VALUELENGTH - 1);
+    }
+  }
+  Py_CLEAR(pValue);
+}
+
+/* ------------------------------------------------------------------ */
+
+int PythonImpl::find(const char *name)
+{
+  for (int i = 0; i < nfunc; i++)
+    if (strcmp(name, pfuncs[i].name) == 0) return i;
+  return -1;
+}
+
+/* ------------------------------------------------------------------ */
+
+int PythonImpl::variable_match(const char *name, const char *varname, int numeric)
+{
+  int ifunc = find(name);
+  if (ifunc < 0) return -1;
+  if (pfuncs[ifunc].noutput == 0) return -2;
+  if (strcmp(pfuncs[ifunc].ovarname, varname) != 0) return -3;
+  if (numeric && pfuncs[ifunc].otype == STRING) return -4;
+  return ifunc;
+}
+
+/* ------------------------------------------------------------------ */
+
+char *PythonImpl::long_string(int ifunc)
+{
+  return pfuncs[ifunc].longstr;
+}
+
+/* ------------------------------------------------------------------ */
+
+int PythonImpl::create_entry(char *name, int ninput, int noutput, int length_longstr, char **istr,
+                             char *ostr, char *format)
+{
+  // ifunc = index to entry by name in pfuncs vector, can be old or new
+  // free old vectors if overwriting old pfunc
+
+  int ifunc = find(name);
+
+  if (ifunc < 0) {
+    ifunc = nfunc;
+    nfunc++;
+    pfuncs = (PyFunc *) memory->srealloc(pfuncs, nfunc * sizeof(struct PyFunc), "python:pfuncs");
+    pfuncs[ifunc].name = utils::strdup(name);
+  } else
+    deallocate(ifunc);
+
+  pfuncs[ifunc].ninput = ninput;
+  pfuncs[ifunc].noutput = noutput;
+
+  if (!format && ninput + noutput)
+    error->all(FLERR, "Missing python format keyword");
+  else if (format && ((int) strlen(format) != ninput + noutput))
+    error->all(FLERR, "Input/output arguments ({}) and format characters ({}) are inconsistent",
+               (ninput + noutput), strlen(format));
+
+  // process inputs as values or variables
+
+  pfuncs[ifunc].itype = new int[ninput];
+  pfuncs[ifunc].ivarflag = new int[ninput];
+  pfuncs[ifunc].ivalue = new int[ninput];
+  pfuncs[ifunc].dvalue = new double[ninput];
+  pfuncs[ifunc].svalue = new char *[ninput];
+
+  for (int i = 0; i < ninput; i++) {
+    pfuncs[ifunc].svalue[i] = nullptr;
+    char type = format[i];
+    if (type == 'i') {
+      pfuncs[ifunc].itype[i] = INT;
+      if (utils::strmatch(istr[i], "^v_")) {
+        pfuncs[ifunc].ivarflag[i] = 1;
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i] + 2);
+      } else {
+        pfuncs[ifunc].ivarflag[i] = 0;
+        pfuncs[ifunc].ivalue[i] = utils::inumeric(FLERR, istr[i], false, spa);
+      }
+    } else if (type == 'f') {
+      pfuncs[ifunc].itype[i] = DOUBLE;
+      if (utils::strmatch(istr[i], "^v_")) {
+        pfuncs[ifunc].ivarflag[i] = 1;
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i] + 2);
+      } else {
+        pfuncs[ifunc].ivarflag[i] = 0;
+        pfuncs[ifunc].dvalue[i] = utils::numeric(FLERR, istr[i], false, spa);
+      }
+    } else if (type == 's') {
+      pfuncs[ifunc].itype[i] = STRING;
+      if (utils::strmatch(istr[i], "^v_")) {
+        pfuncs[ifunc].ivarflag[i] = 1;
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i] + 2);
+      } else {
+        pfuncs[ifunc].ivarflag[i] = 0;
+        pfuncs[ifunc].svalue[i] = utils::strdup(istr[i]);
+      }
+    } else if (type == 'p') {
+      pfuncs[ifunc].ivarflag[i] = 0;
+      pfuncs[ifunc].itype[i] = PTR;
+      if (strcmp(istr[i], "SELF") != 0) error->all(FLERR, "Invalid python command");
+
+    } else
+      error->all(FLERR, "Invalid python format character: {}", type);
+  }
+
+  // process output as value or variable
+
+  pfuncs[ifunc].ovarname = nullptr;
+  pfuncs[ifunc].longstr = nullptr;
+  if (!noutput) return ifunc;
+
+  char type = format[ninput];
+  if (type == 'i')
+    pfuncs[ifunc].otype = INT;
+  else if (type == 'f')
+    pfuncs[ifunc].otype = DOUBLE;
+  else if (type == 's')
+    pfuncs[ifunc].otype = STRING;
+  else
+    error->all(FLERR, "Invalid python return format character: {}", type);
+
+  if (length_longstr) {
+    if (pfuncs[ifunc].otype != STRING)
+      error->all(FLERR, "Python command length keyword cannot be used unless output is a string");
+    pfuncs[ifunc].length_longstr = length_longstr;
+    pfuncs[ifunc].longstr = new char[length_longstr + 1];
+    pfuncs[ifunc].longstr[length_longstr] = '\0';
+  }
+
+  if (strstr(ostr, "v_") != ostr) error->all(FLERR, "Invalid python command");
+  pfuncs[ifunc].ovarname = utils::strdup(ostr + 2);
+
+  return ifunc;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int PythonImpl::execute_string(char *cmd)
+{
+  PyUtils::GIL lock;
+  int err = PyRun_SimpleString(cmd);
+  if (err) PyUtils::Print_Errors();
+  return err;
+}
+
+/* ---------------------------------------------------------------------- */
+
+int PythonImpl::execute_file(char *fname)
+{
+  FILE *fp = fopen(fname, "r");
+  if (fp == nullptr) return -1;
+
+  PyUtils::GIL lock;
+  int err = PyRun_SimpleFile(fp, fname);
+  if (err) PyUtils::Print_Errors();
+
+  if (fp) fclose(fp);
+  return err;
+}
+
+/* ------------------------------------------------------------------ */
+
+void PythonImpl::deallocate(int i)
+{
+  delete[] pfuncs[i].itype;
+  delete[] pfuncs[i].ivarflag;
+  delete[] pfuncs[i].ivalue;
+  delete[] pfuncs[i].dvalue;
+  for (int j = 0; j < pfuncs[i].ninput; j++) delete[] pfuncs[i].svalue[j];
+  delete[] pfuncs[i].svalue;
+  delete[] pfuncs[i].ovarname;
+  delete[] pfuncs[i].longstr;
+}
+
+/* ------------------------------------------------------------------ */
+
+bool PythonImpl::has_minimum_version(int major, int minor)
+{
+  return (PY_MAJOR_VERSION == major && PY_MINOR_VERSION >= minor) || (PY_MAJOR_VERSION > major);
+}
+
+/* ------------------------------------------------------------------ */
+
+void PythonImpl::finalize()
+{
+  if (Py_IsInitialized()) Py_Finalize();
+}

--- a/src/PYTHON/python_impl.cpp
+++ b/src/PYTHON/python_impl.cpp
@@ -57,30 +57,6 @@ PythonImpl::PythonImpl(SPARTA *spa) : Pointers(spa)
 #endif
 #endif
 
-#ifdef MLIAP_PYTHON
-  // cannot register mliappy module a second time
-  if (!Py_IsInitialized()) {
-    // Inform python intialization scheme of the mliappy module.
-    // This -must- happen before python is initialized.
-    int err = PyImport_AppendInittab("mliap_model_python_couple", PyInit_mliap_model_python_couple);
-    if (err) error->all(FLERR, "Could not register MLIAPPY embedded python module.");
-
-    err = PyImport_AppendInittab("mliap_unified_couple", PyInit_mliap_unified_couple);
-    if (err) error->all(FLERR, "Could not register MLIAPPY unified embedded python module.");
-
-#ifdef SPA_KOKKOS
-    // Inform python intialization scheme of the mliappy module.
-    // This -must- happen before python is initialized.
-    err = PyImport_AppendInittab("mliap_model_python_couple_kokkos",
-                                 PyInit_mliap_model_python_couple_kokkos);
-    if (err) error->all(FLERR, "Could not register MLIAPPY embedded python KOKKOS module.");
-
-    err = PyImport_AppendInittab("mliap_unified_couple_kokkos", PyInit_mliap_unified_couple_kokkos);
-    if (err) error->all(FLERR, "Could not register MLIAPPY unified embedded python KOKKOS module.");
-#endif
-  }
-#endif
-
 #if PY_VERSION_HEX >= 0x030800f0 && !defined(Py_LIMITED_API)
   Py_InitializeFromConfig(&config);
   PyConfig_Clear(&config);

--- a/src/PYTHON/python_impl.h
+++ b/src/PYTHON/python_impl.h
@@ -23,7 +23,7 @@ namespace SPARTA_NS {
 class PythonImpl : protected Pointers, public PythonInterface {
 
  public:
-  PythonImpl(class LAMMPS *);
+  PythonImpl(class SPARTA *);
   ~PythonImpl() override;
   void command(int, char **) override;
   void invoke_function(int, char *) override;

--- a/src/PYTHON/python_impl.h
+++ b/src/PYTHON/python_impl.h
@@ -1,0 +1,64 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_PYTHON_IMPL_H
+#define SPARTA_PYTHON_IMPL_H
+
+#include "spapython.h"
+#include "pointers.h"
+
+namespace SPARTA_NS {
+
+class PythonImpl : protected Pointers, public PythonInterface {
+
+ public:
+  PythonImpl(class LAMMPS *);
+  ~PythonImpl() override;
+  void command(int, char **) override;
+  void invoke_function(int, char *) override;
+  int find(const char *) override;
+  int variable_match(const char *, const char *, int) override;
+  char *long_string(int) override;
+  int execute_string(char *) override;
+  int execute_file(char *) override;
+  bool has_minimum_version(int major, int minor) override;
+  static void finalize();
+
+ private:
+  void *pyMain;
+
+  struct PyFunc {
+    char *name;
+    int ninput, noutput;
+    int *itype, *ivarflag;
+    int *ivalue;
+    double *dvalue;
+    char **svalue;
+    int otype;
+    char *ovarname;
+    char *longstr;
+    int length_longstr;
+    void *pFunc;
+  };
+
+  PyFunc *pfuncs;
+  int nfunc;
+
+  int create_entry(char *, int, int, int, char **, char *, char *);
+  void deallocate(int);
+};
+
+}
+
+#endif

--- a/src/PYTHON/python_utils.h
+++ b/src/PYTHON/python_utils.h
@@ -1,0 +1,42 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_PYTHON_UTILS_H
+#define SPARTA_PYTHON_UTILS_H
+
+#include <Python.h>
+
+namespace SPARTA_NS {
+
+namespace PyUtils {
+
+  class GIL {
+    PyGILState_STATE gstate;
+
+   public:
+    GIL() : gstate(PyGILState_Ensure()) {}
+    ~GIL() { PyGILState_Release(gstate); }
+  };
+
+  static void Print_Errors()
+  {
+    PyErr_Print();
+    PyErr_Clear();
+  }
+
+}
+
+}
+
+#endif

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -714,6 +714,7 @@ int Input::execute_command()
   else if (!strcmp(command,"next")) next_command();
   else if (!strcmp(command,"partition")) partition();
   else if (!strcmp(command,"print")) print();
+  else if (!strcmp(command,"python")) python();
   else if (!strcmp(command,"quit")) quit();
   else if (!strcmp(command,"shell")) shell();
   else if (!strcmp(command,"variable")) variable_command();
@@ -1139,6 +1140,13 @@ void Input::print()
       fclose(fp);
     }
   }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Input::python()
+{
+  variable->python_command(narg,arg);
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/input.h
+++ b/src/input.h
@@ -72,6 +72,7 @@ class Input : protected Pointers {
   void next_command();
   void partition();
   void print();
+  void python();
   void quit();
   void shell();
   void variable_command();

--- a/src/pointers.h
+++ b/src/pointers.h
@@ -62,6 +62,7 @@ class Pointers {
     react(ptr->react),
     output(ptr->output),
     timer(ptr->timer),
+    python(ptr->python),
     memoryKK(ptr->memoryKK),
     world(ptr->world),
     infile(ptr->infile),
@@ -89,7 +90,8 @@ class Pointers {
   Output *&output;
   Timer *&timer;
 
-  MemoryKokkos *&memoryKK;
+  class Python *&python;
+  class MemoryKokkos *&memoryKK;
 
   MPI_Comm &world;
   FILE *&infile;

--- a/src/spapython.cpp
+++ b/src/spapython.cpp
@@ -1,0 +1,132 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "spapython.h"
+#if defined(SPARTA_PYTHON)
+#include "python_impl.h"
+#else
+#include "error.h"
+#endif
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+Python::Python(SPARTA *sparta) : Pointers(sparta)
+{
+  // implementation of Python interface is only loaded on demand
+  // and only if PYTHON package has been installed and compiled into binary
+  impl = nullptr;
+}
+
+/* ---------------------------------------------------------------------- */
+
+Python::~Python()
+{
+  delete impl;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Python::init()
+{
+#if defined(SPARTA_PYTHON)
+  if (!impl) impl = new PythonImpl(sparta);
+#else
+  error->all(FLERR, "Python support missing! Compile with PYTHON package installed!");
+#endif
+}
+
+/* ---------------------------------------------------------------------- */
+bool Python::is_enabled() const
+{
+#if defined(SPARTA_PYTHON)
+  return true;
+#else
+  return false;
+#endif
+}
+
+/* ---------------------------------------------------------------------- */
+
+void Python::command(int narg, char **arg)
+{
+  init();
+  impl->command(narg, arg);
+}
+
+/* ------------------------------------------------------------------ */
+
+void Python::invoke_function(int ifunc, char *result)
+{
+  init();
+  impl->invoke_function(ifunc, result);
+}
+
+/* ------------------------------------------------------------------ */
+
+int Python::find(const char *name)
+{
+  init();
+  return impl->find(name);
+}
+
+/* ------------------------------------------------------------------ */
+
+int Python::variable_match(const char *name, const char *varname, int numeric)
+{
+  init();
+  return impl->variable_match(name, varname, numeric);
+}
+
+/* ------------------------------------------------------------------ */
+
+char *Python::long_string(int ifunc)
+{
+  init();
+  return impl->long_string(ifunc);
+}
+
+/* ------------------------------------------------------------------ */
+
+int Python::execute_string(char *cmd)
+{
+  init();
+  return impl->execute_string(cmd);
+}
+
+/* ------------------------------------------------------------------ */
+
+int Python::execute_file(char *fname)
+{
+  init();
+  return impl->execute_file(fname);
+}
+
+/* ------------------------------------------------------------------ */
+
+bool Python::has_minimum_version(int major, int minor)
+{
+  init();
+  return impl->has_minimum_version(major, minor);
+}
+
+/* ------------------------------------------------------------------ */
+
+void Python::finalize()
+{
+#if defined(SPARTA_PYTHON)
+  PythonImpl::finalize();
+#endif
+}

--- a/src/spapython.h
+++ b/src/spapython.h
@@ -34,7 +34,7 @@ class PythonInterface {
 
 class Python : protected Pointers {
  public:
-  Python(class LAMMPS *);
+  Python(class SPARTA *);
   ~Python() override;
 
   void command(int, char **);

--- a/src/spapython.h
+++ b/src/spapython.h
@@ -1,0 +1,59 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_PYTHON_H
+#define SPARTA_PYTHON_H
+
+#include "pointers.h"
+
+namespace SPARTA_NS {
+
+class PythonInterface {
+ public:
+  virtual ~PythonInterface() noexcept(false) {}
+  virtual void command(int, char **) = 0;
+  virtual void invoke_function(int, char *) = 0;
+  virtual int find(const char *) = 0;
+  virtual int variable_match(const char *, const char *, int) = 0;
+  virtual char *long_string(int ifunc) = 0;
+  virtual int execute_string(char *) = 0;
+  virtual int execute_file(char *) = 0;
+  virtual bool has_minimum_version(int major, int minor) = 0;
+};
+
+class Python : protected Pointers {
+ public:
+  Python(class LAMMPS *);
+  ~Python() override;
+
+  void command(int, char **);
+  void invoke_function(int, char *);
+  int find(const char *);
+  int variable_match(const char *, const char *, int);
+  char *long_string(int ifunc);
+  int execute_string(char *);
+  int execute_file(char *);
+  bool has_minimum_version(int major, int minor);
+
+  bool is_enabled() const;
+  void init();
+  static void finalize();
+
+ private:
+  PythonInterface *impl;
+};
+
+}
+
+#endif

--- a/src/sparta.cpp
+++ b/src/sparta.cpp
@@ -29,6 +29,7 @@
 #include "collide.h"
 #include "react.h"
 #include "output.h"
+#include "spapython.h"
 #include "accelerator_kokkos.h"
 #include "timer.h"
 #include "memory.h"
@@ -448,6 +449,7 @@ SPARTA::~SPARTA()
 
   if (world != universe->uworld) MPI_Comm_free(&world);
 
+  delete python;
   delete kokkos;
   delete [] suffix;
 
@@ -486,6 +488,8 @@ void SPARTA::create()
   collide = NULL;
   react = NULL;
 
+  python = new Python(this);
+    
   if (kokkos) modify = new ModifyKokkos(this);
   else modify = new Modify(this);
 
@@ -571,6 +575,7 @@ void SPARTA::destroy()
   delete react;
   delete output;
   delete timer;
+  delete python;
 }
 
 /* ----------------------------------------------------------------------

--- a/src/sparta.h
+++ b/src/sparta.h
@@ -22,7 +22,7 @@ namespace SPARTA_NS {
 class SPARTA {
  public:
 
-  // fundamental SPARTA classes
+  // ptrs to fundamental SPARTA classes
 
   class Memory *memory;          // memory allocation functions
   class Error *error;            // error handling
@@ -41,6 +41,10 @@ class SPARTA {
   class Output *output;          // stats/dump/restart
   class Timer *timer;            // CPU timing info
 
+  class KokkosSPARTA *kokkos;    // KOKKOS accelerator class
+  class MemoryKokkos *memoryKK;  // KOKKOS version of Memory class
+  class Python *python;          // Python interface
+
   MPI_Comm world;                // MPI communicator
   FILE *infile;                  // infile
   FILE *screen;                  // screen output
@@ -50,9 +54,6 @@ class SPARTA {
   int suffix_enable;             // 1 if suffixes are enabled, 0 if disabled
   char ***packargs;              // arguments for cmdline package commands
   int num_package;               // number of cmdline package commands
-
-  class KokkosSPARTA *kokkos;    // KOKKOS accelerator class
-  class MemoryKokkos *memoryKK;  // KOKKOS version of Memory class
 
   // other top-level SPARTA classes and variables
 

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -32,6 +32,7 @@
 #include "surf_react.h"
 #include "input.h"
 #include "output.h"
+#include "spapython.h"
 #include "stats.h"
 #include "random_mars.h"
 #include "random_knuth.h"
@@ -903,6 +904,18 @@ int Variable::find(char *name)
   for (int i = 0; i < nvar; i++)
     if (strcmp(name,names[i]) == 0) return i;
   return -1;
+}
+
+/* ----------------------------------------------------------------------
+   called by python command in input script
+   simply pass input script line args to Python class
+------------------------------------------------------------------------- */
+
+void Variable::python_command(int narg, char **arg)
+{
+  if (!python->is_enabled())
+    error->all(FLERR,"SPARTA is not built with Python embedded");
+  python->command(narg,arg);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -47,7 +47,6 @@ using namespace MathConst;
 #define MAXLEVEL 4
 #define MAXLINE 256
 #define CHUNK 1024
-#define VALUELENGTH 64
 
 #define MYROUND(a) (( a-floor(a) ) >= .5) ? ceil(a) : floor(a)
 
@@ -956,6 +955,22 @@ int Variable::surf_style(int ivar)
 {
   if (style[ivar] == SURF) return 1;
   return 0;
+}
+
+/* ----------------------------------------------------------------------
+   check if variable with name is PYTHON and matches funcname
+   called by Python class before it invokes a Python function
+   return data storage so Python function can return a value for this variable
+   return nullptr if not a match
+------------------------------------------------------------------------- */
+
+char *Variable::python_style(char *name, char *funcname)
+{
+  int ivar = find(name);
+  if (ivar < 0) return nullptr;
+  if (style[ivar] != PYTHON) return nullptr;
+  if (strcmp(data[ivar][0],funcname) != 0) return nullptr;
+  return data[ivar][1];
 }
 
 /* ----------------------------------------------------------------------

--- a/src/variable.h
+++ b/src/variable.h
@@ -22,6 +22,8 @@ namespace SPARTA_NS {
 
 class Variable : protected Pointers {
  public:
+  static constexpr int VALUELENGTH = 64;
+
   Variable(class SPARTA *);
   ~Variable();
   void set(int, char **);
@@ -35,6 +37,7 @@ class Variable : protected Pointers {
   int particle_style(int);
   int grid_style(int);
   int surf_style(int);
+  char *python_style(char *, char *);
   int internal_style(int);
 
   char *retrieve(char *);

--- a/src/variable.h
+++ b/src/variable.h
@@ -29,6 +29,8 @@ class Variable : protected Pointers {
   int next(int, char **);
   int find(char *);
 
+  void python_command(int, char **);
+
   int equal_style(int);
   int particle_style(int);
   int grid_style(int);


### PR DESCRIPTION
## Purpose

Add Python support to SPARTA via the following new features which enable Python code to be invoked directly by input script commands via SPARTA variables.

(a) new "python-style" variables
(b) a new "python" command which hooks a python-style variable to a Python-coded function.  The Python code can be included in the input script, or in a separate Python file.  The "python" command specifies how the Python function arguments and return value are formatted and coupled to the input script
(c) ability to invoke (a,b) from an equal-style or grid-style variable 

## Author(s)

Steve, but a good chunk of this PR, including the Python invocation code was taken from LAMMPS, where it was written by Axel Kohlmeyer (Temple U) and Richard Berger (LANL).

## Backward Compatibility

N/A

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


