### PR TITLE
sparta benchpark support 

### DIFF
--- a/cmake/Modules/DetectHIPInstallation.cmake
+++ b/cmake/Modules/DetectHIPInstallation.cmake
@@ -1,0 +1,8 @@
+if(NOT DEFINED ROCM_PATH)
+    if(NOT DEFINED ENV{ROCM_PATH})
+        set(ROCM_PATH "/opt/rocm" CACHE PATH "Path to ROCm installation")
+    else()
+        set(ROCM_PATH $ENV{ROCM_PATH} CACHE PATH "Path to ROCm installation")
+    endif()
+endif()
+list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH})

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -97,6 +97,9 @@ if(PKG_FFT)
     endif()
 
     string(TOUPPER ${FFT_KOKKOS} FFT_KOKKOS)
+    if(USE_EXTERNAL_KOKKOS)
+      find_package(Kokkos REQUIRED CONFIG)
+    endif()
 
     if(FFT_KOKKOS STREQUAL "CUFFT" AND NOT Kokkos_ENABLE_CUDA)
       message(FATAL_ERROR  "FFT_KOKKOS: ${FFT_KOKKOS} requires Kokkos_ENABLE_CUDA: ON.")
@@ -207,7 +210,12 @@ if(BUILD_KOKKOS)
   # The 2 lines below find an install version of Kokkos. We are using and
   # in-tree copy of kokkos in sparta for now. find_package(KOKKOS REQUIRED)
   # set(TARGET_SPARTA_BUILD_KOKKOS Kokkos::kokkos)
-  set(TARGET_SPARTA_BUILD_KOKKOS kokkos)
+  if(USE_EXTERNAL_KOKKOS)
+    find_package(Kokkos REQUIRED CONFIG)
+    set(TARGET_SPARTA_BUILD_KOKKOS Kokkos::kokkos)
+  else()
+    set(TARGET_SPARTA_BUILD_KOKKOS kokkos)
+  endif()
   list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_KOKKOS})
   # BUILD_KOKKOS does not depend on PKG_KOKKOS, do not attempt to resolve
   # dependency

--- a/cmake/common/set/sparta_options.cmake
+++ b/cmake/common/set/sparta_options.cmake
@@ -40,6 +40,8 @@ sparta_option(
 sparta_option(BUILD_KOKKOS "Enable or disable KOKKOS TPL. Default: OFF." OFF
               SPARTA_BUILD_TPL_LIST)
 
+option(USE_EXTERNAL_KOKKOS "Use an external KOKKOS build. Default: OFF." OFF)
+
 sparta_option(BUILD_JPEG "Enable or disable JPEG TPL. Default: OFF." OFF
               SPARTA_BUILD_TPL_LIST)
 

--- a/src/KOKKOS/CMakeLists.txt
+++ b/src/KOKKOS/CMakeLists.txt
@@ -38,27 +38,33 @@ if(PKG_KOKKOS)
   ########################################################################
 
   if(BUILD_KOKKOS)
-    include(${SPARTA_CMAKE_COMMON_DIR}/set/kokkos_cmake_defaults.cmake)
+    if(USE_EXTERNAL_KOKKOS)
+      find_package(Kokkos REQUIRED CONFIG)
+      set(TARGET_SPARTA_BUILD_KOKKOS Kokkos::kokkos)
+      get_target_property(Kokkos_INCLUDE_DIRS_RET ${TARGET_SPARTA_BUILD_KOKKOS} INTERFACE_INCLUDE_DIRECTORIES)
+    else()
+      include(${SPARTA_CMAKE_COMMON_DIR}/set/kokkos_cmake_defaults.cmake)
 
-    # message(VERBOSE "Checking Kokkos_ENABLE_CUDA: ${Kokkos_ENABLE_CUDA}")
-    if(Kokkos_ENABLE_CUDA)
-      set(ENV{MPICH_CXX} ${SPARTA_TPL_DIR}/kokkos/bin/nvcc_wrapper)
-      set(ENV{OMPI_CXX} $ENV{MPICH_CXX})
-      # message(VERBOSE "MPICH_CXX: $ENV{MPICH_CXX}") message(VERBOSE "OMPI_CXX:
-      # $ENV{OMPI_CXX}")
+      # message(VERBOSE "Checking Kokkos_ENABLE_CUDA: ${Kokkos_ENABLE_CUDA}")
+      if(Kokkos_ENABLE_CUDA)
+        set(ENV{MPICH_CXX} ${SPARTA_TPL_DIR}/kokkos/bin/nvcc_wrapper)
+        set(ENV{OMPI_CXX} $ENV{MPICH_CXX})
+        # message(VERBOSE "MPICH_CXX: $ENV{MPICH_CXX}") message(VERBOSE "OMPI_CXX:
+        # $ENV{OMPI_CXX}")
+      endif()
+
+      add_subdirectory(${SPARTA_TPL_DIR}/kokkos
+                       ${CMAKE_CURRENT_BINARY_DIR}/lib/kokkos)
+
+      # message(VERBOSE "Kokkos_INCLUDE_DIRS_RET: ${Kokkos_INCLUDE_DIRS_RET}")
+      # message(VERBOSE "TARGET_SPARTA_BUILD_KOKKOS:
+      # ${TARGET_SPARTA_BUILD_KOKKOS}")
+      get_target_property(
+        TARGET_SPARTA_BUILD_KOKKOS_INCLUDE_DIRECTORUES
+        ${TARGET_SPARTA_BUILD_KOKKOS} INTERFACE_INCLUDE_DIRECTORIES)
+      # message(VERBOSE "TARGET_SPARTA_BUILD_KOKKOS_INCLUDE_DIRECTORUES:
+      # ${TARGET_SPARTA_BUILD_KOKKOS_INCLUDE_DIRECTORUES}")
     endif()
-
-    add_subdirectory(${SPARTA_TPL_DIR}/kokkos
-                     ${CMAKE_CURRENT_BINARY_DIR}/lib/kokkos)
-
-    # message(VERBOSE "Kokkos_INCLUDE_DIRS_RET: ${Kokkos_INCLUDE_DIRS_RET}")
-    # message(VERBOSE "TARGET_SPARTA_BUILD_KOKKOS:
-    # ${TARGET_SPARTA_BUILD_KOKKOS}")
-    get_target_property(
-      TARGET_SPARTA_BUILD_KOKKOS_INCLUDE_DIRECTORUES
-      ${TARGET_SPARTA_BUILD_KOKKOS} INTERFACE_INCLUDE_DIRECTORIES)
-    # message(VERBOSE "TARGET_SPARTA_BUILD_KOKKOS_INCLUDE_DIRECTORUES:
-    # ${TARGET_SPARTA_BUILD_KOKKOS_INCLUDE_DIRECTORUES}")
   endif()
 
   file(
@@ -92,6 +98,9 @@ if(PKG_KOKKOS)
                              PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
   target_include_directories(${TARGET_SPARTA_PKG_KOKKOS} SYSTEM
                              PUBLIC ${Kokkos_INCLUDE_DIRS_RET})
+
+  message(VERBOSE "Kokkos_INCLUDE_DIRS_RET: ${Kokkos_INCLUDE_DIRS_RET}")  
+  message(VERBOSE "TARGET_SPARTA_PKG_KOKKOS: ${TARGET_SPARTA_PKG_KOKKOS}")  
 
   # Add include dependencies for building TARGET_SPARTA_PKG_KOKKOS
   target_include_directories(${TARGET_SPARTA_PKG_KOKKOS}

--- a/src/KOKKOS/kokkos_type.h
+++ b/src/KOKKOS/kokkos_type.h
@@ -732,7 +732,7 @@ void buffer_view(BufferView &buf, DualView &view,
                  const size_t n7 = 0) {
 
   buf = BufferView(
-          view.template d_view.data(),
+          view.d_view.data(),
           n0,n1,n2,n3,n4,n5,n6,n7);
 
 }


### PR DESCRIPTION
## Purpose
This PR modifies sparta code to enable spack support as required by the benchpark project
https://github.com/LLNL/benchpark/pull/1033
This PR makes the following changes:
1. Allows Sparta to use an external Kokkos package. This is enabled through a new cmake option `USE_EXTERNAL_KOKKOS`
2. Fixes a C++ syntax error
3. Adds support to detect an existing HIP installation.

## Author(s)
@rfhaque (LLNL)

## Backward Compatibility
The change does not break backward compatibility. It is still possible to build Kokkos in source, if an external build is not preferred.

## Implementation Notes
Tested on LLNL Tuolumne system with Kokkos built using the HIP backend 

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


