### PR TITLE
adds missing list_custom_surf_changed allocation and resets counter

### DIFF
--- a/src/modify.cpp
+++ b/src/modify.cpp
@@ -50,6 +50,7 @@ Modify::Modify(SPARTA *sparta) : Pointers(sparta)
   list_update_custom = NULL;
   list_gas_react = NULL;
   list_surf_react = NULL;
+  list_custom_surf_changed = NULL;
   list_timeflag = NULL;
 
   ncompute = maxcompute = 0;
@@ -85,6 +86,7 @@ Modify::~Modify()
   delete [] list_update_custom;
   delete [] list_gas_react;
   delete [] list_surf_react;
+  delete [] list_custom_surf_changed;
   delete [] list_timeflag;
 }
 


### PR DESCRIPTION
## Purpose

A missing allocation is repaired. The missing allocation would result in a segfault when using surface custom variables

## Author(s)

Mike Park

## Backward Compatibility

No impact on backward compatability

## Implementation Notes

bug fix. segfault is avoided with using surface custom variables.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

N/A

