### PR TITLE
Add KOKKOS support for regions

### DIFF
--- a/doc/region.html
+++ b/doc/region.html
@@ -17,19 +17,19 @@
 </PRE>
 <UL><LI>ID = user-assigned name for the region 
 
-<LI>style = <I>block</I> or <I>cylinder</I> or <I>plane</I> or <I>sphere</I> or <I>union</I> or <I>intersect</I> 
+<LI>style = <I>block</I> or <I>cylinder</I> or <I>plane</I> or <I>sphere</I> or <I>union</I> or <I>intersect</I> or <I>block/kk</I> or <I>cylinder/kk</I> or <I>plane/kk</I> or <I>sphere/kk</I> 
 
-<PRE>  <I>block</I> args = xlo xhi ylo yhi zlo zhi
+<PRE>  <I>block</I> or <I>block/kk</I> args = xlo xhi ylo yhi zlo zhi
     xlo,xhi,ylo,yhi,zlo,zhi = bounds of block in all dimensions (distance units)
-  <I>cylinder</I> args = dim c1 c2 radius lo hi
+  <I>cylinder</I> or <I>cylinder/kk</I> args = dim c1 c2 radius lo hi
     dim = <I>x</I> or <I>y</I> or <I>z</I> = axis of cylinder
     c1,c2 = coords of cylinder axis in other 2 dimensions (distance units)
     radius = cylinder radius (distance units)
     lo,hi = bounds of cylinder in dim (distance units)
-  <I>plane</I> args = px py pz nx ny nz
+  <I>plane</I> or <I>plane/kk</I> args = px py pz nx ny nz
     px,py,pz = point on the plane (distance units)
     nx,ny,nz = direction normal to plane (distance units)
-  <I>sphere</I> args = x y z radius
+  <I>sphere</I> or <I>sphere/kk</I> args = x y z radius
     x,y,z = center of sphere (distance units)
     radius = radius of sphere (distance units)
   <I>union</I> args = N reg-ID1 reg-ID2 ...
@@ -102,6 +102,31 @@ constructed listing the region-IDs of the 2 spheres, the resulting
 region would be all the volume in the simulation box that was outside
 both of the spheres.
 </P>
+<HR>
+
+<P>Styles with a <I>kk</I> suffix are functionally the same as the
+corresponding style without the suffix.  They have been optimized to
+run faster, depending on your available hardware, as discussed in the
+<A HREF = "Section_accelerate.html">Accelerating SPARTA</A> section of the manual.
+The accelerated styles take the same arguments and should produce the
+same results, except for different random number, round-off and
+precision issues.
+</P>
+<P>These accelerated styles are part of the KOKKOS package. They are only
+enabled if SPARTA was built with that package.  See the <A HREF = "Section_start.html#start_3">Making
+SPARTA</A> section for more info.
+</P>
+<P>You can specify the accelerated styles explicitly in your input script
+by including their suffix, or you can use the <A HREF = "Section_start.html#start_7">-suffix command-line
+switch</A> when you invoke SPARTA, or you can
+use the <A HREF = "suffix.html">suffix</A> command in your input script.
+</P>
+<P>See the <A HREF = "Section_accelerate.html">Accelerating SPARTA</A> section of the
+manual for more instructions on how to use the accelerated styles
+effectively.
+</P>
+<HR>
+
 <P><B>Restrictions:</B> none
 </P>
 <P><B>Related commands:</B>

--- a/doc/region.txt
+++ b/doc/region.txt
@@ -13,18 +13,18 @@ region command :h3
 region ID style args keyword value ... :pre
 
 ID = user-assigned name for the region :ulb,l
-style = {block} or {cylinder} or {plane} or {sphere} or {union} or {intersect} :l
-  {block} args = xlo xhi ylo yhi zlo zhi
+style = {block} or {cylinder} or {plane} or {sphere} or {union} or {intersect} or {block/kk} or {cylinder/kk} or {plane/kk} or {sphere/kk} :l
+  {block} or {block/kk} args = xlo xhi ylo yhi zlo zhi
     xlo,xhi,ylo,yhi,zlo,zhi = bounds of block in all dimensions (distance units)
-  {cylinder} args = dim c1 c2 radius lo hi
+  {cylinder} or {cylinder/kk} args = dim c1 c2 radius lo hi
     dim = {x} or {y} or {z} = axis of cylinder
     c1,c2 = coords of cylinder axis in other 2 dimensions (distance units)
     radius = cylinder radius (distance units)
     lo,hi = bounds of cylinder in dim (distance units)
-  {plane} args = px py pz nx ny nz
+  {plane} or {plane/kk} args = px py pz nx ny nz
     px,py,pz = point on the plane (distance units)
     nx,ny,nz = direction normal to plane (distance units)
-  {sphere} args = x y z radius
+  {sphere} or {sphere/kk} args = x y z radius
     x,y,z = center of sphere (distance units)
     radius = radius of sphere (distance units)
   {union} args = N reg-ID1 reg-ID2 ...
@@ -92,6 +92,31 @@ each defined as regions, and a {union} style with {side} = out was
 constructed listing the region-IDs of the 2 spheres, the resulting
 region would be all the volume in the simulation box that was outside
 both of the spheres.
+
+:line
+
+Styles with a {kk} suffix are functionally the same as the
+corresponding style without the suffix.  They have been optimized to
+run faster, depending on your available hardware, as discussed in the
+"Accelerating SPARTA"_Section_accelerate.html section of the manual.
+The accelerated styles take the same arguments and should produce the
+same results, except for different random number, round-off and
+precision issues.
+
+These accelerated styles are part of the KOKKOS package. They are only
+enabled if SPARTA was built with that package.  See the "Making
+SPARTA"_Section_start.html#start_3 section for more info.
+
+You can specify the accelerated styles explicitly in your input script
+by including their suffix, or you can use the "-suffix command-line
+switch"_Section_start.html#start_7 when you invoke SPARTA, or you can
+use the "suffix"_suffix.html command in your input script.
+
+See the "Accelerating SPARTA"_Section_accelerate.html section of the
+manual for more instructions on how to use the accelerated styles
+effectively.
+
+:line
 
 [Restrictions:] none
 

--- a/src/KOKKOS/Install.sh
+++ b/src/KOKKOS/Install.sh
@@ -158,6 +158,14 @@ action fix_grid_check_kokkos.cpp
 action fix_grid_check_kokkos.h
 action read_surf_kokkos.cpp
 action read_surf_kokkos.h
+action region_block_kokkos.cpp
+action region_block_kokkos.h
+action region_cylinder_kokkos.cpp
+action region_cylinder_kokkos.h
+action region_plane_kokkos.cpp
+action region_plane_kokkos.h
+action region_sphere_kokkos.cpp
+action region_sphere_kokkos.h
 action remove_surf_kokkos.cpp
 action remove_surf_kokkos.h
 action variable_kokkos.cpp

--- a/src/KOKKOS/fix_ave_histo_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_kokkos.cpp
@@ -573,7 +573,7 @@ void FixAveHistoKokkos::bin_particles(
 
   KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);
 
-  if (k_match.extent(0) > nmax)
+  if (k_match.extent(0) < nmax)
     MemKK::realloc_kokkos(k_match,"fix_ave_histo_weight:match",nmax);
 
   regionKKBase->match_all_kokkos(k_match);

--- a/src/KOKKOS/fix_ave_histo_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_kokkos.cpp
@@ -499,22 +499,30 @@ void FixAveHistoKokkos::bin_particles(
 
   this->index = index;
   int n = particle->nlocal;
+  int nmax = particle->maxlocal;
 
-  // FIXME: Kokkos version of region
-  //Region *region;
-  //if (regionflag) region = domain->regions[iregion];
+  Region *region;
+  if (regionflag) region = domain->regions[iregion];
 
-  if (regionflag)
-    error->all(FLERR,"Cannot (yet) use regionflag with fix ave/histo/kk");
+  if (!region->kokkos_flag)
+    error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+
+  KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);
+
+  if (k_match.extent(0) > nmax)
+    MemKK::realloc_kokkos(k_match,"fix_ave_histo_weight:match",nmax);
+
+  regionKKBase->match_all_kokkos(k_match);
+  d_match = k_match.view_device();
 
   if (attribute == X) {
 
     if (regionflag && mixflag) {
-      //auto policy = RangePolicy<TagFixAveHisto_BinParticlesX1,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHisto_BinParticlesX1,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (regionflag) {
-      //auto policy = RangePolicy<TagFixAveHisto_BinParticlesX2,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHisto_BinParticlesX2,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (mixflag) {
       auto policy = RangePolicy<TagFixAveHisto_BinParticlesX3,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
@@ -526,11 +534,11 @@ void FixAveHistoKokkos::bin_particles(
   } else if (attribute == V) {
 
     if (regionflag && mixflag) {
-      //auto policy = RangePolicy<TagFixAveHisto_BinParticlesV1,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHisto_BinParticlesV1,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (regionflag) {
-      //auto policy = RangePolicy<TagFixAveHisto_BinParticlesV2,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHisto_BinParticlesV2,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (mixflag) {
       auto policy = RangePolicy<TagFixAveHisto_BinParticlesV3,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
@@ -553,23 +561,30 @@ void FixAveHistoKokkos::bin_particles(
 
   this->stride = stride;
   int n = particle->nlocal;
+  int nmax = particle->maxlocal;
 
   d_values = mirror_view_from_raw_host_array<double,DeviceType>(values, n, stride);
 
-  // FIXME: Kokkos version of region
-  // FIXME: Does values need to be made a view that lives on Device?
-  //Region *region;
-  //if (regionflag) region = domain->regions[iregion];
+  Region *region;
+  if (regionflag) region = domain->regions[iregion];
 
-  if (regionflag)
-    error->all(FLERR,"Cannot (yet) use regionflag with fix ave/histo/kk");
+  if (!region->kokkos_flag)
+    error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+
+  KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);
+
+  if (k_match.extent(0) > nmax)
+    MemKK::realloc_kokkos(k_match,"fix_ave_histo_weight:match",nmax);
+
+  regionKKBase->match_all_kokkos(k_match);
+  d_match = k_match.view_device();
 
   if (regionflag && mixflag) {
-    //auto policy = RangePolicy<TagFixAveHisto_BinParticles1,DeviceType>(0, n);
-    //Kokkos::parallel_reduce(policy, *this, reducer);
+    auto policy = RangePolicy<TagFixAveHisto_BinParticles1,DeviceType>(0, n);
+    Kokkos::parallel_reduce(policy, *this, reducer);
   } else if (regionflag) {
-    //auto policy = RangePolicy<TagFixAveHisto_BinParticles2,DeviceType>(0, n);
-    //Kokkos::parallel_reduce(policy, *this, reducer);
+    auto policy = RangePolicy<TagFixAveHisto_BinParticles2,DeviceType>(0, n);
+    Kokkos::parallel_reduce(policy, *this, reducer);
   } else if (mixflag) {
     auto policy = RangePolicy<TagFixAveHisto_BinParticles3,DeviceType>(0, n);
     Kokkos::parallel_reduce(policy, *this, reducer);
@@ -638,17 +653,10 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticles1, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_match(i) && d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_values(i));
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -657,16 +665,9 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticles2, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible.
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
-  if (region_kk->match(d_particles(i).x))
-  {
+  if (d_match(i)) {
     bin_one(lminmax, d_values(i));
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -676,8 +677,7 @@ FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticles3, const int i,
                               minmax_type::value_type& lminmax) const
 {
   const int ispecies = d_particles(i).ispecies;
-  if (d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_values(i));
   }
 }
@@ -697,8 +697,7 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinGridCells1, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  if (grid_kk->k_cinfo.view_device()[i].mask & groupbit)
-  {
+  if (grid_kk->k_cinfo.view_device()[i].mask & groupbit) {
     bin_one(lminmax, d_values(i));
   }
 }
@@ -718,17 +717,10 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesX1, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_match(i) && d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).x[index]);
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -737,16 +729,9 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesX2, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
-  if (region_kk->match(d_particles(i).x))
-  {
+  if (d_match(i)) {
     bin_one(lminmax, d_particles(i).x[index]);
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -756,8 +741,7 @@ FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesX3, const int i,
                               minmax_type::value_type& lminmax) const
 {
   const int ispecies = d_particles(i).ispecies;
-  if (d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).x[index]);
   }
 }
@@ -777,17 +761,10 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesV1, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_match(i) && d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).v[index]);
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -796,16 +773,9 @@ void
 FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesV2, const int i,
                               minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
-  if (region_kk->match(d_particles(i).x))
-  {
+  if (d_match(i)) {
     bin_one(lminmax, d_particles(i).v[index]);
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -815,8 +785,7 @@ FixAveHistoKokkos::operator()(TagFixAveHisto_BinParticlesV3, const int i,
                               minmax_type::value_type& lminmax) const
 {
   const int ispecies = d_particles(i).ispecies;
-  if (d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).v[index]);
   }
 }

--- a/src/KOKKOS/fix_ave_histo_kokkos.h
+++ b/src/KOKKOS/fix_ave_histo_kokkos.h
@@ -45,23 +45,21 @@ struct TagFixAveHisto_BinParticlesV3 {};
 struct TagFixAveHisto_BinParticlesV4 {};
 
 namespace FixKokkosDetails {
-
-template<class ValueType, class OutputDeviceType>
-inline
-Kokkos::View<ValueType*, OutputDeviceType>
-mirror_view_from_raw_host_array(ValueType* x, const int size, const int stride)
-{
-  typedef typename OutputDeviceType::memory_space out_mem_space;
-  typedef Kokkos::View<ValueType*, OutputDeviceType> out_view_type;
-  typedef Kokkos::View<ValueType*, typename out_view_type::array_layout,
-                       Kokkos::HostSpace> host_view_type;
-  host_view_type h_x("h_x", size);
-  for (int i=0, j=0; i<size; i++, j+=stride) h_x(i) = x[j];
-  out_view_type d_x = Kokkos::create_mirror_view(out_mem_space(), h_x);
-  Kokkos::deep_copy(d_x, h_x);
-  return d_x;
-}
-
+  template<class ValueType, class OutputDeviceType>
+  inline
+  Kokkos::View<ValueType*, OutputDeviceType>
+  mirror_view_from_raw_host_array(ValueType* x, const int size, const int stride)
+  {
+    typedef typename OutputDeviceType::memory_space out_mem_space;
+    typedef Kokkos::View<ValueType*, OutputDeviceType> out_view_type;
+    typedef Kokkos::View<ValueType*, typename out_view_type::array_layout,
+                         Kokkos::HostSpace> host_view_type;
+    host_view_type h_x("h_x", size);
+    for (int i=0, j=0; i<size; i++, j+=stride) h_x(i) = x[j];
+    out_view_type d_x = Kokkos::create_mirror_view(out_mem_space(), h_x);
+    Kokkos::deep_copy(d_x, h_x);
+    return d_x;
+  }
 }
 
 class FixAveHistoKokkos : public FixAveHisto
@@ -136,6 +134,9 @@ protected:
   DAT::t_int_2d d_s2g;
 
   DAT::tdual_float_1d k_vector;
+
+  DAT::tdual_int_1d k_match;
+  DAT::t_int_1d d_match;
 
   int index;
   int stride;

--- a/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
@@ -312,7 +312,7 @@ void FixAveHistoWeightKokkos::bin_particles(
 
   KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);
 
-  if (k_match.extent(0) > nmax)
+  if (k_match.extent(0) < nmax)
     MemKK::realloc_kokkos(k_match,"fix_ave_histo_weight:match",nmax);
 
   regionKKBase->match_all_kokkos(k_match);

--- a/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_histo_weight_kokkos.cpp
@@ -302,22 +302,30 @@ void FixAveHistoWeightKokkos::bin_particles(
 
   this->index = index;
   int n = particle->nlocal;
+  int nmax = particle->maxlocal;
 
-  // FIXME: Kokkos version of region
-  //Region *region;
-  //if (regionflag) region = domain->regions[iregion];
+  Region *region;
+  if (regionflag) region = domain->regions[iregion];
 
-  if (regionflag)
-    error->all(FLERR,"Cannot (yet) use regionflag with fix ave/histo/kk");
+  if (!region->kokkos_flag)
+    error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+
+  KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);
+
+  if (k_match.extent(0) > nmax)
+    MemKK::realloc_kokkos(k_match,"fix_ave_histo_weight:match",nmax);
+
+  regionKKBase->match_all_kokkos(k_match);
+  d_match = k_match.view_device();
 
   if (attribute == X) {
 
     if (regionflag && mixflag) {
-      //auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesX1,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesX1,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (regionflag) {
-      //auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesX2,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesX2,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (mixflag) {
       auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesX3,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
@@ -329,11 +337,11 @@ void FixAveHistoWeightKokkos::bin_particles(
   } else if (attribute == V) {
 
     if (regionflag && mixflag) {
-      //auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesV1,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesV1,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (regionflag) {
-      //auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesV2,DeviceType>(0, n);
-      //Kokkos::parallel_reduce(policy, *this, reducer);
+      auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesV2,DeviceType>(0, n);
+      Kokkos::parallel_reduce(policy, *this, reducer);
     } else if (mixflag) {
       auto policy = RangePolicy<TagFixAveHistoWeight_BinParticlesV3,DeviceType>(0, n);
       Kokkos::parallel_reduce(policy, *this, reducer);
@@ -356,16 +364,23 @@ void FixAveHistoWeightKokkos::bin_particles(
 
   this->stride = stride;
   int n = particle->nlocal;
+  int nmax = particle->maxlocal;
 
   d_values = mirror_view_from_raw_host_array<double,DeviceType>(values, n, stride);
 
-  // FIXME: Kokkos version of region
-  // FIXME: Does values need to be made a view that lives on Device?
-  //Region *region;
-  //if (regionflag) region = domain->regions[iregion];
+  Region *region;
+  if (regionflag) region = domain->regions[iregion];
 
-  if (regionflag)
-    error->all(FLERR,"Cannot (yet) use regionflag with fix ave/histo/kk");
+  if (!region->kokkos_flag)
+    error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+
+  KokkosBase* regionKKBase = dynamic_cast<KokkosBase*>(region);
+
+  if (k_match.extent(0) > nmax)
+    MemKK::realloc_kokkos(k_match,"fix_ave_histo_weight:match",nmax);
+
+  regionKKBase->match_all_kokkos(k_match);
+  d_match = k_match.view_device();
 
   if (regionflag && mixflag) {
     //auto policy = RangePolicy<TagFixAveHistoWeight_BinParticles1,DeviceType>(0, n);
@@ -502,17 +517,10 @@ void
 FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesX1, const int i,
                                     minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_match(i) && d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).x[index], d_weights(i));
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -521,16 +529,9 @@ void
 FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesX2, const int i,
                                     minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
-  if (region_kk->match(d_particles(i).x))
-  {
+  if (d_match(i)) {
     bin_one(lminmax, d_particles(i).x[index], d_weights(i));
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -561,17 +562,10 @@ void
 FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesV1, const int i,
                                     minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
   const int ispecies = d_particles(i).ispecies;
-  if (region_kk->match(d_particles(i).x) && d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_match(i) && d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).v[index], d_weights(i));
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -580,16 +574,9 @@ void
 FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesV2, const int i,
                                     minmax_type::value_type& lminmax) const
 {
-  /*
-   * region is not Kokkos compatible
-   * If a Kokkos compatible region becomes available,
-   * this code can be recommissioned.
-   *
-  if (region_kk->match(d_particles(i).x))
-  {
+  if (d_match(i)) {
     bin_one(lminmax, d_particles(i).v[index], d_weights(i));
   }
-  */
 }
 
 /* ------------------------------------------------------------------------- */
@@ -599,8 +586,7 @@ FixAveHistoWeightKokkos::operator()(TagFixAveHistoWeight_BinParticlesV3, const i
                                     minmax_type::value_type& lminmax) const
 {
   const int ispecies = d_particles(i).ispecies;
-  if (d_s2g(imix, ispecies) >= 0)
-  {
+  if (d_s2g(imix, ispecies) >= 0) {
     bin_one(lminmax, d_particles(i).v[index], d_weights(i));
   }
 }

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -49,6 +49,9 @@ enum{NOSUBSONIC,PTBOTH,PONLY};
 #define DELTATASK 256
 #define TEMPLIMIT 1.0e5
 
+#define VAL_1(X) X
+#define VAL_2(X) VAL_1(X), VAL_1(X)
+
 /* ----------------------------------------------------------------------
    insert particles in grid cells with faces touching inflow boundaries
 ------------------------------------------------------------------------- */
@@ -60,12 +63,18 @@ FixEmitFaceKokkos::FixEmitFaceKokkos(SPARTA *sparta, int narg, char **arg) :
             , sparta
 #endif
             ),
-  particle_kk_copy(sparta)
+  particle_kk_copy(sparta),
+  regblock_kk_copy(sparta),
+  regcylinder_kk_copy(sparta),
+  regplane_kk_copy(sparta),
+  regsphere_kk_copy(sparta)
 {
   kokkos_flag = 1;
   execution_space = Device;
   datamask_read = EMPTY_MASK;
   datamask_modify = EMPTY_MASK;
+
+  region_flag = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -75,6 +84,7 @@ FixEmitFaceKokkos::~FixEmitFaceKokkos()
   if (copymode) return;
 
   particle_kk_copy.uncopy();
+  regblock_kk_copy.uncopy();
 
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.destroy();
@@ -255,8 +265,31 @@ void FixEmitFaceKokkos::perform_task()
   particle_kk->update_class_variables();
   particle_kk_copy.copy(particle_kk);
 
-  if (region)
-    error->one(FLERR,"Cannot yet use fix emit/face/kk with regions");
+  if (region && !region->kokkos_flag)
+    error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+
+  region_flag = 0;
+  if (region) {
+    if (strstr(region->style,"block") != NULL) {
+      RegBlockKokkos* region_kk = ((RegBlockKokkos*)region);
+      regblock_kk_copy.copy(region_kk);
+      region_flag = 1;
+    } else if (strstr(region->style,"cylinder") != NULL) {
+      RegCylinderKokkos* region_kk = ((RegCylinderKokkos*)region);
+      regcylinder_kk_copy.copy(region_kk);
+      region_flag = 2;
+    } else if (strstr(region->style,"plane") != NULL) {
+      RegPlaneKokkos* region_kk = ((RegPlaneKokkos*)region);
+      regplane_kk_copy.copy(region_kk);
+      region_flag = 3;
+    } else if (strstr(region->style,"sphere") != NULL) {
+      RegSphereKokkos* region_kk = ((RegSphereKokkos*)region);
+      regsphere_kk_copy.copy(region_kk);
+      region_flag = 4;
+    } else {
+      error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+    }
+  }
 
   int nsingle_reduce = 0;
   copymode = 1;
@@ -421,7 +454,16 @@ void FixEmitFaceKokkos::operator()(TagFixEmitFace_perform_task, const int &i, in
         if (dimension == 3) x[2] = lo[2] + rand_gen.drand() * (hi[2]-lo[2]);
         else x[2] = 0.0;
 
-        //if (region && !region->match(x)) continue; ////////////////////////
+        if (region_flag == 1) {
+          if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        } else if (region_flag == 2) {
+          if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        } else if (region_flag == 3) {
+          if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        } else if (region_flag == 4) {
+          if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        }
+
         nactual++;
         d_keep(cand) = 1;
         d_task(cand) = i;
@@ -470,7 +512,16 @@ void FixEmitFaceKokkos::operator()(TagFixEmitFace_perform_task, const int &i, in
       if (dimension == 3) x[2] = lo[2] + rand_gen.drand() * (hi[2]-lo[2]);
       else x[2] = 0.0;
 
-      //if (region && !region->match(x)) continue; ////////////////////////
+      if (region_flag == 1) {
+        if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      } else if (region_flag == 2) {
+        if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      } else if (region_flag == 3) {
+        if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      } else if (region_flag == 4) {
+        if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      }
+
       nactual++;
       d_keep(cand) = 1;
       d_task(cand) = i;

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -85,6 +85,9 @@ FixEmitFaceKokkos::~FixEmitFaceKokkos()
 
   particle_kk_copy.uncopy();
   regblock_kk_copy.uncopy();
+  regcylinder_kk_copy.uncopy();
+  regplane_kk_copy.uncopy();
+  regsphere_kk_copy.uncopy();
 
 #ifdef SPARTA_KOKKOS_EXACT
   rand_pool.destroy();

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -458,13 +458,13 @@ void FixEmitFaceKokkos::operator()(TagFixEmitFace_perform_task, const int &i, in
         else x[2] = 0.0;
 
         if (region_flag == 1) {
-          if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         } else if (region_flag == 2) {
-          if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         } else if (region_flag == 3) {
-          if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         } else if (region_flag == 4) {
-          if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         }
 
         nactual++;
@@ -516,13 +516,13 @@ void FixEmitFaceKokkos::operator()(TagFixEmitFace_perform_task, const int &i, in
       else x[2] = 0.0;
 
       if (region_flag == 1) {
-        if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       } else if (region_flag == 2) {
-        if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       } else if (region_flag == 3) {
-        if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       } else if (region_flag == 4) {
-        if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       }
 
       nactual++;

--- a/src/KOKKOS/fix_emit_face_kokkos.h
+++ b/src/KOKKOS/fix_emit_face_kokkos.h
@@ -23,10 +23,18 @@ FixStyle(emit/face/kk,FixEmitFaceKokkos)
 
 #include "fix_emit_face.h"
 #include "rand_pool_wrap.h"
+#include "kokkos_base.h"
 #include "kokkos_copy.h"
 #include "particle_kokkos.h"
+#include "region_block_kokkos.h"
+#include "region_cylinder_kokkos.h"
+#include "region_plane_kokkos.h"
+#include "region_sphere_kokkos.h"
 
 namespace SPARTA_NS {
+
+#define KOKKOS_MAX_REGION_PER_TYPE 2
+#define KOKKOS_MAX_TOT_REGION 10
 
 struct TagFixEmitFace_ninsert{};
 struct TagFixEmitFace_perform_task{};
@@ -59,9 +67,13 @@ class FixEmitFaceKokkos : public FixEmitFace {
 #endif
 
  private:
-  int prefactor;
+  int prefactor, region_flag;
 
   KKCopy<ParticleKokkos> particle_kk_copy;
+  KKCopy<RegBlockKokkos> regblock_kk_copy;
+  KKCopy<RegCylinderKokkos> regcylinder_kk_copy;
+  KKCopy<RegPlaneKokkos> regplane_kk_copy;
+  KKCopy<RegSphereKokkos> regsphere_kk_copy;
 
   typedef Kokkos::DualView<Task*, DeviceType::array_layout, DeviceType> tdual_task_1d;
   typedef tdual_task_1d::t_dev t_task_1d;

--- a/src/KOKKOS/fix_emit_surf_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_surf_kokkos.cpp
@@ -86,6 +86,10 @@ FixEmitSurfKokkos::~FixEmitSurfKokkos()
   if (copymode) return;
 
   particle_kk_copy.uncopy();
+  regblock_kk_copy.uncopy();
+  regcylinder_kk_copy.uncopy();
+  regplane_kk_copy.uncopy();
+  regsphere_kk_copy.uncopy();
 
   for (int i=0; i<KOKKOS_MAX_SLIST; i++) {
     slist_active_copy[i].uncopy();

--- a/src/KOKKOS/fix_emit_surf_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_surf_kokkos.cpp
@@ -578,13 +578,13 @@ void FixEmitSurfKokkos::operator()(TagFixEmitSurf_perform_task, const int &i, in
         }
 
         if (region_flag == 1) {
-          if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         } else if (region_flag == 2) {
-          if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         } else if (region_flag == 3) {
-          if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         } else if (region_flag == 4) {
-          if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+          if (!regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
         }
 
         nactual++;
@@ -689,13 +689,13 @@ void FixEmitSurfKokkos::operator()(TagFixEmitSurf_perform_task, const int &i, in
       }
 
       if (region_flag == 1) {
-        if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       } else if (region_flag == 2) {
-        if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       } else if (region_flag == 3) {
-        if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       } else if (region_flag == 4) {
-        if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        if (!regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
       }
 
       nactual++;

--- a/src/KOKKOS/fix_emit_surf_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_surf_kokkos.cpp
@@ -65,12 +65,18 @@ FixEmitSurfKokkos::FixEmitSurfKokkos(SPARTA *sparta, int narg, char **arg) :
             ),
   particle_kk_copy(sparta),
   slist_active_copy{VAL_2(KKCopy<ComputeSurfKokkos>(sparta))},
-  tmp_compute_surf_kk(sparta)
+  tmp_compute_surf_kk(sparta),
+  regblock_kk_copy(sparta),
+  regcylinder_kk_copy(sparta),
+  regplane_kk_copy(sparta),
+  regsphere_kk_copy(sparta)
 {
   kokkos_flag = 1;
   execution_space = Device;
   datamask_read = EMPTY_MASK;
   datamask_modify = EMPTY_MASK;
+
+  region_flag = 0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -361,8 +367,31 @@ void FixEmitSurfKokkos::perform_task()
   particle_kk->update_class_variables();
   particle_kk_copy.copy(particle_kk);
 
-  if (region)
-    error->one(FLERR,"Cannot yet use fix emit/surf/kk with regions");
+  if (region && !region->kokkos_flag)
+    error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+
+  region_flag = 0;
+  if (region) {
+    if (strstr(region->style,"block") != NULL) {
+      RegBlockKokkos* region_kk = ((RegBlockKokkos*)region);
+      regblock_kk_copy.copy(region_kk);
+      region_flag = 1;
+    } else if (strstr(region->style,"cylinder") != NULL) {
+      RegCylinderKokkos* region_kk = ((RegCylinderKokkos*)region);
+      regcylinder_kk_copy.copy(region_kk);
+      region_flag = 2;
+    } else if (strstr(region->style,"plane") != NULL) {
+      RegPlaneKokkos* region_kk = ((RegPlaneKokkos*)region);
+      regplane_kk_copy.copy(region_kk);
+      region_flag = 3;
+    } else if (strstr(region->style,"sphere") != NULL) {
+      RegSphereKokkos* region_kk = ((RegSphereKokkos*)region);
+      regsphere_kk_copy.copy(region_kk);
+      region_flag = 4;
+    } else {
+      error->all(FLERR,"KOKKOS package does not (yet) support chosen region style");
+    }
+  }
 
   int nsingle_reduce = 0;
   copymode = 1;
@@ -544,7 +573,16 @@ void FixEmitSurfKokkos::operator()(TagFixEmitSurf_perform_task, const int &i, in
           x[2] = p1[2] + alpha*e1[2] + beta*e2[2];
         }
 
-        //if (region && !region->match(x)) continue; ////////////////////////
+        if (region_flag == 1) {
+          if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        } else if (region_flag == 2) {
+          if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        } else if (region_flag == 3) {
+          if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        } else if (region_flag == 4) {
+          if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+        }
+
         nactual++;
         d_keep(cand) = 1;
         d_task(cand) = i;
@@ -646,7 +684,16 @@ void FixEmitSurfKokkos::operator()(TagFixEmitSurf_perform_task, const int &i, in
         x[2] = p1[2] + alpha*e1[2] + beta*e2[2];
       }
 
-      //if (region && !region->match(x)) continue; ////////////////////////
+      if (region_flag == 1) {
+        if (regblock_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      } else if (region_flag == 2) {
+        if (regcylinder_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      } else if (region_flag == 3) {
+        if (regplane_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      } else if (region_flag == 4) {
+        if (regsphere_kk_copy.obj.match_kokkos(x[0], x[1], x[2])) continue;
+      }
+
       nactual++;
       d_keep(cand) = 1;
       d_task(cand) = i;

--- a/src/KOKKOS/fix_emit_surf_kokkos.h
+++ b/src/KOKKOS/fix_emit_surf_kokkos.h
@@ -26,6 +26,10 @@ FixStyle(emit/surf/kk,FixEmitSurfKokkos)
 #include "kokkos_copy.h"
 #include "particle_kokkos.h"
 #include "compute_surf_kokkos.h"
+#include "region_block_kokkos.h"
+#include "region_cylinder_kokkos.h"
+#include "region_plane_kokkos.h"
+#include "region_sphere_kokkos.h"
 
 namespace SPARTA_NS {
 
@@ -71,10 +75,14 @@ class FixEmitSurfKokkos : public FixEmitSurf {
 #endif
 
  private:
-  int npcurrent,nsurf_tally,nlocal_before,nlocal_surf;
+  int npcurrent,nsurf_tally,nlocal_before,nlocal_surf,region_flag;
 
   KKCopy<ParticleKokkos> particle_kk_copy;
   KKCopy<ComputeSurfKokkos> slist_active_copy[KOKKOS_MAX_SLIST];
+  KKCopy<RegBlockKokkos> regblock_kk_copy;
+  KKCopy<RegCylinderKokkos> regcylinder_kk_copy;
+  KKCopy<RegPlaneKokkos> regplane_kk_copy;
+  KKCopy<RegSphereKokkos> regsphere_kk_copy;
 
   typedef Kokkos::DualView<Task*, DeviceType::array_layout, DeviceType> tdual_task_1d;
   typedef tdual_task_1d::t_dev t_task_1d;

--- a/src/KOKKOS/kokkos_base.h
+++ b/src/KOKKOS/kokkos_base.h
@@ -37,6 +37,12 @@ class KokkosBase {
   DAT::t_float_2d_lr d_array_particle;   // Kokkos version of per-particle array
 
   DAT::tdual_float_2d_lr k_array;    // Kokkos DualView of global array
+
+  // Region
+  virtual void match_all_kokkos(DAT::tdual_int_1d) {}
+
+  KOKKOS_INLINE_FUNCTION
+  int match_kokkos(double x, double y, double z) const {}
 };
 
 }

--- a/src/KOKKOS/region_block_kokkos.cpp
+++ b/src/KOKKOS/region_block_kokkos.cpp
@@ -1,0 +1,68 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "region_block_kokkos.h"
+#include "sparta_masks.h"
+#include "memory_kokkos.h"
+#include "particle_kokkos.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+RegBlockKokkos::RegBlockKokkos(SPARTA *sparta, int narg, char **arg) :
+  RegBlock(sparta, narg, arg)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegBlockKokkos::RegBlockKokkos(SPARTA *sparta) :
+  RegBlock(sparta)
+{
+  copy = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegBlockKokkos::~RegBlockKokkos()
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+void RegBlockKokkos::match_all_kokkos(DAT::tdual_int_1d k_match_in)
+{
+  d_match = k_match_in.view_device();
+  ParticleKokkos* particleKK = (ParticleKokkos*) particle;
+  particleKK->sync(Device, PARTICLE_MASK);
+  d_particles = particleKK->k_particles.view_device();
+  int nlocal = particle->nlocal;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<TagRegBlockMatchAll>(0,nlocal),*this);
+  copymode = 0;
+  k_match_in.modify_device();
+}
+
+/* ---------------------------------------------------------------------- */
+
+KOKKOS_INLINE_FUNCTION
+void RegBlockKokkos::operator()(TagRegBlockMatchAll, const int &i) const
+{
+  const double x_tmp = d_particles[i].x[0];
+  const double y_tmp = d_particles[i].x[1];
+  const double z_tmp = d_particles[i].x[2];
+  d_match[i] = match_kokkos(x_tmp,y_tmp,z_tmp);
+}

--- a/src/KOKKOS/region_block_kokkos.cpp
+++ b/src/KOKKOS/region_block_kokkos.cpp
@@ -24,6 +24,7 @@ using namespace SPARTA_NS;
 RegBlockKokkos::RegBlockKokkos(SPARTA *sparta, int narg, char **arg) :
   RegBlock(sparta, narg, arg)
 {
+  kokkos_flag = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/region_block_kokkos.h
+++ b/src/KOKKOS/region_block_kokkos.h
@@ -1,0 +1,72 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef REGION_CLASS
+
+RegionStyle(block/kk,RegBlockKokkos)
+
+#else
+
+#ifndef SPARTA_REGION_BLOCK_KOKKOS_H
+#define SPARTA_REGION_BLOCK_KOKKOS_H
+
+#include "region_block.h"
+
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+namespace SPARTA_NS {
+
+struct TagRegBlockMatchAll{};
+
+class RegBlockKokkos : public RegBlock, public KokkosBase {
+
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+
+  RegBlockKokkos(class SPARTA *, int, char **);
+  RegBlockKokkos(class SPARTA *sparta);
+  ~RegBlockKokkos() override;
+
+  void match_all_kokkos(DAT::tdual_int_1d) override;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagRegBlockMatchAll, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  int match_kokkos(double x, double y, double z) const
+  {
+    return !(k_inside(x,y,z) ^ interior);
+  }
+
+ private:
+  int groupbit;
+  typename AT::t_int_1d d_match;
+  t_particle_1d d_particles;
+
+  KOKKOS_INLINE_FUNCTION
+  int k_inside(double x, double y, double z) const
+  {
+    if (x >= xlo && x <= xhi && y >= ylo && y <= yhi && z >= zlo && z <= zhi)
+      return 1;
+    return 0;
+  }
+};
+
+}
+
+#endif
+#endif
+

--- a/src/KOKKOS/region_cylinder_kokkos.cpp
+++ b/src/KOKKOS/region_cylinder_kokkos.cpp
@@ -24,6 +24,7 @@ using namespace SPARTA_NS;
 RegCylinderKokkos::RegCylinderKokkos(SPARTA *sparta, int narg, char **arg) :
   RegCylinder(sparta, narg, arg)
 {
+  kokkos_flag = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/region_cylinder_kokkos.cpp
+++ b/src/KOKKOS/region_cylinder_kokkos.cpp
@@ -1,0 +1,68 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "region_cylinder_kokkos.h"
+#include "sparta_masks.h"
+#include "memory_kokkos.h"
+#include "particle_kokkos.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+RegCylinderKokkos::RegCylinderKokkos(SPARTA *sparta, int narg, char **arg) :
+  RegCylinder(sparta, narg, arg)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegCylinderKokkos::RegCylinderKokkos(SPARTA *sparta) :
+  RegCylinder(sparta)
+{
+  copy = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegCylinderKokkos::~RegCylinderKokkos()
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+void RegCylinderKokkos::match_all_kokkos(DAT::tdual_int_1d k_match_in)
+{
+  d_match = k_match_in.view_device();
+  ParticleKokkos* particleKK = (ParticleKokkos*) particle;
+  particleKK->sync(Device, PARTICLE_MASK);
+  d_particles = particleKK->k_particles.view_device();
+  int nlocal = particle->nlocal;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<TagRegCylinderMatchAll>(0,nlocal),*this);
+  copymode = 0;
+  k_match_in.modify_device();
+}
+
+/* ---------------------------------------------------------------------- */
+
+KOKKOS_INLINE_FUNCTION
+void RegCylinderKokkos::operator()(TagRegCylinderMatchAll, const int &i) const
+{
+  const double x_tmp = d_particles[i].x[0];
+  const double y_tmp = d_particles[i].x[1];
+  const double z_tmp = d_particles[i].x[2];
+  d_match[i] = match_kokkos(x_tmp,y_tmp,z_tmp);
+}

--- a/src/KOKKOS/region_cylinder_kokkos.h
+++ b/src/KOKKOS/region_cylinder_kokkos.h
@@ -1,0 +1,93 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef REGION_CLASS
+
+RegionStyle(cylinder/kk,RegCylinderKokkos)
+
+#else
+
+#ifndef SPARTA_REGION_CYLINDER_KOKKOS_H
+#define SPARTA_REGION_CYLINDER_KOKKOS_H
+
+#include "region_cylinder.h"
+
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+namespace SPARTA_NS {
+
+struct TagRegCylinderMatchAll{};
+
+class RegCylinderKokkos : public RegCylinder, public KokkosBase {
+
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+
+  RegCylinderKokkos(class SPARTA *, int, char **);
+  RegCylinderKokkos(class SPARTA *sparta);
+  ~RegCylinderKokkos() override;
+
+  void match_all_kokkos(DAT::tdual_int_1d) override;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagRegCylinderMatchAll, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  int match_kokkos(double x, double y, double z) const
+  {
+    return !(k_inside(x,y,z) ^ interior);
+  }
+
+ private:
+  int groupbit;
+  typename AT::t_int_1d d_match;
+  t_particle_1d d_particles;
+
+  KOKKOS_INLINE_FUNCTION
+  int k_inside(double x, double y, double z) const
+  {
+    double del1,del2,dist;
+    int inside;
+
+    if (axis == 'x') {
+      del1 = y - c1;
+      del2 = z - c2;
+      dist = sqrt(del1*del1 + del2*del2);
+      if (dist <= radius && x >= lo && x <= hi) inside = 1;
+      else inside = 0;
+    } else if (axis == 'y') {
+      del1 = x - c1;
+      del2 = z - c2;
+      dist = sqrt(del1*del1 + del2*del2);
+      if (dist <= radius && y >= lo && y <= hi) inside = 1;
+      else inside = 0;
+    } else {
+      del1 = x - c1;
+      del2 = y - c2;
+      dist = sqrt(del1*del1 + del2*del2);
+      if (dist <= radius && z >= lo && z <= hi) inside = 1;
+      else inside = 0;
+    }
+
+    return inside;
+  }
+};
+
+}
+
+#endif
+#endif
+

--- a/src/KOKKOS/region_plane_kokkos.cpp
+++ b/src/KOKKOS/region_plane_kokkos.cpp
@@ -24,6 +24,7 @@ using namespace SPARTA_NS;
 RegPlaneKokkos::RegPlaneKokkos(SPARTA *sparta, int narg, char **arg) :
   RegPlane(sparta, narg, arg)
 {
+  kokkos_flag = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/region_plane_kokkos.cpp
+++ b/src/KOKKOS/region_plane_kokkos.cpp
@@ -1,0 +1,68 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "region_plane_kokkos.h"
+#include "sparta_masks.h"
+#include "memory_kokkos.h"
+#include "particle_kokkos.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+RegPlaneKokkos::RegPlaneKokkos(SPARTA *sparta, int narg, char **arg) :
+  RegPlane(sparta, narg, arg)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegPlaneKokkos::RegPlaneKokkos(SPARTA *sparta) :
+  RegPlane(sparta)
+{
+  copy = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegPlaneKokkos::~RegPlaneKokkos()
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+void RegPlaneKokkos::match_all_kokkos(DAT::tdual_int_1d k_match_in)
+{
+  d_match = k_match_in.view_device();
+  ParticleKokkos* particleKK = (ParticleKokkos*) particle;
+  particleKK->sync(Device, PARTICLE_MASK);
+  d_particles = particleKK->k_particles.view_device();
+  int nlocal = particle->nlocal;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<TagRegPlaneMatchAll>(0,nlocal),*this);
+  copymode = 0;
+  k_match_in.modify_device();
+}
+
+/* ---------------------------------------------------------------------- */
+
+KOKKOS_INLINE_FUNCTION
+void RegPlaneKokkos::operator()(TagRegPlaneMatchAll, const int &i) const
+{
+  const double x_tmp = d_particles[i].x[0];
+  const double y_tmp = d_particles[i].x[1];
+  const double z_tmp = d_particles[i].x[2];
+  d_match[i] = match_kokkos(x_tmp,y_tmp,z_tmp);
+}

--- a/src/KOKKOS/region_plane_kokkos.h
+++ b/src/KOKKOS/region_plane_kokkos.h
@@ -1,0 +1,73 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef REGION_CLASS
+
+RegionStyle(plane/kk,RegPlaneKokkos)
+
+#else
+
+#ifndef SPARTA_REGION_PLANE_KOKKOS_H
+#define SPARTA_REGION_PLANE_KOKKOS_H
+
+#include "region_plane.h"
+
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+namespace SPARTA_NS {
+
+struct TagRegPlaneMatchAll{};
+
+class RegPlaneKokkos : public RegPlane, public KokkosBase {
+
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+
+  RegPlaneKokkos(class SPARTA *, int, char **);
+  RegPlaneKokkos(class SPARTA *sparta);
+  ~RegPlaneKokkos() override;
+
+  void match_all_kokkos(DAT::tdual_int_1d) override;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagRegPlaneMatchAll, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  int match_kokkos(double x, double y, double z) const
+  {
+    return !(k_inside(x,y,z) ^ interior);
+  }
+
+ private:
+  int groupbit;
+  typename AT::t_int_1d d_match;
+  t_particle_1d d_particles;
+
+  KOKKOS_INLINE_FUNCTION
+  int k_inside(double x, double y, double z) const
+  {
+    const double dot = (x-xp)*normal[0] + (y-yp)*normal[1] + (z-zp)*normal[2];
+
+    if (dot >= 0.0) return 1;
+    return 0;
+  }
+};
+
+}
+
+#endif
+#endif
+

--- a/src/KOKKOS/region_sphere_kokkos.cpp
+++ b/src/KOKKOS/region_sphere_kokkos.cpp
@@ -1,0 +1,68 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#include "region_sphere_kokkos.h"
+#include "sparta_masks.h"
+#include "memory_kokkos.h"
+#include "particle_kokkos.h"
+
+using namespace SPARTA_NS;
+
+/* ---------------------------------------------------------------------- */
+
+RegSphereKokkos::RegSphereKokkos(SPARTA *sparta, int narg, char **arg) :
+  RegSphere(sparta, narg, arg)
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegSphereKokkos::RegSphereKokkos(SPARTA *sparta) :
+  RegSphere(sparta)
+{
+  copy = 1;
+}
+
+/* ---------------------------------------------------------------------- */
+
+RegSphereKokkos::~RegSphereKokkos()
+{
+}
+
+/* ---------------------------------------------------------------------- */
+
+void RegSphereKokkos::match_all_kokkos(DAT::tdual_int_1d k_match_in)
+{
+  d_match = k_match_in.view_device();
+  ParticleKokkos* particleKK = (ParticleKokkos*) particle;
+  particleKK->sync(Device, PARTICLE_MASK);
+  d_particles = particleKK->k_particles.view_device();
+  int nlocal = particle->nlocal;
+
+  copymode = 1;
+  Kokkos::parallel_for(Kokkos::RangePolicy<TagRegSphereMatchAll>(0,nlocal),*this);
+  copymode = 0;
+  k_match_in.modify_device();
+}
+
+/* ---------------------------------------------------------------------- */
+
+KOKKOS_INLINE_FUNCTION
+void RegSphereKokkos::operator()(TagRegSphereMatchAll, const int &i) const
+{
+  const double x_tmp = d_particles[i].x[0];
+  const double y_tmp = d_particles[i].x[1];
+  const double z_tmp = d_particles[i].x[2];
+  d_match[i] = match_kokkos(x_tmp,y_tmp,z_tmp);
+}

--- a/src/KOKKOS/region_sphere_kokkos.cpp
+++ b/src/KOKKOS/region_sphere_kokkos.cpp
@@ -24,6 +24,7 @@ using namespace SPARTA_NS;
 RegSphereKokkos::RegSphereKokkos(SPARTA *sparta, int narg, char **arg) :
   RegSphere(sparta, narg, arg)
 {
+  kokkos_flag = 1;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/KOKKOS/region_sphere_kokkos.h
+++ b/src/KOKKOS/region_sphere_kokkos.h
@@ -1,0 +1,76 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifdef REGION_CLASS
+
+RegionStyle(sphere/kk,RegSphereKokkos)
+
+#else
+
+#ifndef SPARTA_REGION_SPHERE_KOKKOS_H
+#define SPARTA_REGION_SPHERE_KOKKOS_H
+
+#include "region_sphere.h"
+
+#include "kokkos_base.h"
+#include "kokkos_type.h"
+
+namespace SPARTA_NS {
+
+struct TagRegSphereMatchAll{};
+
+class RegSphereKokkos : public RegSphere, public KokkosBase {
+
+ public:
+  typedef DeviceType device_type;
+  typedef ArrayTypes<DeviceType> AT;
+
+  RegSphereKokkos(class SPARTA *, int, char **);
+  RegSphereKokkos(class SPARTA *sparta);
+  ~RegSphereKokkos() override;
+
+  void match_all_kokkos(DAT::tdual_int_1d) override;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(TagRegSphereMatchAll, const int&) const;
+
+  KOKKOS_INLINE_FUNCTION
+  int match_kokkos(double x, double y, double z) const
+  {
+    return !(k_inside(x,y,z) ^ interior);
+  }
+
+ private:
+  int groupbit;
+  typename AT::t_int_1d d_match;
+  t_particle_1d d_particles;
+
+  KOKKOS_INLINE_FUNCTION
+  int k_inside(double x, double y, double z) const
+  {
+    double delx = x - xc;
+    double dely = y - yc;
+    double delz = z - zc;
+    double r = sqrt(delx*delx + dely*dely + delz*delz);
+
+    if (r <= radius) return 1;
+    return 0;
+  }
+};
+
+}
+
+#endif
+#endif
+

--- a/src/domain.cpp
+++ b/src/domain.cpp
@@ -438,6 +438,26 @@ void Domain::add_region(int narg, char **arg)
 
   // create the Region
 
+  if (sparta->suffix_enable) {
+    if (sparta->suffix) {
+      char estyle[256];
+      sprintf(estyle,"%s/%s",arg[1],sparta->suffix);
+
+      if (0) return;
+
+#define REGION_CLASS
+#define RegionStyle(key,Class) \
+      else if (strcmp(estyle,#key) == 0) { \
+        regions[nregion] = new Class(sparta,narg,arg); \
+        nregion++; \
+        return; \
+      }
+#include "style_region.h"
+#undef RegionStyle
+#undef REGION_CLASS
+    }
+  }
+
   if (strcmp(arg[1],"none") == 0) error->all(FLERR,"Invalid region style");
 
 #define REGION_CLASS
@@ -445,6 +465,7 @@ void Domain::add_region(int narg, char **arg)
   else if (strcmp(arg[1],#key) == 0) \
     regions[nregion] = new Class(sparta,narg,arg);
 #include "style_region.h"
+#undef RegionStyle
 #undef REGION_CLASS
 
   else error->all(FLERR,"Unrecognized region style");

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -32,12 +32,18 @@ Region::Region(SPARTA *sparta, int, char **arg) : Pointers(sparta)
   n = strlen(arg[1]) + 1;
   style = new char[n];
   strcpy(style,arg[1]);
+
+  kokkos_flag = 0;
+  copy = copymode = 0;
+  uncopy = 1;
 }
 
 /* ---------------------------------------------------------------------- */
 
 Region::~Region()
 {
+  if (copymode) return;
+
   delete [] id;
   delete [] style;
 }

--- a/src/region.cpp
+++ b/src/region.cpp
@@ -42,7 +42,7 @@ Region::Region(SPARTA *sparta, int, char **arg) : Pointers(sparta)
 
 Region::~Region()
 {
-  if (copymode) return;
+  if (copy || copymode) return;
 
   delete [] id;
   delete [] style;

--- a/src/region.h
+++ b/src/region.h
@@ -28,7 +28,12 @@ class Region : protected Pointers {
   double extent_zlo,extent_zhi;
   int bboxflag;                     // 1 if bounding box is computable
 
+  int kokkos_flag;              // 0/1 if Kokkos region
+  int copy,uncopy,copymode;     // used by Kokkos, prevent deallocation of
+                                //  base class when child copy is destroyed
+
   Region(class SPARTA *, int, char **);
+  Region(class SPARTA *sparta) : Pointers(sparta) {} // needed for Kokkos
   virtual ~Region();
 
   // called by other classes to check point versus region

--- a/src/region_block.h
+++ b/src/region_block.h
@@ -28,9 +28,10 @@ namespace SPARTA_NS {
 class RegBlock : public Region {
  public:
   RegBlock(class SPARTA *, int, char **);
+  RegBlock(class SPARTA *sparta) : Region(sparta) {} // needed for Kokkos
   int inside(double *);
 
- private:
+ protected:
   double xlo,xhi,ylo,yhi,zlo,zhi;
 };
 

--- a/src/region_cylinder.h
+++ b/src/region_cylinder.h
@@ -28,9 +28,10 @@ namespace SPARTA_NS {
 class RegCylinder : public Region {
  public:
   RegCylinder(class SPARTA *, int, char **);
+  RegCylinder(class SPARTA *sparta) : Region(sparta) {} // needed for Kokkos
   int inside(double *);
 
- private:
+ protected:
   char axis;
   double c1,c2;
   double radius;

--- a/src/region_plane.h
+++ b/src/region_plane.h
@@ -28,9 +28,10 @@ namespace SPARTA_NS {
 class RegPlane : public Region {
  public:
   RegPlane(class SPARTA *, int, char **);
+  RegPlane(class SPARTA *sparta) : Region(sparta) {} // needed for Kokkos
   int inside(double *);
 
- private:
+ protected:
   double xp,yp,zp;
   double normal[3];
 };

--- a/src/region_sphere.h
+++ b/src/region_sphere.h
@@ -28,9 +28,10 @@ namespace SPARTA_NS {
 class RegSphere : public Region {
  public:
   RegSphere(class SPARTA *, int, char **);
+  RegSphere(class SPARTA *sparta) : Region(sparta) {} // needed for Kokkos
   int inside(double *);
 
- private:
+ protected:
   double xc,yc,zc;
   double radius;
 };


### PR DESCRIPTION
## Purpose

Add KOKKOS support for regions including `block`, `cylinder`, `plane`, and `sphere`.

The `intersect` and `union` region styles are not yet supported by KOKKOS.

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes

