### PR TITLE
Improve warning in adapt grid

### DIFF
--- a/src/adapt_grid.cpp
+++ b/src/adapt_grid.cpp
@@ -418,9 +418,15 @@ void AdaptGrid::process_args(int narg, char **arg)
   }
 
   if (maxlevel_request && maxlevel < maxlevel_request && me == 0) {
-    char str[128];
-    sprintf(str,"Reduced maxlevel because it induces "
-            "cell IDs that exceed %d bits",(int) sizeof(cellint)*8);
+    char str[256];
+#ifdef SPARTA_BIGBIG
+    sprintf(str,"Reduced maxlevel for grid adaptation from %d to %d because it induces "
+            "cell IDs that exceed %d bits",maxlevel_request,maxlevel,(int) sizeof(cellint)*8);
+#else
+    sprintf(str,"Reduced maxlevel for grid adaptation from %d to %d because it induces "
+            "cell IDs that exceed %d bits, compiling with -DSPARTA_BIGBIG may allow further adaptation"
+            ,maxlevel_request,maxlevel,(int) sizeof(cellint)*8);
+#endif
     error->warning(FLERR,str);
   }
 }


### PR DESCRIPTION
## Purpose

Improve warning in adapt grid when the requested maxlevel is too big.

Old:

```
WARNING: Reduced maxlevel because it induces cell IDs that exceed 32 bits
```

New:

```
WARNING: Reduced maxlevel for grid adaptation from 15 to 11 because it induces cell IDs that exceed 32 bits, compiling with -DSPARTA_BIGBIG may allow further adaptation (../adapt_grid.cpp:432)

WARNING: Reduced maxlevel for grid adaptation from 64 to 21 because it induces cell IDs that exceed 64 bits (../adapt_grid.cpp:432)
```

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes


