### PR TITLE
Prevent divide by zero in collide VSS `test_collision()`

### DIFF
--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -46,6 +46,7 @@ enum{CONSTANT,VARIABLE};
 #define DELTACELLCOUNT 2
 
 #define MAXLINE 1024
+#define EPSZERO 1.0e-14
 #define BIG 1.0e20
 
 /* ---------------------------------------------------------------------- */
@@ -1383,6 +1384,12 @@ int CollideVSSKokkos::test_collision_kokkos(int icell, int igroup, int jgroup,
   double dv  = vi[1] - vj[1];
   double dw  = vi[2] - vj[2];
   double vr2 = du*du + dv*dv + dw*dw;
+
+  // prevent division by zero
+
+  if (vr2 < EPSZERO && d_params(ispecies,jspecies).omega >= 1.0)
+    return 0;
+
   double vro  = pow(vr2,1.0-d_params(ispecies,jspecies).omega);
 
   // although the vremax is calcualted for the group,

--- a/src/collide_vss.cpp
+++ b/src/collide_vss.cpp
@@ -37,6 +37,7 @@ enum{NONE,DISCRETE,SMOOTH};            // several files
 enum{CONSTANT,VARIABLE};
 
 #define MAXLINE 1024
+#define EPSZERO 1.0e-14
 
 /* ---------------------------------------------------------------------- */
 
@@ -196,7 +197,13 @@ int CollideVSS::test_collision(int icell, int igroup, int jgroup,
   double dv  = vi[1] - vj[1];
   double dw  = vi[2] - vj[2];
   double vr2 = du*du + dv*dv + dw*dw;
-  double vro  = pow(vr2,1.0-params[ispecies][jspecies].omega);
+
+  // prevent division by zero
+
+  if (vr2 < EPSZERO && params[ispecies][jspecies].omega >= 1.0)
+    return 0;
+
+  double vro = pow(vr2,1.0-params[ispecies][jspecies].omega);
 
   // although the vremax is calculated for the group,
   // the individual collisions calculated species dependent vre


### PR DESCRIPTION
## Purpose

Prevent divide by zero in collide_vss `test_collision()`
Fixes #604 

## Author(s)

Stan Moore (SNL)

## Backward Compatibility

Yes


