### PR TITLE
fix_ablate: use surf_modify-assigned isc/isr instead of hardcoded index 0 for ablated surfaces

### DIFF
--- a/doc/fix_ablate.txt
+++ b/doc/fix_ablate.txt
@@ -308,6 +308,15 @@ The scalar and vector values are unitless.
 
 This fix can only be used in simulations that define implicit surfaces.
 
+All surface elements must be assigned to the same surface collision
+model and (optionally) the same surface reaction model via the
+"surf_modify"_surf_modify.html command.  This is because each ablation
+operation discards and re-creates all the implicit surface elements,
+and this fix re-assigns the same pair of models to all the new
+elements.  Assigning different models to different groups of surface
+elements is not yet supported with ablation; an error is generated if
+that is the case.
+
 [Related commands:]
 
 "read isurf"_read_isurf.html

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -455,18 +455,52 @@ void FixAblate::init()
 
   // determine default collision/reaction model indices from existing surfaces
   // these values were set by surf_modify and are used during each ablation step
-  // to correctly re-assign models to newly created implicit surfaces
+  //   to correctly re-assign models to newly created implicit surfaces
+  // implicit surfs are distributed, so allreduce the values to procs
+  //   which own no surfs now, since ablation may create surfs in their cells
+  // error if surfs are not all assigned to the same models, e.g. by
+  //   surf_modify with multiple surf groups, since create_surfs() can only
+  //   re-assign one collision/reaction model to all new surfs
 
-  if (surf->nlocal > 0) {
+  int isc_local = -1;
+  int isr_local = -1;
+  int flag = 0;
+
+  int nslocal = surf->nlocal;
+
+  if (nslocal > 0) {
     if (dim == 2) {
-      isc_default = surf->lines[0].isc;
-      isr_default = surf->lines[0].isr;
+      Surf::Line *lines = surf->lines;
+      isc_local = lines[0].isc;
+      isr_local = lines[0].isr;
+      for (int i = 1; i < nslocal; i++)
+        if (lines[i].isc != isc_local || lines[i].isr != isr_local) flag = 1;
     } else {
-      isc_default = surf->tris[0].isc;
-      isr_default = surf->tris[0].isr;
+      Surf::Tri *tris = surf->tris;
+      isc_local = tris[0].isc;
+      isr_local = tris[0].isr;
+      for (int i = 1; i < nslocal; i++)
+        if (tris[i].isc != isc_local || tris[i].isr != isr_local) flag = 1;
     }
-    if (isc_default < 0) isc_default = 0;
   }
+
+  int local_vals[2],global_vals[2];
+  local_vals[0] = isc_local;
+  local_vals[1] = isr_local;
+  MPI_Allreduce(local_vals,global_vals,2,MPI_INT,MPI_MAX,world);
+  isc_default = global_vals[0];
+  isr_default = global_vals[1];
+
+  if (nslocal > 0 && (isc_local != isc_default || isr_local != isr_default))
+    flag = 1;
+
+  int allflag;
+  MPI_Allreduce(&flag,&allflag,1,MPI_INT,MPI_MAX,world);
+  if (allflag)
+    error->all(FLERR,"Fix ablate requires all surfs be assigned "
+               "to the same surface collision and reaction models");
+
+  if (isc_default < 0) isc_default = 0;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -201,6 +201,7 @@ FixAblate::FixAblate(SPARTA *sparta, int narg, char **arg) :
   ndelete = 0;
 
   storeflag = multi_val_flag = 0;
+  isc_default = isr_default = 0;
   array_grid = cvalues = NULL;
   mvalues = NULL;
   tvalues = NULL;
@@ -451,6 +452,21 @@ void FixAblate::init()
 
   nglocal = grid->nlocal;
   grow_percell(0);
+
+  // determine default collision/reaction model indices from existing surfaces
+  // these values were set by surf_modify and are used during each ablation step
+  // to correctly re-assign models to newly created implicit surfaces
+
+  if (surf->nlocal > 0) {
+    if (dim == 2) {
+      isc_default = surf->lines[0].isc;
+      isr_default = surf->lines[0].isr;
+    } else {
+      isc_default = surf->tris[0].isc;
+      isr_default = surf->tris[0].isr;
+    }
+    if (isc_default < 0) isc_default = 0;
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -588,9 +604,9 @@ void FixAblate::create_surfs(int outflag)
   // assign surf collision/reaction models to newly created surfs
   // this assignment can be made in input script via surf_modify
   //   after implicit surfs are created
-  // for active ablation, must be re-assigned at every ablation atep
-  // for now just assume all surfs are assigned to first collide/react model
-  // NOTE: need a more flexible way to do this
+  // for active ablation, must be re-assigned at every ablation step
+  // use isc_default/isr_default which were set during init() by reading
+  //   the values surf_modify assigned to existing surfaces
 
   int nslocal = surf->nlocal;
 
@@ -598,18 +614,18 @@ void FixAblate::create_surfs(int outflag)
     Surf::Line *lines = surf->lines;
     if (surf->nsc)
       for (int i = 0; i < nslocal; i++)
-        lines[i].isc = 0;
-    if (surf->nsr)
+        lines[i].isc = isc_default;
+    if (surf->nsr && isr_default >= 0)
       for (int i = 0; i < nslocal; i++)
-        lines[i].isr = 0;
+        lines[i].isr = isr_default;
   } else {
     Surf::Tri *tris = surf->tris;
     if (surf->nsc)
       for (int i = 0; i < nslocal; i++)
-        tris[i].isc = 0;
-    if (surf->nsr)
+        tris[i].isc = isc_default;
+    if (surf->nsr && isr_default >= 0)
       for (int i = 0; i < nslocal; i++)
-        tris[i].isr = 0;
+        tris[i].isr = isr_default;
   }
 
   // watertight check can be done before surfs are mapped to grid cells

--- a/src/fix_ablate.h
+++ b/src/fix_ablate.h
@@ -64,6 +64,8 @@ class FixAblate : public Fix {
   int ncorner;
   int nmultiv;
   int sgroupbit;
+  int isc_default;        // default isc index for newly created implicit surfs
+  int isr_default;        // default isr index for newly created implicit surfs
   double thresh;
   double sum_delta;
   int ndelete;


### PR DESCRIPTION
## Purpose

fix_ablate: use surf_modify-assigned isc/isr instead of hardcoded index 0 for ablated surfaces
Fixes #612 

## Author(s)

Stan Moore (SNL) using Github Copilot (Claude Sonnet 4.6)

## Backward Compatibility

Yes

## Further Information, Files, and Links

Description from Github Copilot (Claude Sonnet 4.6):

`fix_ablate::create_surfs()` always reassigned `isc = 0` and `isr = 0` to every regenerated implicit surface, unconditionally overwriting whatever `surf_modify` had set. This means the *first* registered `surf_collide` model is always used — if that happens to be `vanish` (which sets `allowreact = 0`), all particles hitting ablated surfaces are deleted instead of reacting.

## Changes

- **`fix_ablate.h`**: Add `isc_default` / `isr_default` member fields.
- **`fix_ablate.cpp` constructor**: Initialize both to `0` (preserves prior behavior when no `surf_modify` has run).
- **`fix_ablate.cpp::init()`**: After `surf_modify` has executed, read `isc`/`isr` from the first existing surface and store into the new fields.
- **`fix_ablate.cpp::create_surfs()`**: Replace hardcoded `0` with `isc_default` / `isr_default`.

The trigger scenario:

```
surf_collide o    vanish    # index 0 — allowreact=0
surf_collide r    specular  # index 1
surf_react   sr   prob surf_react.txt
surf_modify  all  collide r react sr   # sets isc=1 on initial surfs
                                       # ...but ablation reset it to isc=0 each step
```

The code even noted this with `// NOTE: need a more flexible way to do this`; this fix resolves that known gap for the common single-group case.