### PR TITLE
Fix wildcard `*` expansion inconsistency for single-value `fix ave/grid` in `dump grid`

### DIFF
--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -549,8 +549,10 @@ int DumpGrid::parse_fields(int narg, char **arg)
         error->all(FLERR,"Dump grid fix does not compute per-grid info");
       if (argindex[i] == 0 && modify->fix[n]->size_per_grid_cols != 0)
         error->all(FLERR,"Dump grid fix does not calculate a per-grid vector");
-      if (argindex[i] > 0 && modify->fix[n]->size_per_grid_cols == 0)
-        error->all(FLERR,"Dump grid fix does not calculate per-grid array");
+      if (argindex[i] > 0 && modify->fix[n]->size_per_grid_cols == 0) {
+        if (argindex[i] == 1) argindex[i] = 0;
+        else error->all(FLERR,"Dump grid fix does not calculate per-grid array");
+      }
       if (argindex[i] > 0 && argindex[i] > modify->fix[n]->size_per_grid_cols)
         error->all(FLERR,"Dump grid fix array is accessed out-of-range");
 

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -605,8 +605,10 @@ int DumpSurf::parse_fields(int narg, char **arg)
         error->all(FLERR,"Dump surf fix does not compute per-surf info");
       if (argindex[i]== 0 && modify->fix[n]->size_per_surf_cols != 0)
         error->all(FLERR,"Dump surf fix does not compute per-surf vector");
-      if (argindex[i] > 0 && modify->fix[n]->size_per_surf_cols == 0)
-        error->all(FLERR,"Dump surf fix does not compute per-surf array");
+      if (argindex[i] > 0 && modify->fix[n]->size_per_surf_cols == 0) {
+        if (argindex[i] == 1) argindex[i] = 0;
+        else error->all(FLERR,"Dump surf fix does not compute per-surf array");
+      }
       if (argindex[i] > 0 && argindex[i] > modify->fix[n]->size_per_surf_cols)
         error->all(FLERR,"Dump surf fix array is accessed out-of-range");
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -695,13 +695,13 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                            modify->fix[ifix]->size_per_particle_cols) {
                   nmax = modify->fix[ifix]->size_per_particle_cols;
                   expandflag = 1;
-                } else if (modify->fix[ifix]->per_grid_flag &&
-                           modify->fix[ifix]->size_per_grid_cols) {
-                  nmax = modify->fix[ifix]->size_per_grid_cols;
+                } else if (modify->fix[ifix]->per_grid_flag) {
+                  nmax = modify->fix[ifix]->size_per_grid_cols ?
+                    modify->fix[ifix]->size_per_grid_cols : 1;
                   expandflag = 1;
-                } else if (modify->fix[ifix]->per_surf_flag &&
-                           modify->fix[ifix]->size_per_surf_cols) {
-                  nmax = modify->fix[ifix]->size_per_surf_cols;
+                } else if (modify->fix[ifix]->per_surf_flag) {
+                  nmax = modify->fix[ifix]->size_per_surf_cols ?
+                    modify->fix[ifix]->size_per_surf_cols : 1;
                   expandflag = 1;
                 }
               }


### PR DESCRIPTION
## Purpose

Fix wildcard `*` expansion inconsistency for single-value `fix ave/grid` in `dump grid`
Fixes #614 

## Author(s)

Stan Moore (SNL) working with Github Copilot (Claude Sonnet 4.6)

## Backward Compatibility

Yes

## Implementation Notes

From Github Copilot (Claude Sonnet 4.6):

`dump grid` inconsistently expands the `[*]` wildcard between `compute grid` and `fix ave/grid` outputs when there is only one species: `c_n[*]` correctly becomes `c_n[1]`, but `f_n[*]` stays as `f_n[*]` in column labels.

**Root cause:** `compute_grid` always sets `size_per_grid_cols = ngroup * nvalue` (≥ 1), while `fix_ave_grid` sets `size_per_grid_cols = 0` when `nvalues == 1` (vector convention). `expand_args` only expands `[*]` when `size_per_grid_cols > 0`, so single-value fixes are silently skipped. Data access happens to be correct because `atoi("*") == 0` maps to vector access — only the column label is wrong.

## Changes

- **`src/input.cpp` — `expand_args`**: For `per_grid_flag` and `per_surf_flag` fix cases, drop the `size > 0` guard. Use `nmax = size_per_grid_cols ? size_per_grid_cols : 1` so that single-value (vector) fixes expand `[*]` → `[1]`.

- **`src/dump_grid.cpp` — `parse_fields`**: When `argindex == 1` but the fix is a per-grid vector (`size_per_grid_cols == 0`), silently normalize `argindex` to `0` (vector access) instead of erroring. This makes `f_n[1]` and `f_n` equivalent for single-value fixes and preserves backward compatibility with existing scripts using bare `f_n`.

- **`src/dump_surf.cpp` — `parse_fields`**: Same normalization for per-surf vector fixes.
