### PR TITLE
Fix multiprocessing spawn start method incorrectly applied on Linux

### DIFF
--- a/tools/paraview/grid2paraview.py
+++ b/tools/paraview/grid2paraview.py
@@ -1547,10 +1547,12 @@ if __name__ == "__main__":
                                      time_steps_dict, args.paraview_output_file)
       else:
         # Use multiprocessing on other platforms
-        try:
-          mp.set_start_method('spawn', force=True)
-        except RuntimeError:
-          pass
+        # macOS requires 'spawn' start method; Linux uses the default 'fork'
+        if platform.system() == 'Darwin':
+          try:
+            mp.set_start_method('spawn', force=True)
+          except RuntimeError:
+            pass
         
         pool = mp.Pool()
         for idx, chunk in enumerate(chunking):


### PR DESCRIPTION
## Purpose

Fix multiprocessing spawn start method incorrectly applied on Linux
Fixes #589 

## Author(s)

Stan Moore (SNL) and Github Copilot (Sonnet 4.6)

## Backward Compatibility

Yes 

## Implementation Notes

Description from Copilot:

`grid2paraview.py` hangs on Linux in the 24Sep2025 release with `semaphore_tracker: process died unexpectedly` after printing the chunk count, requiring Ctrl+C to abort. The regression was introduced when an ARM64 Mac fix unconditionally forced `spawn` as the multiprocessing start method on all platforms, including Linux.

## Root cause

`mp.set_start_method('spawn', force=True)` was applied to both Linux and non-ARM64 macOS. On Linux, `spawn` creates fresh Python interpreters that cannot initialize VTK in pvpython's non-standard library environment — workers crash immediately, and `pool.join()` deadlocks. Linux requires the default `fork` method, which inherits the already-loaded VTK state from the parent pvpython process.

## Fix

Guard the `spawn` call so it only applies to macOS:

```python
# Before: forced spawn on Linux too
try:
    mp.set_start_method('spawn', force=True)
except RuntimeError:
    pass

# After: spawn only on Darwin; Linux keeps default 'fork'
if platform.system() == 'Darwin':
    try:
        mp.set_start_method('spawn', force=True)
    except RuntimeError:
        pass
```

ARM64 Mac already takes the sequential path before reaching this branch, so this change does not affect that case.

