### PR TITLE
Fixed type of parameter passed to sparta_extract_compute in Python wrapper.

### DIFF
--- a/python/sparta.py
+++ b/python/sparta.py
@@ -74,7 +74,6 @@ class sparta:
     return ptr[0]
 
   def extract_compute(self,id,style,type):
-    style = style.encode('utf-8')
     if type == 0:
       self.lib.sparta_extract_compute.restype = POINTER(c_double)
       ptr = self.lib.sparta_extract_compute(self.spa,id,style,type)


### PR DESCRIPTION
Fixed wrong parameter type. Parameter style should be an integer, but had been passed as encoded string according to function signature in library.h.

## Purpose

_Python wrapper implementation encode the parameter style as utf8 string leading to error on calling C library function sparta_extract_compute. Checking possible calls of said function in Python wrapper and comparison with function signature in library.h concludes to passing integer type instead._

## Author(s)

Daniel G.

## Backward Compatibility

No, as parameter type changed  and existing code might relied on string-based styles.

## Implementation Notes

Removed code to convert parameter before passing. Type check and enforced conversion to integer might be of use.

## Post Submission Checklist

Please check the fields below as they are completed
- [x] The feature or features in this pull request is complete
- [X] Suitable new documentation files and/or updates to the existing docs are included
- [X] One or more example input decks are included
- [X] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

None.

## Changes

**python/sparta.py**: Removed 
```
style = style.encode('utf-8')
```