### PR TITLE
Fix Python wrapper types at the SPARTA library boundary

### DIFF
--- a/python/examples/demo.py
+++ b/python/examples/demo.py
@@ -27,23 +27,23 @@ spa = sparta()
 
 # test out various library functions after running in.demo
 
-spa.file(b"in.demo")
+spa.file("in.demo")
 
 if me == 0: print("\nPython output:")
 
-nparticles = spa.extract_global(b"nplocal",0)
-dt = spa.extract_global(b"dt",1)
-fnum = spa.extract_global(b"fnum",1)
+nparticles = spa.extract_global("nplocal",0)
+dt = spa.extract_global("dt",1)
+fnum = spa.extract_global("fnum",1)
 print("Nparticles, dt, fnum =",nparticles,dt,fnum)
 
-temp = spa.extract_compute(b"temp",0,0)
+temp = spa.extract_compute("temp",0,0)
 print("Temperature from compute =",temp)
 
-lx = spa.extract_variable(b"lx",0)
+lx = spa.extract_variable("lx",0)
 print("Box-length lx from equal-style variable =",lx)
 
-xc = spa.extract_variable(b"xc",1)
-vy = spa.extract_variable(b"vy",1)
+xc = spa.extract_variable("xc",1)
+vy = spa.extract_variable("vy",1)
 print("X coord from particle-style variable =",xc[0],xc[nparticles-1])
 print("Vy component coord from particle-style variable =",vy[0],vy[nparticles-1])
 

--- a/python/examples/trivial.py
+++ b/python/examples/trivial.py
@@ -12,7 +12,7 @@ import sys
 
 argv = sys.argv
 if len(argv) != 2:
-  print "Syntax: trivial.py in.sparta"
+  print("Syntax: trivial.py in.sparta")
   sys.exit()
 
 infile = sys.argv[1]

--- a/python/sparta.py
+++ b/python/sparta.py
@@ -74,7 +74,7 @@ class sparta:
     return ptr[0]
 
   def extract_compute(self,id,style,type):
-    style = style.encode('utf-8')
+    id = id.encode('utf-8')
     if type == 0:
       self.lib.sparta_extract_compute.restype = POINTER(c_double)
       ptr = self.lib.sparta_extract_compute(self.spa,id,style,type)

--- a/tools/pizza/dump.py
+++ b/tools/pizza/dump.py
@@ -262,7 +262,7 @@ class dump:
 
     # sort entries by timestep, cull duplicates
 
-    self.snaps.sort(self.compare_time)
+    self.snaps.sort(key=lambda x: x.time)
     self.cull()
     self.nsnaps = len(self.snaps)
     print("read %d snapshots" % self.nsnaps)

--- a/tools/pizza/sdata.py
+++ b/tools/pizza/sdata.py
@@ -495,7 +495,7 @@ class sdata:
   # create a custom 3d surf from list of points and lines
 
   def surf3d(self,id,plist,tlist):
-    if self.ids.has_key(id): raise Exception("ID %s is already in use" % id)
+    if id in self.ids: raise Exception("ID %s is already in use" % id)
     if self.dim == 2: raise Exception("cannot have both 2d/3d surfs")
     self.dim = 3
 
@@ -657,7 +657,7 @@ class sdata:
   # refine surf to form a new surf with lines/tris <= size
 
   def refine(self,id,size):
-    if not self.ids.has_key(id):
+    if id not in self.ids:
       raise Exception("ID %s is not defined" % id)
 
     surf = self.surfs[self.ids[id]]


### PR DESCRIPTION
## Purpose

Fix Python wrapper types at the SPARTA library boundary

## Author(s)

Stan Moore (SNL) and Claude Code (Opus 4.8)

## Backward Compatibility

Yes

## Implementation Notes

Description from Claude:

extract_compute() encoded the int `style` argument as a UTF-8 string
(raising AttributeError on the int, and passing the wrong type for the
C signature `sparta_extract_compute(void*, char*, int, int)`), while
leaving the `char *id` argument as a Python str. Without argtypes set,
ctypes converts a str to wchar_t*, so the id reached the C side garbled
and find_compute() would fail. Encode `id` instead of `style`.

PR #630 removed the bogus `style.encode()` but did not add the missing
`id` encoding, so extract_compute() was still broken; this completes it.

Also fix python/examples/demo.py, which passed bytes literals (b"...")
into wrapper methods that call .encode('utf-8'); that raises
AttributeError on Python 3. Pass plain strings, matching the documented
interface (doc/Section_python.txt) and the file()/command() convention.

