### PR TITLE
Collected Small Changes 

### DIFF
--- a/doc/surf_react_adsorb.html
+++ b/doc/surf_react_adsorb.html
@@ -40,7 +40,21 @@
 <LI>temp = temperature of the surface
 n_sites = # of available adsorption sites per unit area (3D) or length (2D) 
 
-<LI>adsp1,adsp2,... = list of species that can adsorb on surface 
+<LI>adsp1,adsp2,... = list of species that can adsorb on surface
+
+
+</UL>
+<P>The reaction file(s) read by this command can also include the optional
+per-reaction keywords <I>kisliuk</I> and <I>energy</I>, which modify how the
+reaction rate constant is computed.  See the discussion of the reaction
+file format below for details.
+</P>
+<UL><LI><I>kisliuk</I> = scale the adsorption rate constant by the Kisliuk
+  precursor-mediated sticking factor (only for adsorption reactions: AA,
+  DA, LH1, LH3, CD)
+
+<LI><I>energy</I> = scale the rate constant by an incident-energy and
+  angle-dependent factor (only for CI)
 
 
 </UL>

--- a/doc/surf_react_adsorb.html
+++ b/doc/surf_react_adsorb.html
@@ -40,7 +40,7 @@
 <LI>temp = temperature of the surface
 n_sites = # of available adsorption sites per unit area (3D) or length (2D) 
 
-<LI>adsp1,adsp2,... = list of species that can adsorb on surface
+<LI>adsp1,adsp2,... = list of species that can adsorb on surface 
 
 
 </UL>
@@ -51,10 +51,10 @@ file format below for details.
 </P>
 <UL><LI><I>kisliuk</I> = scale the adsorption rate constant by the Kisliuk
   precursor-mediated sticking factor (only for adsorption reactions: AA,
-  DA, LH1, LH3, CD)
+  DA, LH1, LH3, CD) 
 
 <LI><I>energy</I> = scale the rate constant by an incident-energy and
-  angle-dependent factor (only for CI)
+  angle-dependent factor (only for CI) 
 
 
 </UL>

--- a/doc/surf_react_adsorb.txt
+++ b/doc/surf_react_adsorb.txt
@@ -30,6 +30,18 @@ n_sites = # of available adsorption sites per unit area (3D) or length (2D) :l
 adsp1,adsp2,... = list of species that can adsorb on surface :l
 :ule
 
+The reaction file(s) read by this command can also include the optional
+per-reaction keywords {kisliuk} and {energy}, which modify how the
+reaction rate constant is computed.  See the discussion of the reaction
+file format below for details.
+
+{kisliuk} = scale the adsorption rate constant by the Kisliuk
+  precursor-mediated sticking factor (only for adsorption reactions: AA,
+  DA, LH1, LH3, CD) :ulb,l
+{energy} = scale the rate constant by an incident-energy and
+  angle-dependent factor (only for CI) :l
+:ule
+
 [Examples:]
 
 surf_react adsorb gs gs_react.surf nsync 10 surf 1000 6.022e18 O CO

--- a/examples/surf_collide/in.beam.adiabatic
+++ b/examples/surf_collide/in.beam.adiabatic
@@ -28,7 +28,7 @@ mixture             air O frac 0.2
 surf_collide        1 adiabatic
 bound_modify        zlo collide 1
 
-region              circle cylinder z 0 -10 1 -INF INF
+region              circle cylinder z 0 -10 1 INF INF
 fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
 
 #dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 

--- a/examples/surf_collide/in.beam.cll
+++ b/examples/surf_collide/in.beam.cll
@@ -28,7 +28,7 @@ mixture             air O frac 0.2
 surf_collide        1 cll 300.0 0.8 0.8 0.8 0.8 #partial 0.5 
 bound_modify        zlo collide 1
 
-region              circle cylinder z 0 -10 1 -INF INF
+region              circle cylinder z 0 -10 1 INF INF
 fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
 
 #dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 

--- a/examples/surf_collide/in.beam.diffuse
+++ b/examples/surf_collide/in.beam.diffuse
@@ -28,7 +28,7 @@ mixture             air O frac 0.2
 surf_collide        1 diffuse 300 0.5
 bound_modify        zlo collide 1
 
-region              circle cylinder z 0 -10 1 -INF INF
+region              circle cylinder z 0 -10 1 INF INF
 fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
 
 #dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 

--- a/examples/surf_collide/in.beam.impulsive
+++ b/examples/surf_collide/in.beam.impulsive
@@ -30,7 +30,7 @@ surf_collide        1 impulsive 1000.0 softsphere 0.2 50 2000 60 5 75 #double 10
 
 bound_modify        zlo collide 1
 
-region              circle cylinder z 0 -10 1 -INF INF
+region              circle cylinder z 0 -10 1 INF INF
 fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
 
 #dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 

--- a/examples/surf_collide/in.beam.specular
+++ b/examples/surf_collide/in.beam.specular
@@ -28,7 +28,7 @@ mixture             air O frac 0.2
 surf_collide        1 specular
 bound_modify        zlo collide 1
 
-region              circle cylinder z 0 -10 1 -INF INF
+region              circle cylinder z 0 -10 1 INF INF
 fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
 
 #dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 

--- a/examples/surf_collide/in.beam.td
+++ b/examples/surf_collide/in.beam.td
@@ -32,7 +32,7 @@ surf_collide	    1 td 1000.0 #barrier 1000
 
 bound_modify        zlo collide 1
 
-region              circle cylinder z 0 -10 1 -INF INF
+region              circle cylinder z 0 -10 1 INF INF
 fix                 in emit/face/file air zhi data.beam beam_area nevery 100 region circle
 
 #dump                2 image all 10 image.*.ppm type type pdiam 0.2 surf proc 0.01 size 512 512 zoom 1.75 gline no 0.005 

--- a/examples/surf_react_adsorb/in.beam.face.gs
+++ b/examples/surf_react_adsorb/in.beam.face.gs
@@ -47,7 +47,7 @@ bound_modify        zlo react adsorb_test_gs2
 ########################## BEAM ############################################################
 # Beam at multiple points so that different processors handle the surface collisions
 
-region              circle1 cylinder z  0 -10 1 -INF INF
+region              circle1 cylinder z  0 -10 1 INF INF
 
 fix                 in1 emit/face/file air zhi data.beam beam_area_1 nevery 100 region circle1
 

--- a/examples/surf_react_adsorb/in.beam.face.gs_ps
+++ b/examples/surf_react_adsorb/in.beam.face.gs_ps
@@ -47,7 +47,7 @@ bound_modify        zlo react adsorb_test_gs_ps2
 ########################## BEAM ############################################################
 # Beam at multiple points so that different processors handle the surface collisions
 
-region              circle1 cylinder z  0 -10 1 -INF INF
+region              circle1 cylinder z  0 -10 1 INF INF
 
 fix                 in1 emit/face/file air zhi data.beam beam_area_1 nevery 100 region circle1
 

--- a/examples/surf_react_adsorb/in.beam.face.ps
+++ b/examples/surf_react_adsorb/in.beam.face.ps
@@ -47,7 +47,7 @@ bound_modify        zlo react adsorb_test_ps2
 ########################## BEAM ############################################################
 # Beam at multiple points so that different processors handle the surface collisions
 
-region              circle1 cylinder z  0 -10 1 -INF INF
+region              circle1 cylinder z  0 -10 1 INF INF
 
 fix                 in1 emit/face/file air zhi data.beam beam_area_1 nevery 100 region circle1
 

--- a/examples/surf_react_adsorb/in.beam.surf.gs
+++ b/examples/surf_react_adsorb/in.beam.surf.gs
@@ -46,8 +46,8 @@ surf_modify 		all collide 1 react adsorb_test_gs2
 ########################## BEAM ############################################################
 # Beam at multiple points so that different processors handle the surface collisions
 
-region              circle2 cylinder z  6 -10 1 -INF INF
-region              circle3 cylinder z -6 -10 1 -INF INF
+region              circle2 cylinder z  6 -10 1 INF INF
+region              circle3 cylinder z -6 -10 1 INF INF
 
 fix                 in2 emit/face/file air zhi data.beam beam_area_2 nevery 100 region circle2
 fix                 in3 emit/face/file air zhi data.beam beam_area_3 nevery 100 region circle3

--- a/examples/surf_react_adsorb/in.beam.surf.gs_ps
+++ b/examples/surf_react_adsorb/in.beam.surf.gs_ps
@@ -46,8 +46,8 @@ surf_modify 		all collide 1 react adsorb_test_gs_ps2
 ########################## BEAM ############################################################
 # Beam at multiple points so that different processors handle the surface collisions
 
-region              circle2 cylinder z  6 -10 1 -INF INF
-region              circle3 cylinder z -6 -10 1 -INF INF
+region              circle2 cylinder z  6 -10 1 INF INF
+region              circle3 cylinder z -6 -10 1 INF INF
 
 fix                 in2 emit/face/file air zhi data.beam beam_area_2 nevery 100 region circle2
 fix                 in3 emit/face/file air zhi data.beam beam_area_3 nevery 100 region circle3

--- a/examples/surf_react_adsorb/in.beam.surf.ps
+++ b/examples/surf_react_adsorb/in.beam.surf.ps
@@ -46,8 +46,8 @@ surf_modify 		all collide 1 react adsorb_test_ps2
 ########################## BEAM ############################################################
 # Beam at multiple points so that different processors handle the surface collisions
 
-region              circle2 cylinder z  6 -10 1 -INF INF
-region              circle3 cylinder z -6 -10 1 -INF INF
+region              circle2 cylinder z  6 -10 1 INF INF
+region              circle3 cylinder z -6 -10 1 INF INF
 
 fix                 in2 emit/face/file air zhi data.beam beam_area_2 nevery 100 region circle2
 fix                 in3 emit/face/file air zhi data.beam beam_area_3 nevery 100 region circle3

--- a/python/sparta.py
+++ b/python/sparta.py
@@ -22,13 +22,28 @@ class sparta:
 
     # load libsparta.so by default
     # if name = "g++", load libsparta_g++.so
+    # the shared library extension is platform-dependent:
+    #   .so on Linux, .dylib on macOS, .dll on Windows
+    # try the native extension first, then fall back to the others
+    # so a library built with any naming convention can still be found
 
-    try:
-      if not name: self.lib = CDLL("libsparta.so",RTLD_GLOBAL)
-      else: self.lib = CDLL("libsparta_%s.so" % name,RTLD_GLOBAL)
-    except:
-      type,value,tb = sys.exc_info()
-      traceback.print_exception(type,value,tb)
+    if sys.platform == "darwin": exts = [".dylib",".so"]
+    elif sys.platform.startswith("win"): exts = [".dll",".so"]
+    else: exts = [".so",".dylib"]
+
+    if not name: stem = "libsparta"
+    else: stem = "libsparta_%s" % name
+
+    self.lib = None
+    for ext in exts:
+      try:
+        self.lib = CDLL(stem + ext,RTLD_GLOBAL)
+        break
+      except:
+        type,value,tb = sys.exc_info()
+        last_exc = (type,value,tb)
+    if self.lib is None:
+      traceback.print_exception(*last_exc)
       raise Exception("Could not load SPARTA dynamic library")
 
     # create an instance of SPARTA
@@ -49,7 +64,7 @@ class sparta:
       # self.spa = self.lib.sparta_open_no_mpi(0,None)
 
   def __del__(self):
-    if self.spa: self.lib.sparta_close(self.spa)
+    if getattr(self,"spa",None): self.lib.sparta_close(self.spa)
 
   def close(self):
     self.lib.sparta_close(self.spa)

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -282,6 +282,16 @@ void CollideVSSKokkos::init()
                  "electrons be their own group");
   }
 
+  // warn if ambipolar and a single group (e.g. collide ... all)
+  // the light electrons inflate the single-group vremax, so many more
+  //   collision attempts are made than with a per-species grouping
+  // grouping electrons separately (e.g. collide ... species) is far faster
+
+  if (ambiflag && mixture->ngroup == 1)
+    error->warning(FLERR,"Single-group ambipolar collisions are inefficient; "
+                   "grouping electrons separately (e.g. collide ... species) "
+                   "is recommended");
+
   // vre_next = next timestep to zero vremax & remain, based on vre_every
 
   if (vre_every) vre_next = (update->ntimestep/vre_every)*vre_every + vre_every;

--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -211,8 +211,12 @@ void SurfCollideDiffuseKokkos::dynamic()
 
     if (surf->estatus[tindex_custom] == 0) surf->spread_custom(tindex_custom);
 
-    h_edvec_local[tindex_custom].k_view.sync_device();
-    d_t_persurf = h_edvec_local[tindex_custom].k_view.view_device();
+    // edvec_local is indexed by the per-type slot ewhich[tindex_custom],
+    //  not by the global custom index tindex_custom (see Surf::add_custom)
+
+    int ewhich = surf->ewhich[tindex_custom];
+    h_edvec_local[ewhich].k_view.sync_device();
+    d_t_persurf = h_edvec_local[ewhich].k_view.view_device();
   }
 }
 

--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -310,6 +310,16 @@ void Collide::init()
                  "electrons be their own group");
   }
 
+  // warn if ambipolar and a single group (e.g. collide ... all)
+  // the light electrons inflate the single-group vremax, so many more
+  //   collision attempts are made than with a per-species grouping
+  // grouping electrons separately (e.g. collide ... species) is far faster
+
+  if (ambiflag && mixture->ngroup == 1)
+    error->warning(FLERR,"Single-group ambipolar collisions are inefficient; "
+                   "grouping electrons separately (e.g. collide ... species) "
+                   "is recommended");
+
   // vre_next = next timestep to zero vremax & remain, based on vre_every
 
   if (vre_every) vre_next = (update->ntimestep/vre_every)*vre_every + vre_every;

--- a/src/create_isurf.cpp
+++ b/src/create_isurf.cpp
@@ -39,6 +39,7 @@ using namespace MathConst;
 #define DELTASEND 1024
 #define EPSILON_GRID 1.0e-3
 #define EPSILON 1.0e-4
+#define SMALL 1.0e-6              // roundoff tolerance for corner-value bounds checks
 
 enum{CVAL,SVAL,IVAL,INVAL};
 enum{XLO,XHI,YLO,YHI,ZLO,ZHI,INTERIOR};         // same as Domain
@@ -1553,8 +1554,13 @@ void CreateISurf::set_cvalues_voxel()
     dz = cells[icell].hi[2] - cells[icell].lo[2];
     sfrac = (dx*dy*dz - cvol) / (dx*dy*dz);
 
-    if (sfrac < 0.0 || sfrac > 1.0)
+    // use a small tolerance so that a cell which is essentially fully solid
+    // or fully open is not rejected due to floating-point roundoff in the
+    // clipped volume; genuine errors still fall well outside [0,1]
+
+    if (sfrac < 0.0 - SMALL || sfrac > 1.0 + SMALL)
       error->one(FLERR,"Calculated solid fraction above one or negative");
+    sfrac = MIN(MAX(sfrac,0.0),1.0);
 
     for (int ic = 0; ic < ncorner; ic++)
       tmp_cvalues[icell][ic] = MIN(MAX(sfrac*cin,0.0),255.0);
@@ -1594,8 +1600,13 @@ void CreateISurf::set_cvalues_ave()
         if (nval == 0) tmp_cvalues[icell][ic] = cin;
         else {
           ivalsum /= nval;
-          if (ivalsum > 1.0)
+
+          // tolerate roundoff so an averaged location that lands exactly on
+          // the cell boundary is not rejected; clamp before use
+
+          if (ivalsum > 1.0 + SMALL)
             error->one(FLERR,"Calculated vertex location outside cell");
+          ivalsum = MIN(ivalsum,1.0);
           tmp_cvalues[icell][ic] = MAX(param2cval(ivalsum,0.0),0.0);
         }
       } // end svalues

--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -803,14 +803,18 @@ void DumpGrid::pack_custom(int n)
     if (grid->esize[index] == 0) {
       int *vector = grid->eivec[grid->ewhich[index]];
       for (int i = 0; i < ncpart; i++) {
-        buf[n] = vector[cpart[i]];
+        // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+        // INT columns via ubuf(buf[m]).i. Numeric storage made every INT
+        // custom attribute print as 0 (low 32 bits of IEEE-754 double).
+        buf[n] = ubuf(vector[cpart[i]]).d;
         n += size_one;
       }
     } else {
       int icol = argindex[n]-1;
       int **array = grid->eiarray[grid->ewhich[index]];
       for (int i = 0; i < ncpart; i++) {
-        buf[n] = array[cpart[i]][icol];
+        // see comment above: bit-punned encoding required for INT decode
+        buf[n] = ubuf(array[cpart[i]][icol]).d;
         n += size_one;
       }
     }

--- a/src/dump_particle.cpp
+++ b/src/dump_particle.cpp
@@ -1263,14 +1263,18 @@ void DumpParticle::pack_custom(int n)
     if (particle->esize[index] == 0) {
       int *vector = particle->eivec[particle->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = vector[clist[i]];
+        // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+        // INT columns via ubuf(buf[m]).i. Numeric storage made every INT
+        // custom attribute print as 0 (low 32 bits of IEEE-754 double).
+        buf[n] = ubuf(vector[clist[i]]).d;
         n += size_one;
       }
     } else {
       int icol = argindex[n]-1;
       int **array = particle->eiarray[particle->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = array[clist[i]][icol];
+        // see comment above: bit-punned encoding required for INT decode
+        buf[n] = ubuf(array[clist[i]][icol]).d;
         n += size_one;
       }
     }
@@ -1337,13 +1341,14 @@ void DumpParticle::pack_cellid(int n)
   Particle::OnePart *particles = particle->particles;
   Grid::ChildCell *cells = grid->cells;
 
-  // NOTE: cellint (bigint) won't fit in double in some cases
-
   int icell;
 
   for (int i = 0; i < nchoose; i++) {
     icell = particles[clist[i]].icell;
-    buf[n] = cells[icell].id;
+    // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+    // the cellid column via ubuf(buf[m]).i (vtype INT/BIGINT). Numeric storage
+    // printed 0/garbage and could not hold a cellint that overflows a double.
+    buf[n] = ubuf(cells[icell].id).d;
     n += size_one;
   }
 }

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -817,14 +817,18 @@ void DumpSurf::pack_custom(int n)
     if (surf->esize[index] == 0) {
       int *vector = surf->eivec[surf->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = vector[clocal[i]];
+        // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+        // INT columns via ubuf(buf[m]).i. Numeric storage made every INT
+        // custom attribute print as 0 (low 32 bits of IEEE-754 double).
+        buf[n] = ubuf(vector[clocal[i]]).d;
         n += size_one;
       }
     } else {
       int icol = argindex[n]-1;
       int **array = surf->eiarray[surf->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = array[clocal[i]][icol];
+        // see comment above: bit-punned encoding required for INT decode
+        buf[n] = ubuf(array[clocal[i]][icol]).d;
         n += size_one;
       }
     }

--- a/src/mixture.cpp
+++ b/src/mixture.cpp
@@ -26,6 +26,7 @@
 using namespace SPARTA_NS;
 
 #define DELTA 8
+#define SMALL 1.0e-6
 
 /* ---------------------------------------------------------------------- */
 
@@ -287,7 +288,10 @@ int Mixture::init_fraction(int *fflag, double *fuser, double *f, double *c)
     else nimplicit++;
   }
 
-  if (sum > 1.0) return 1;
+  // use a small tolerance so that fractions which sum to 1.0 are not
+  // rejected due to order-dependent floating-point roundoff in the sum above
+
+  if (sum > 1.0 + SMALL) return 1;
 
   // fraction for each unset species = equal portion of unset remainder
   // cummulative = cummulative fraction across species

--- a/src/region_block.cpp
+++ b/src/region_block.cpp
@@ -16,6 +16,7 @@
 #include "string.h"
 #include "region_block.h"
 #include "domain.h"
+#include "input.h"
 #include "error.h"
 
 using namespace SPARTA_NS;
@@ -30,19 +31,19 @@ RegBlock::RegBlock(SPARTA *sparta, int narg, char **arg) :
   options(narg-8,&arg[8]);
 
   if (strcmp(arg[2],"INF") == 0) xlo = -BIG;
-  else xlo = atof(arg[2]);
+  else xlo = input->numeric(FLERR,arg[2]);
   if (strcmp(arg[3],"INF") == 0) xhi = BIG;
-  else xhi = atof(arg[3]);
+  else xhi = input->numeric(FLERR,arg[3]);
 
   if (strcmp(arg[4],"INF") == 0) ylo = -BIG;
-  else ylo = atof(arg[4]);
+  else ylo = input->numeric(FLERR,arg[4]);
   if (strcmp(arg[5],"INF") == 0) yhi = BIG;
-  else yhi = atof(arg[5]);
+  else yhi = input->numeric(FLERR,arg[5]);
 
   if (strcmp(arg[6],"INF") == 0) zlo = -BIG;
-  else zlo = atof(arg[6]);
+  else zlo = input->numeric(FLERR,arg[6]);
   if (strcmp(arg[7],"INF") == 0) zhi = BIG;
-  else zhi = atof(arg[7]);
+  else zhi = input->numeric(FLERR,arg[7]);
 
   // error check
 

--- a/src/region_cylinder.cpp
+++ b/src/region_cylinder.cpp
@@ -16,6 +16,7 @@
 #include "stdlib.h"
 #include "string.h"
 #include "region_cylinder.h"
+#include "input.h"
 #include "error.h"
 
 using namespace SPARTA_NS;
@@ -33,14 +34,14 @@ RegCylinder::RegCylinder(SPARTA *sparta, int narg, char **arg) :
     error->all(FLERR,"Illegal region cylinder command");
 
   axis = arg[2][0];
-  c1 = atof(arg[3]);
-  c2 = atof(arg[4]);
-  radius = atof(arg[5]);
+  c1 = input->numeric(FLERR,arg[3]);
+  c2 = input->numeric(FLERR,arg[4]);
+  radius = input->numeric(FLERR,arg[5]);
 
   if (strcmp(arg[6],"INF") == 0) lo = -BIG;
-  else lo = atof(arg[6]);
+  else lo = input->numeric(FLERR,arg[6]);
   if (strcmp(arg[7],"INF") == 0) hi = BIG;
-  else hi = atof(arg[7]);
+  else hi = input->numeric(FLERR,arg[7]);
 
   // error check
 

--- a/src/region_plane.cpp
+++ b/src/region_plane.cpp
@@ -16,6 +16,7 @@
 #include "stdlib.h"
 #include "string.h"
 #include "region_plane.h"
+#include "input.h"
 #include "error.h"
 
 using namespace SPARTA_NS;
@@ -27,12 +28,12 @@ RegPlane::RegPlane(SPARTA *sparta, int narg, char **arg) :
 {
   options(narg-8,&arg[8]);
 
-  xp = atof(arg[2]);
-  yp = atof(arg[3]);
-  zp = atof(arg[4]);
-  normal[0] = atof(arg[5]);
-  normal[1] = atof(arg[6]);
-  normal[2] = atof(arg[7]);
+  xp = input->numeric(FLERR,arg[2]);
+  yp = input->numeric(FLERR,arg[3]);
+  zp = input->numeric(FLERR,arg[4]);
+  normal[0] = input->numeric(FLERR,arg[5]);
+  normal[1] = input->numeric(FLERR,arg[6]);
+  normal[2] = input->numeric(FLERR,arg[7]);
 
   // enforce unit normal
 

--- a/src/region_sphere.cpp
+++ b/src/region_sphere.cpp
@@ -16,6 +16,7 @@
 #include "stdlib.h"
 #include "string.h"
 #include "region_sphere.h"
+#include "input.h"
 #include "error.h"
 
 using namespace SPARTA_NS;
@@ -27,10 +28,10 @@ RegSphere::RegSphere(SPARTA *sparta, int narg, char **arg) :
 {
   options(narg-6,&arg[6]);
 
-  xc = atof(arg[2]);
-  yc = atof(arg[3]);
-  zc = atof(arg[4]);
-  radius = atof(arg[5]);
+  xc = input->numeric(FLERR,arg[2]);
+  yc = input->numeric(FLERR,arg[3]);
+  zc = input->numeric(FLERR,arg[4]);
+  radius = input->numeric(FLERR,arg[5]);
 
   // error check
 

--- a/src/surf_collide.cpp
+++ b/src/surf_collide.cpp
@@ -230,7 +230,11 @@ void SurfCollide::dynamic()
     //   surfs are distributed and load balance/adaptation took place
 
     if (surf->estatus[tindex_custom] == 0) surf->spread_custom(tindex_custom);
-    t_persurf = surf->edvec_local[tindex_custom];
+
+    // edvec_local is indexed by the per-type slot ewhich[tindex_custom],
+    //  not by the global custom index tindex_custom (see Surf::add_custom)
+
+    t_persurf = surf->edvec_local[surf->ewhich[tindex_custom]];
   }
 }
 

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -42,6 +42,8 @@ using namespace MathConst;
 enum{NONE,DISCRETE,SMOOTH};
 enum{NUMERIC,CUSTOM,VARIABLE,VAREQUAL,VARSURF};   // surf_collide classes
 
+#define SMALL 1.0e-6              // roundoff tolerance for summed-fraction check
+
 /* ---------------------------------------------------------------------- */
 
 SurfCollideImpulsive::SurfCollideImpulsive(SPARTA *sparta, int narg, char **arg) :
@@ -121,7 +123,7 @@ SurfCollideImpulsive::SurfCollideImpulsive(SPARTA *sparta, int narg, char **arg)
       if (vib_frac < 0.0 || vib_frac > 1.0 )
         error->all(FLERR,"Illegal surf_collide impulsive internal energy "
                    "vibrational fraction");
-      if (rot_frac + vib_frac > 1.0)
+      if (rot_frac + vib_frac > 1.0 + SMALL)
         error->all(FLERR,"Illegal surf_collide impulsive internal energy "
                    "rot-vib fraction sum");
       iarg += 3;

--- a/src/surf_react_global.cpp
+++ b/src/surf_react_global.cpp
@@ -24,6 +24,8 @@
 
 using namespace SPARTA_NS;
 
+#define SMALL 1.0e-6              // roundoff tolerance for summed-probability check
+
 /* ---------------------------------------------------------------------- */
 
 SurfReactGlobal::SurfReactGlobal(SPARTA *sparta, int narg, char **arg) :
@@ -34,7 +36,7 @@ SurfReactGlobal::SurfReactGlobal(SPARTA *sparta, int narg, char **arg) :
   prob_destroy = input->numeric(FLERR,arg[2]);
   prob_create = input->numeric(FLERR,arg[3]);
 
-  if (prob_destroy + prob_create > 1.0)
+  if (prob_destroy + prob_create > 1.0 + SMALL)
     error->all(FLERR,"Illegal surf_react global command");
 
   // setup the reaction tallies

--- a/src/surf_react_prob.cpp
+++ b/src/surf_react_prob.cpp
@@ -33,6 +33,7 @@ enum{SIMPLE};
 #define MAXCOEFF 2
 
 #define MAXLINE 1024
+#define SMALL 1.0e-6              // roundoff tolerance for summed-probability check
 #define DELTALIST 16
 
 /* ---------------------------------------------------------------------- */
@@ -283,7 +284,11 @@ void SurfReactProb::init_reactions()
     sum = 0.0;
     for (int j = 0; j < reactions[i].n; j++)
       sum += rlist[reactions[i].list[j]].coeff[0];
-    if (sum > 1.0)
+
+    // tolerate order-dependent roundoff in the running sum so that
+    // probabilities specified to total 1.0 are not falsely rejected
+
+    if (sum > 1.0 + SMALL)
       error->all(FLERR,"Surface reaction probability for a species > 1.0");
   }
 }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -538,9 +538,10 @@ template < int DIM, int SURF, int OPT > void Update::move()
 
           // particle outside ghost grid halo must use standard move
 
-          if (grid->hash->find(cellIdx) != grid->hash->end()) {
+          Grid::MyHash::iterator hashptr = grid->hash->find(cellIdx);
+          if (hashptr != grid->hash->end()) {
 
-            int icell = (*(grid->hash))[cellIdx];
+            int icell = hashptr->second;
 
             // reset particle cell and coordinates
 

--- a/tools/paraview/grid2paraview.py
+++ b/tools/paraview/grid2paraview.py
@@ -1174,7 +1174,7 @@ def write_pvd_file(time_steps_dict, file_name, num_chunks):
           read_array_names(afh, array_names)
           afh.close()
         except IOError:
-          print("Unable to open SPARTA result file: ", f)
+          print("Unable to open SPARTA result file: ", file_list[0])
           return
       write_pvtu_file(array_names, file_name, num_chunks, time)
   fh.write('   </Collection>    \n')
@@ -1200,8 +1200,12 @@ def write_pvtu_file(array_names, output_file, num_chunks, time):
   fh.write('</PPoints>\n')
 
   for chunk_id in range(num_chunks):
-    fh.write('<Piece Source="' + output_file + '_' + str(chunk_id) + '_' + \
-      str(time) + '.vtu"/>\n')
+    piece_name = output_file + '_' + str(chunk_id) + '_' + str(time) + '.vtu'
+    # Only reference pieces that were actually written. An empty chunk
+    # produces no .vtu file, and referencing a missing piece causes ParaView
+    # to fail reading the dataset.
+    if os.path.isfile(os.path.join(output_file, piece_name)):
+      fh.write('<Piece Source="' + piece_name + '"/>\n')
 
   fh.write('</PUnstructuredGrid>\n')
   fh.write('</VTKFile>\n')
@@ -1223,7 +1227,7 @@ def write_slice_pvd_file(time_steps_dict, output_file):
         try:
           afh = open(file_list[0], "r")
         except IOError:
-          print("Unable to open SPARTA result file: ", f)
+          print("Unable to open SPARTA result file: ", file_list[0])
           return
       else:
           return
@@ -1555,12 +1559,18 @@ if __name__ == "__main__":
             pass
         
         pool = mp.Pool()
+        async_results = []
         for idx, chunk in enumerate(chunking):
-          pool.apply_async(create_and_write_grid_chunk, \
+          async_results.append(pool.apply_async(create_and_write_grid_chunk, \
                            args=(idx, chunk, len(chunking), grid_desc, \
-                                 time_steps_dict, args.paraview_output_file, ))
+                                 time_steps_dict, args.paraview_output_file, )))
         pool.close()
         pool.join()
+        # Surface any exception raised in a worker process. Without this,
+        # apply_async results are discarded and a failed chunk is silently
+        # skipped, leaving a missing/partial .vtu that ParaView cannot read.
+        for res in async_results:
+          res.get()
     else:
       pd = {}
       if local_proc_id == 0:


### PR DESCRIPTION
## Purpose

Branch of collected small changes, e.g. bugfixes, documentation updates, etc.

- Add warning when using ambipolar with "all", fixes #8
- Improve documentation for surf react adsorb `kisliuk` option, fixes #427
- Error out on invalid numeric input to `region` command, fixes #92
- Harden grid2paraview.py error handling, fixes #328
- Fix false roundoff aborts in fraction/probability bounds checks, fixes #591, fixes #563
- Fix SPARTA Python wrapper to load .dylib on macOS (and .dll on Windows), fixes #571
- Fix segfault in surf_collide CUSTOM per-surf temperature, fixes #641
- Fix INT custom/cellID attributes written as 0 in dump surf/grid/particle, fixes #640
- Update: avoid double hash lookup in CPU `optmove` fast path

## Author(s)

Stan Moore (SNL) and Claude Code (Opus 4.8)

## Backward Compatibility

Yes

