### PR TITLE
Allow ambipolar ions as third bodies in dissociation/recombination (issue #176)

### DIFF
--- a/doc/react.txt
+++ b/doc/react.txt
@@ -290,7 +290,14 @@ Ambipolar dissociation reactions must list their reactants and
 products in one of the following orders:
 
 AB + e -> A + e + B
-AB+ + e -> A+ + e + B :pre
+AB+ + e -> A+ + e + B
+AB + C+ -> A + C+ + B
+AB+ + C+ -> A+ + C+ + B :pre
+
+In the last two forms an ambipolar ion C+ acts as an inert third
+body (collision partner).  As with the electron "e", the third body
+must be written as the middle product, so that it maps to the
+unaltered second colliding particle.
 
 Ambipolar ionization reactions with 2 or 3 products must be in one of
 the following orders:
@@ -308,7 +315,14 @@ Ambipolar recombination reactions must be in the following order:
 
 A+ + e -> A
 A + B+ -> AB+
-A+ + B -> AB+ :pre
+A+ + B -> AB+
+A + B -> AB + C+ :pre
+
+In the last form an ambipolar ion C+ acts as the inert third body,
+written as the second product P2 (see the non-ambipolar discussion of
+3rd particles above).  The two reactants and the recombined molecule
+P1 must be neutral; the ion C+ is a spectator whose species selects the
+recombination rate.
 
 A third particle for recombination reactions can be specified in
 the same way as described above for non-ambipolar recombination.

--- a/examples/ambi_3body/ambi_3body.species
+++ b/examples/ambi_3body/ambi_3body.species
@@ -1,0 +1,17 @@
+# Species data for ambipolar third-body test (subset of air.species)
+
+# ID
+# Molwt (amu)
+# Molmass (kg)
+# Rotational dof
+# RotRel
+# Vibrational dof
+# VibRel
+# VibTemp (K)
+# species wt
+# charge
+
+O2  32.00    5.31E-26  2    0.2   2    5.58659E-5    2256.0    1.0      0.0
+O   16.00    2.65E-26  0    0.0   0    0.0           0.0       1.0      0.0
+O2+ 32.00    5.31E-26  2    0.2   2    5.58659E-5    2256.0    1.0      1.0
+e   0.001  9.10938188E-31 0 0.0   0    0.0           0.0       1.0     -1.0

--- a/examples/ambi_3body/ambi_3body.tce
+++ b/examples/ambi_3body/ambi_3body.tce
@@ -1,0 +1,15 @@
+# Reactions exercising an ambipolar ion (O2+) as an inert third body.
+# These formats were rejected as "Invalid ambipolar reaction" before the
+# fix for issue #176.
+
+# Dissociation with O2+ as the inert third body (collision partner).
+# The ion third body must be written as the middle product, so that it
+# maps to the unaltered second colliding particle.
+O2 + O2+ --> O + O2+ + O
+D A 1.0 8.197e-19 3.321e-9 -1.5 -8.197e-19
+
+# Recombination with O2+ as the inert third body.
+# The ion third body is the 2nd product P2; it is a spectator whose
+# species selects the recombination rate.
+O + O --> O2 + O2+
+R A 1.0 0.0 1.0e-28 0.0 8.197e-19

--- a/examples/ambi_3body/ambi_3body.vss
+++ b/examples/ambi_3body/ambi_3body.vss
@@ -1,0 +1,15 @@
+# VSS collision model parameters (subset of air.vss)
+
+# diameter (mass)
+# omega (unitless)
+# tref (temperature)
+# alpha (unitless)
+# Zrotinf (unitless)
+# T* (temperature)
+# C1 (temperature)
+# C2 (temperature^(1/3))
+
+O2   3.96E-10    0.77  273.15  1.4   16.5 113.5 56.5 153.5
+O    3.0E-10     0.80  273.15  1.0   0.0 0.0 0.0 0.0
+O2+  3.96E-10    0.77  273.15  1.4   16.5 113.5 56.5 153.5
+e    7.0E-13     0.50  273.15  1.0   0.0 0.0 0.0 0.0

--- a/examples/ambi_3body/in.ambi_3body
+++ b/examples/ambi_3body/in.ambi_3body
@@ -1,0 +1,53 @@
+################################################################################
+# Ambipolar ions as third bodies in dissociation and recombination (issue #176)
+#
+# A closed, periodic box of hot O2 / O / O2+ (+ ambipolar electrons).  The
+# only reactions defined are an ion-third-body dissociation and an
+# ion-third-body recombination, so any gas reactions that occur exercise the
+# new functionality directly.
+#
+# A single-group mixture is used so the case runs on the KOKKOS package,
+# which currently supports only single-group collisions.  The "comm/sort"
+# and "twopass" options make MPI and Kokkos runs reproducible and should not
+# be used for production runs.
+################################################################################
+
+seed                12345
+dimension           3
+global              gridcut 0.0 comm/sort yes
+boundary            p p p
+
+create_box          0.0 0.001 0.0 0.001 0.0 0.001
+create_grid         10 10 10
+balance_grid        rcb cell
+
+global              nrho 1.0e22 fnum 1.0e8
+
+species             ambi_3body.species O2 O O2+ e
+
+# collide mixture: all species in one group (required for Kokkos)
+mixture             plasma O2 O O2+ e temp 50000.0
+
+# create mixture: heavy species only (electrons are added by fix ambipolar)
+mixture             gas O2 O O2+ temp 50000.0
+mixture             gas O2 frac 0.5
+mixture             gas O frac 0.3
+mixture             gas O2+ frac 0.2
+
+fix                 ambi ambipolar e O2+
+
+collide             vss plasma ambi_3body.vss relax variable
+collide_modify      vremax 1000 yes vibrate discrete rotate smooth
+collide_modify      ambipolar yes
+react               tce ambi_3body.tce
+
+create_particles    gas n 0 twopass
+
+timestep            1.0e-9
+
+compute             c count species
+stats_style         step cpu np nattempt ncoll nreact &
+                    c_c[1] c_c[2] c_c[3] c_c[4]
+stats               50
+
+run                 500

--- a/src/KOKKOS/collide_vss_kokkos.cpp
+++ b/src/KOKKOS/collide_vss_kokkos.cpp
@@ -33,6 +33,7 @@
 #include "modify.h"
 #include "fix.h"
 #include "fix_ambipolar.h"
+#include "fix_ambipolar_kokkos.h"
 
 using namespace SPARTA_NS;
 using namespace MathConst;
@@ -270,6 +271,8 @@ void CollideVSSKokkos::init()
       if (strcmp(modify->fix[ifix]->style,"ambipolar") == 0) break;
     FixAmbipolar *afix = (FixAmbipolar *) modify->fix[ifix];
     ambispecies = afix->especies;
+    FixAmbipolarKokkos *afix_kk = (FixAmbipolarKokkos *) afix;
+    d_ions = afix_kk->d_ions;
   }
 
   // if ambipolar and multiple groups in mixture, ambispecies must be its own group
@@ -2158,9 +2161,20 @@ void CollideVSSKokkos::ambi_reset_kokkos(int i, int j, int jsp, int index_kpart,
 
   if (kp) {
     int k = index_kpart;
-    d_ionambi[k] = 0;
-    if (jsp != e) return;
 
+    // no electron reactant: I/J order is not canonical if an ion is the
+    // third body (e.g. AB + C+ -> A + C+ + B), so sync each product's
+    // ion flag to its post-reaction species
+    // also correct for all-neutral dissociation, where flags stay 0
+
+    if (jsp != e) {
+      d_ionambi[i] = d_ions[ip->ispecies];
+      d_ionambi[j] = d_ions[jp->ispecies];
+      d_ionambi[k] = d_ions[kp->ispecies];
+      return;
+    }
+
+    d_ionambi[k] = 0;
     if (d_ionambi[i]) {                // nothing to change
     } else if (kp->ispecies == e) {
       d_ionambi[i] = 1;                // 1st reactant is now 1st product ion
@@ -2183,7 +2197,8 @@ void CollideVSSKokkos::ambi_reset_kokkos(int i, int j, int jsp, int index_kpart,
   // ambi reaction if J reactant is electron
 
   } else if (!jp) {
-    if (jsp == e) d_ionambi[i] = 0;   // 1st reactant is now 1st product neutral
+    if (jsp == e) d_ionambi[i] = 0;   // R: A+ + e -> A, 1st product neutral
+    else d_ionambi[i] = d_ions[ip->ispecies];  // sync product to its species
   }
 }
 

--- a/src/KOKKOS/collide_vss_kokkos.h
+++ b/src/KOKKOS/collide_vss_kokkos.h
@@ -148,6 +148,7 @@ class CollideVSSKokkos : public CollideVSS {
   tdual_struct_tdual_int_2d_1d k_eiarray;
   tdual_struct_tdual_float_2d_1d k_edarray;
   DAT::t_int_1d d_ionambi;
+  DAT::t_int_1d d_ions;
   DAT::t_float_2d_lr d_velambi;
   t_particle_2d d_elist;
 

--- a/src/collide.cpp
+++ b/src/collide.cpp
@@ -88,6 +88,7 @@ Collide::Collide(SPARTA *sparta, int, char **arg) : Pointers(sparta)
   recomb_ijflag = NULL;
 
   ambiflag = 0;
+  ions = NULL;
   maxelectron = 0;
   elist = NULL;
 
@@ -298,6 +299,7 @@ void Collide::init()
       if (strcmp(modify->fix[ifix]->style,"ambipolar") == 0) break;
     FixAmbipolar *afix = (FixAmbipolar *) modify->fix[ifix];
     ambispecies = afix->especies;
+    ions = afix->ions;
   }
 
   // if ambipolar and multiple groups in mixture, ambispecies must be its own group
@@ -1596,8 +1598,8 @@ template < int GASTALLY > void Collide::collisions_group_ambipolar()
    reactants i,j and isp/jsp will always be in order listed below
    products ip,jp,kp will always be in order listed below
    logic must be valid for all ambipolar AND non-ambipolar reactions
-   check for 3 versions of 2 -> 3: dissociation or ionization
-     all have J product = electron
+   check for versions of 2 -> 3: dissociation or ionization
+     reactions with an electron have J reactant = electron
      D: AB + e -> A + e + B
         if I reactant = neutral and K product not electron:
         set K product = neutral
@@ -1607,7 +1609,10 @@ template < int GASTALLY > void Collide::collisions_group_ambipolar()
      I: A + e -> A+ + e + e
         if I reactant = neutral and K product = electron:
         set I product = ion
-     all other 2 -> 3 cases, set K product = neutral
+     D: AB + C+ -> A + C+ + B (ambipolar ion C+ as third body)
+        no electron involved, so I/J reactant order is not canonical:
+        sync I/J/K product ion flags to their post-reaction species
+     all other 2 -> 3 cases (no electron), sync ion flags to species
    check for 4 versions of 2 -> 2: ionization or exchange
      I: A + B -> AB+ + e
         if J product = electron:
@@ -1622,10 +1627,12 @@ template < int GASTALLY > void Collide::collisions_group_ambipolar()
         if J reactant = ion:
         nothing to change for products
      all other 2 -> 2 cases, no changes
-   check for one version of 2 -> 1: recombination
+   check for versions of 2 -> 1: recombination
      R: A+ + e -> A
         if ej = elec, set I product to neutral
-     all other 2 -> 1 cases, no changes
+     R: A + B + C+ -> AB + C+ (ambipolar ion C+ as inert third body)
+        third body is a spectator (recomb_part3), not modified here
+     all other 2 -> 1 cases (no electron), sync I product flag to its species
    WARNING:
      do not index by I,J if could be e, since may be negative I,J index
      do not access ionambi if could be e, since e may be in elist
@@ -1642,9 +1649,20 @@ void Collide::ambi_reset(int i, int j, int jsp,
 
   if (kp) {
     int k = particle->nlocal-1;
-    ionambi[k] = 0;
-    if (jsp != e) return;
 
+    // no electron reactant: I/J order is not canonical if an ion is the
+    // third body (e.g. AB + C+ -> A + C+ + B), so sync each product's
+    // ion flag to its post-reaction species
+    // also correct for all-neutral dissociation, where flags stay 0
+
+    if (jsp != e) {
+      ionambi[i] = ions[ip->ispecies];
+      ionambi[j] = ions[jp->ispecies];
+      ionambi[k] = ions[kp->ispecies];
+      return;
+    }
+
+    ionambi[k] = 0;
     if (ionambi[i]) {                // nothing to change
     } else if (kp->ispecies == e) {
       ionambi[i] = 1;                // 1st reactant is now 1st product ion
@@ -1667,7 +1685,8 @@ void Collide::ambi_reset(int i, int j, int jsp,
   // ambi reaction if J reactant is electron
 
   } else if (!jp) {
-    if (jsp == e) ionambi[i] = 0;   // 1st reactant is now 1st product neutral
+    if (jsp == e) ionambi[i] = 0;   // R: A+ + e -> A, 1st product neutral
+    else ionambi[i] = ions[ip->ispecies];  // sync surviving product to species
   }
 }
 

--- a/src/collide.h
+++ b/src/collide.h
@@ -118,6 +118,7 @@ class Collide : protected Pointers {
 
   int ambiflag;       // 1 if ambipolar option is enabled
   int ambispecies;    // species for ambipolar electrons
+  int *ions;          // 1 if a species is an ambipolar ion, from fix ambipolar
   int index_ionambi;  // 2 custom ambipolar vectors
   int index_velambi;
 

--- a/src/react_bird.cpp
+++ b/src/react_bird.cpp
@@ -467,6 +467,24 @@ void ReactBird::ambi_check()
         else if (ions[r->reactants[0]] == 1 && r->reactants[1] == especies &&
                  ions[r->products[0]] == 1 && r->products[1] == especies &&
                  ions[r->products[2]] == 0) flag = 0;
+
+        // ambipolar ion as inert third body, dissociating species is neutral
+        // D: AB + C+ -> A + C+ + B
+        //   third body C+ is conserved as middle product (products[1])
+        //   so it maps to the surviving J particle in react attempt()
+
+        else if (ions[r->reactants[0]] == 0 && ions[r->reactants[1]] == 1 &&
+                 ions[r->products[0]] == 0 &&
+                 r->products[1] == r->reactants[1] &&
+                 ions[r->products[2]] == 0) flag = 0;
+
+        // ambipolar ion as inert third body, dissociating species is an ion
+        // D: AB+ + C+ -> A+ + C+ + B
+
+        else if (ions[r->reactants[0]] == 1 && ions[r->reactants[1]] == 1 &&
+                 ions[r->products[0]] == 1 &&
+                 r->products[1] == r->reactants[1] &&
+                 ions[r->products[2]] == 0) flag = 0;
       }
     }
 
@@ -520,6 +538,17 @@ void ReactBird::ambi_check()
             ions[r->products[0]] == 1) flag = 0;
         else if (ions[r->reactants[0]] == 1 && ions[r->reactants[1]] == 0 &&
             ions[r->products[0]] == 1) flag = 0;
+      }
+
+      // ambipolar ion as inert third body
+      // R: A + B + C+ -> AB + C+
+      //   third body C+ is the 2nd product (products[1]), used only to
+      //   select the recombination rate; it is not a colliding particle
+      //   reactants and recombined molecule (products[0]) are not electrons
+
+      else if (r->nreactant == 2 && r->nproduct == 2) {
+        if (r->reactants[0] != especies && r->reactants[1] != especies &&
+            r->products[0] != especies && ions[r->products[1]] == 1) flag = 0;
       }
     }
 


### PR DESCRIPTION
## Purpose

Allow ambipolar ions as third bodies in dissociation/recombination
Implements and therefore closes #176 

## Author(s)

Stan Moore (SNL) and Claude Code (Opus 4.8)

## Backward Compatibility

Yes

## Implementation Notes

Description from Claude

When the ambipolar approximation is enabled, SPARTA validated every reaction
involving an ambipolar ion or electron against a fixed whitelist of formats in
`ReactBird::ambi_check()`. That whitelist had no entry for an ambipolar **ion
acting as an inert third body** (collision partner) in otherwise-neutral
chemistry, so reactions such as

```
D: O2 + O2+ -> O + O2+ + O
R: O + O  -> O2 + O2+
```

were rejected at setup with `ERROR: Invalid ambipolar reaction`. Physically an
ion is a perfectly valid third body for dissociation and three-body
recombination (charged third bodies often dominate recombination in plasmas),
so this was a real modeling limitation rather than a physics constraint. This
PR allows ambipolar ions to serve as inert third bodies in dissociation and
recombination reactions.

- **`react_bird.cpp` (`ambi_check`)**: accept dissociation with an ion third
  body (for both neutral and ionic dissociating species) and recombination with
  an ion third body. The ion third body must be written as the **middle**
  dissociation product (so it maps to the unaltered second colliding particle in
  `ReactTCE::attempt()`, matching the existing electron-third-body convention),
  or as the **2nd recombination product P2** (which only selects the rate; the
  third body is a spectator drawn from the cell, never a colliding particle).

- **`collide.cpp` (`ambi_reset`)**: for reactions with no electron
  (`jsp != e`), sync each surviving particle's `ionambi` flag to its
  post-reaction species. This is required because, unlike the electron, an ion
  third body is **not** force-swapped into the J slot, so the I/J reactant order
  is not canonical and the positional product mapping could otherwise leave
  `ionambi` inconsistent with the species. The sync is a no-op for all-neutral
  reactions (flags stay 0) and also repairs the analogous latent case for ionic
  recombination products. `fix ambipolar`'s `ions[]` vector is now stored on
  `Collide` for this lookup.

- **Electron-conservation safety**: ion third-body reactions create or destroy
  no electrons, so the per-cell `ion-count == electron-count` invariant is
  preserved; `velambi` is reassigned per-cell from the electron pool regardless.

- **Kokkos**: `ambi_reset_kokkos` mirrors the host logic and a `d_ions` device
  view is wired up from `FixAmbipolarKokkos`.

- **Docs**: `doc/react.txt` documents the new dissociation/recombination
  orderings and the middle-product / P2 requirement.

**Verification performed:**
- Built and ran CPU (serial + MPI), KOKKOS Serial with `SPARTA_KOKKOS_EXACT`,
  and KOKKOS OpenMP.
- **No regression**: A/B comparison against a baseline binary built from the
  parent commit shows *identical* stats output on `examples/ambi`; the baseline
  rejects the new reactions while the patched build accepts them.
- **CPU vs Kokkos**: KOKKOS Serial+EXACT matches the CPU build bit-for-bit
  (all stats columns) on the new example; KOKKOS with 4 MPI ranks matches CPU
  with 4 MPI ranks bit-for-bit.
- **Threads/MPI**: clean runs that conserve electrons on KOKKOS OpenMP (4
  threads), CPU (4 MPI ranks), and KOKKOS (4 MPI ranks).
- **Functional correctness**: in the new example the ion third body (O2+) count
  stays exactly constant at every timestep while O2 dissociates into O,
  confirming the ion behaves as a true inert spectator; no
  `Invalid ambipolar reaction` or electron-count errors in any configuration.

New example `examples/ambi_3body` is a single-group, periodic box of hot
O2 / O / O2+ whose only reactions are an ion-third-body dissociation and
recombination, so any gas reactions that occur exercise the new functionality
directly. A single-group mixture is used because the KOKKOS package currently
supports only single-group collisions (a pre-existing limitation, unrelated to
this change, which is why the multigroup `examples/ambi` case does not run on
Kokkos).