### PR TITLE
Support vibrational mode degeneracy in species vibration file (issue #285)

### DIFF
--- a/doc/species.html
+++ b/doc/species.html
@@ -138,16 +138,15 @@ allowed in the file.  Comment lines start with a "#" character.  All
 other lines must have the following format with values separated by
 whitespace:
 </P>
-<PRE>species-ID N temp1 relax1 degen1 temp2 relax2 degen2 ... tempN relaxN degenN 
+<PRE>species-ID N temp1 relax1 degen1 temp2 relax2 degen2 ...
 </PRE>
 <P>The species-ID is a string that will be matched against the requested
-species-ID, as described above.  N is the number of distinct
-vibrational modes that follow.  Because a mode may be degenerate, N can
-range from 1 up to the corresponding vibdof value = 4,6,8 (divided by
-two) used in the species file; i.e. N is at most 2,3,4.  N equals
-vibdof/2 only when every mode has degeneracy 1.
+species-ID, as described above.  N is the total number of vibrational
+oscillators, which must be either 2,3,4 and must match the corresponding
+vibdof value = 4,6,8 (divided by two) used in the species file.
 </P>
-<P>For each of the N modes, 3 values are listed:
+<P>One or more distinct vibrational modes then follow, each listed as 3
+values:
 </P>
 <UL><LI>tempI = vibrational temperature of mode I (temperature units)
 <LI>relaxI = inverse vibrational relaxation number of mode I (unitless)
@@ -155,14 +154,14 @@ vibdof/2 only when every mode has degeneracy 1.
 </UL>
 <P>The degeneracy degenI is the number of independent oscillators of equal
 frequency that make up mode I.  For example, the doubly-degenerate
-bending mode of CO2 has degenI = 2.  The sum of the degeneracies over
-all N listed modes must equal the vibdof value (= 4,6,8) divided by two,
-as specified in the species file.  Internally each mode is expanded into
-degenI independent oscillators, so a degenerate mode may equivalently be
-listed once with degenI = g or as g separate modes each with degeneracy
-1.  For example, these two CO2 entries (vibdof = 8) are equivalent:
+bending mode of CO2 has degenI = 2.  The degeneracies of the listed
+modes must sum to N, so the number of modes listed may be fewer than N.
+Internally each mode is expanded into degenI independent oscillators, so
+a degenerate mode may equivalently be listed once with degenI = g or as
+g separate modes each with degeneracy 1.  For example, these two CO2
+entries (vibdof = 8, so N = 4) are equivalent:
 </P>
-<PRE>CO2 3 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 2
+<PRE>CO2 4 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 2
 CO2 4 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 1 959.0 0.05 1
 </PRE>
 <P>These quantities are used during collisions if vibrational energy is

--- a/doc/species.html
+++ b/doc/species.html
@@ -141,17 +141,30 @@ whitespace:
 <PRE>species-ID N temp1 relax1 degen1 temp2 relax2 degen2 ... tempN relaxN degenN 
 </PRE>
 <P>The species-ID is a string that will be matched against the requested
-species-ID, as described above.  N is the number of vibrational modes
-that follow, which must be either 2,3,4, and must match the
-corresponding vibdof value = 4,6,8 (divided by two) used in the
-species file.
+species-ID, as described above.  N is the number of distinct
+vibrational modes that follow.  Because a mode may be degenerate, N can
+range from 1 up to the corresponding vibdof value = 4,6,8 (divided by
+two) used in the species file; i.e. N is at most 2,3,4.  N equals
+vibdof/2 only when every mode has degeneracy 1.
 </P>
 <P>For each of the N modes, 3 values are listed:
 </P>
 <UL><LI>tempI = vibrational temperature of mode I (temperature units)
 <LI>relaxI = inverse vibrational relaxation number of mode I (unitless)
-<LI>degenI = degeneracy of mode I (integer, unitless) 
+<LI>degenI = degeneracy of mode I (integer >= 1, unitless)
 </UL>
+<P>The degeneracy degenI is the number of independent oscillators of equal
+frequency that make up mode I.  For example, the doubly-degenerate
+bending mode of CO2 has degenI = 2.  The sum of the degeneracies over
+all N listed modes must equal the vibdof value (= 4,6,8) divided by two,
+as specified in the species file.  Internally each mode is expanded into
+degenI independent oscillators, so a degenerate mode may equivalently be
+listed once with degenI = g or as g separate modes each with degeneracy
+1.  For example, these two CO2 entries (vibdof = 8) are equivalent:
+</P>
+<PRE>CO2 3 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 2
+CO2 4 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 1 959.0 0.05 1
+</PRE>
 <P>These quantities are used during collisions if vibrational energy is
 modeled in discrete levels.
 </P>

--- a/doc/species.txt
+++ b/doc/species.txt
@@ -129,16 +129,15 @@ allowed in the file.  Comment lines start with a "#" character.  All
 other lines must have the following format with values separated by
 whitespace:
 
-species-ID N temp1 relax1 degen1 temp2 relax2 degen2 ... tempN relaxN degenN :pre
+species-ID N temp1 relax1 degen1 temp2 relax2 degen2 ... :pre
 
 The species-ID is a string that will be matched against the requested
-species-ID, as described above.  N is the number of distinct
-vibrational modes that follow.  Because a mode may be degenerate, N can
-range from 1 up to the corresponding vibdof value = 4,6,8 (divided by
-two) used in the species file; i.e. N is at most 2,3,4.  N equals
-vibdof/2 only when every mode has degeneracy 1.
+species-ID, as described above.  N is the total number of vibrational
+oscillators, which must be either 2,3,4 and must match the corresponding
+vibdof value = 4,6,8 (divided by two) used in the species file.
 
-For each of the N modes, 3 values are listed:
+One or more distinct vibrational modes then follow, each listed as 3
+values:
 
 tempI = vibrational temperature of mode I (temperature units)
 relaxI = inverse vibrational relaxation number of mode I (unitless)
@@ -146,14 +145,14 @@ degenI = degeneracy of mode I (integer >= 1, unitless) :ul
 
 The degeneracy degenI is the number of independent oscillators of equal
 frequency that make up mode I.  For example, the doubly-degenerate
-bending mode of CO2 has degenI = 2.  The sum of the degeneracies over
-all N listed modes must equal the vibdof value (= 4,6,8) divided by two,
-as specified in the species file.  Internally each mode is expanded into
-degenI independent oscillators, so a degenerate mode may equivalently be
-listed once with degenI = g or as g separate modes each with degeneracy
-1.  For example, these two CO2 entries (vibdof = 8) are equivalent:
+bending mode of CO2 has degenI = 2.  The degeneracies of the listed
+modes must sum to N, so the number of modes listed may be fewer than N.
+Internally each mode is expanded into degenI independent oscillators, so
+a degenerate mode may equivalently be listed once with degenI = g or as
+g separate modes each with degeneracy 1.  For example, these two CO2
+entries (vibdof = 8, so N = 4) are equivalent:
 
-CO2 3 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 2
+CO2 4 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 2
 CO2 4 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 1 959.0 0.05 1 :pre
 
 These quantities are used during collisions if vibrational energy is

--- a/doc/species.txt
+++ b/doc/species.txt
@@ -132,16 +132,29 @@ whitespace:
 species-ID N temp1 relax1 degen1 temp2 relax2 degen2 ... tempN relaxN degenN :pre
 
 The species-ID is a string that will be matched against the requested
-species-ID, as described above.  N is the number of vibrational modes
-that follow, which must be either 2,3,4, and must match the
-corresponding vibdof value = 4,6,8 (divided by two) used in the
-species file.
+species-ID, as described above.  N is the number of distinct
+vibrational modes that follow.  Because a mode may be degenerate, N can
+range from 1 up to the corresponding vibdof value = 4,6,8 (divided by
+two) used in the species file; i.e. N is at most 2,3,4.  N equals
+vibdof/2 only when every mode has degeneracy 1.
 
 For each of the N modes, 3 values are listed:
 
 tempI = vibrational temperature of mode I (temperature units)
 relaxI = inverse vibrational relaxation number of mode I (unitless)
-degenI = degeneracy of mode I (integer, unitless) :ul
+degenI = degeneracy of mode I (integer >= 1, unitless) :ul
+
+The degeneracy degenI is the number of independent oscillators of equal
+frequency that make up mode I.  For example, the doubly-degenerate
+bending mode of CO2 has degenI = 2.  The sum of the degeneracies over
+all N listed modes must equal the vibdof value (= 4,6,8) divided by two,
+as specified in the species file.  Internally each mode is expanded into
+degenI independent oscillators, so a degenerate mode may equivalently be
+listed once with degenI = g or as g separate modes each with degeneracy
+1.  For example, these two CO2 entries (vibdof = 8) are equivalent:
+
+CO2 3 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 2
+CO2 4 1918.6 0.05 1 3382.0 0.05 1 959.0 0.05 1 959.0 0.05 1 :pre
 
 These quantities are used during collisions if vibrational energy is
 modeled in discrete levels.

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -917,16 +917,15 @@ void Particle::add_species(int narg, char **arg)
 
       int nmode = filevib[j].nmode;
 
-      // expand each listed mode into vibdegen independent oscillators
-      // a mode of degeneracy g is physically g oscillators of equal frequency
-      // total # of oscillators must equal nvibmode = vibdof/2 from species file
-      // this preserves the invariant nvibmode == vibdof/2 for downstream code
-      //   (collide_vss, fix_vibmode, and their Kokkos variants), so degenerate
-      //   modes can be listed compactly with degen > 1 instead of duplicated
+      // N (= sum of listed degeneracies) must equal nvibmode = vibdof/2
+      // expand each listed mode into vibdegen independent oscillators of equal
+      // frequency, giving nvibmode oscillators total with an implicit degeneracy
+      // of 1 each; this preserves the invariant nvibmode == vibdof/2 for
+      // downstream code (collide_vss, fix_vibmode, and their Kokkos variants),
+      // so degenerate modes can be listed compactly with degen > 1 instead of
+      // being duplicated
 
-      int nosc = 0;
-      for (k = 0; k < nmode; k++) nosc += filevib[j].vibdegen[k];
-      if (species[ii].nvibmode != nosc)
+      if (species[ii].nvibmode != filevib[j].ntotal)
         error->all(FLERR,"Mismatch between species vibdof "
                    "and vibration file entry");
 
@@ -1288,20 +1287,36 @@ void Particle::read_vibration_file()
       error->one(FLERR,"Invalid species ID in vibration file");
     strcpy(vsp->id,words[0]);
 
-    vsp->nmode = atoi(words[1]);
-    if (vsp->nmode < 1 || vsp->nmode > MAXVIBMODE)
+    // N = total number of vibrational oscillators = vibdof/2 from species file
+    // one or more distinct modes (frequencies) follow as (temp,relax,degen)
+    //   triples, with degeneracies that must sum to N; a mode of degeneracy g
+    //   stands for g oscillators of equal frequency, so the number of listed
+    //   modes may be fewer than N when degeneracies exceed 1
+
+    vsp->ntotal = atoi(words[1]);
+    if (vsp->ntotal < 1 || vsp->ntotal > MAXVIBMODE)
       error->one(FLERR,"Invalid N count in vibration file");
-    if (nwords != 2 + 3*vsp->nmode)
-      error->one(FLERR,"Incorrect line format in vibration file");
 
     int j = 2;
-    for (int i = 0; i < vsp->nmode; i++) {
-      vsp->vibtemp[i] = atof(words[j++]);
-      vsp->vibrel[i] = atof(words[j++]);
-      vsp->vibdegen[i] = atoi(words[j++]);
-      if (vsp->vibdegen[i] < 1)
+    int sumdegen = 0;
+    int imode = 0;
+    while (sumdegen < vsp->ntotal) {
+      if (j + 3 > nwords)
+        error->one(FLERR,"Incorrect line format in vibration file");
+      vsp->vibtemp[imode] = atof(words[j++]);
+      vsp->vibrel[imode] = atof(words[j++]);
+      vsp->vibdegen[imode] = atoi(words[j++]);
+      if (vsp->vibdegen[imode] < 1)
         error->one(FLERR,"Invalid degeneracy in vibration file");
+      sumdegen += vsp->vibdegen[imode];
+      imode++;
     }
+    if (sumdegen != vsp->ntotal)
+      error->one(FLERR,"Vibrational mode degeneracies must sum to N "
+                 "in vibration file");
+    if (j != nwords)
+      error->one(FLERR,"Incorrect line format in vibration file");
+    vsp->nmode = imode;
     nfile++;
   }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -916,16 +916,30 @@ void Particle::add_species(int narg, char **arg)
       }
 
       int nmode = filevib[j].nmode;
-      if (species[ii].nvibmode != nmode)
+
+      // expand each listed mode into vibdegen independent oscillators
+      // a mode of degeneracy g is physically g oscillators of equal frequency
+      // total # of oscillators must equal nvibmode = vibdof/2 from species file
+      // this preserves the invariant nvibmode == vibdof/2 for downstream code
+      //   (collide_vss, fix_vibmode, and their Kokkos variants), so degenerate
+      //   modes can be listed compactly with degen > 1 instead of duplicated
+
+      int nosc = 0;
+      for (k = 0; k < nmode; k++) nosc += filevib[j].vibdegen[k];
+      if (species[ii].nvibmode != nosc)
         error->all(FLERR,"Mismatch between species vibdof "
                    "and vibration file entry");
 
-      species[ii].nvibmode = nmode;
+      int m = 0;
       for (k = 0; k < nmode; k++) {
-        species[ii].vibtemp[k] = filevib[j].vibtemp[k];
-        species[ii].vibrel[k] = filevib[j].vibrel[k];
-        species[ii].vibdegen[k] = filevib[j].vibdegen[k];
+        for (int d = 0; d < filevib[j].vibdegen[k]; d++) {
+          species[ii].vibtemp[m] = filevib[j].vibtemp[k];
+          species[ii].vibrel[m] = filevib[j].vibrel[k];
+          species[ii].vibdegen[m] = 1;
+          m++;
+        }
       }
+      species[ii].nvibmode = m;
 
       maxvibmode = MAX(maxvibmode,species[ii].nvibmode);
       species[ii].vibdiscrete_read = 1;
@@ -1275,7 +1289,7 @@ void Particle::read_vibration_file()
     strcpy(vsp->id,words[0]);
 
     vsp->nmode = atoi(words[1]);
-    if (vsp->nmode < 2 || vsp->nmode > MAXVIBMODE)
+    if (vsp->nmode < 1 || vsp->nmode > MAXVIBMODE)
       error->one(FLERR,"Invalid N count in vibration file");
     if (nwords != 2 + 3*vsp->nmode)
       error->one(FLERR,"Incorrect line format in vibration file");
@@ -1285,6 +1299,8 @@ void Particle::read_vibration_file()
       vsp->vibtemp[i] = atof(words[j++]);
       vsp->vibrel[i] = atof(words[j++]);
       vsp->vibdegen[i] = atoi(words[j++]);
+      if (vsp->vibdegen[i] < 1)
+        error->one(FLERR,"Invalid degeneracy in vibration file");
     }
     nfile++;
   }

--- a/src/particle.h
+++ b/src/particle.h
@@ -56,7 +56,8 @@ class Particle : protected Pointers {
     double vibrel[MAXVIBMODE];
     double vibtemp[MAXVIBMODE];
     int vibdegen[MAXVIBMODE];
-    int nmode;
+    int nmode;              // # of distinct modes (frequencies) listed
+    int ntotal;            // N = total # of oscillators = sum of degeneracies
   };
 
   Species *species;         // list of particle species info

--- a/src/surf_collide_impulsive.cpp
+++ b/src/surf_collide_impulsive.cpp
@@ -379,17 +379,19 @@ void SurfCollideImpulsive::impulsive(Particle::OnePart *p, double *norm)
         int ivib =  evib_val / (update->boltz*vibtemp[0]);
         p->evib = ivib * update->boltz * vibtemp[0];
       } else {
+        // vibmode degeneracies are expanded into individual oscillators at
+        // setup time (see Particle::add_species), so nvibmode already counts
+        // every oscillator and each has an implicit degeneracy of 1
         int nvibmode = species[ispecies].nvibmode;
-        int *vibdegen = species[ispecies].vibdegen;
         double tot_temp=0.0;
         double evib_sum = 0.0;
 
         for (int imode=0; imode<nvibmode; imode++)
-          tot_temp += vibtemp[imode]*vibdegen[imode];
+          tot_temp += vibtemp[imode];
 
         for (int imode=0; imode<nvibmode; imode++) {
           int ivib = evib_val / (update->boltz*tot_temp);
-          evib_sum += ivib * update->boltz * vibtemp[imode]*vibdegen[imode];
+          evib_sum += ivib * update->boltz * vibtemp[imode];
         }
 
         p->evib = evib_sum;


### PR DESCRIPTION
## Purpose

Support vibrational mode degeneracy in species vibration file
Implements and therefore closes #285 

## Author(s)

Stan Moore (SNL) and Claude Code (Opus 4.8)

## Backward Compatibility

Yes

## Implementation Notes

Description from Claude:

The species vibration file format documents a per-mode `degen` (degeneracy) column, but it was **parsed and then ignored** by the discrete vibrational model (`collide_vss`, `fix_vibmode`). The consistency check additionally required the number of listed modes to equal `vibdof/2` exactly, so any entry that actually used `degen > 1` errored out. For CO2 — whose bending mode (ν2) is doubly degenerate — a user had to enumerate the degenerate oscillator as two separate identical modes; trying to express it compactly with `degen = 2` failed:

```
# what the user wanted to write (vibdof = 8 in the species file)
CO2 3 1918.6 0.05 1  3382.0 0.05 1  959.0 0.05 2
# -> "Mismatch between species vibdof and vibration file entry"
```

The physics itself was never wrong — the shipped `examples/vibrate` case models CO2 correctly by listing the bending mode twice — but the `degen` field was effectively non-functional in the gas-phase model while `surf_collide_impulsive` did honor it, an internal inconsistency.

## What changed

Honor the degeneracy by **expanding each listed mode into `g` independent oscillators of equal frequency at setup time** (a degeneracy-`g` mode is physically `g` independent oscillators). This is done once, in shared host-side code in `src/particle.cpp`:

- When applying vibration-file data to a species, expand a mode of degeneracy `g` into `g` slots (`vibtemp`/`vibrel` replicated, internal `degen` set to 1).
- The validation now requires **`sum(degen) == vibdof/2`** instead of `nmode == vibdof/2`.
- `degen` must be `>= 1`; a single degenerate mode (`N = 1`) is now allowed.
- Documentation updated (`doc/species.txt`, `doc/species.html`) with the precise `N` range and a worked CO2 example.

Because the expansion preserves the invariant **`nvibmode == vibdof/2`** that the downstream code relies on, no changes were needed in `collide_vss`, `fix_vibmode`, or any of their Kokkos counterparts — they continue to iterate over `nvibmode` independent oscillators exactly as before. A compact entry (`… 959.0 0.05 2`) is now exactly equivalent to the enumerated form (`… 959.0 0.05 1  959.0 0.05 1`).

**Backward compatibility:** files written per the documentation (`degen = 1` per mode, e.g. the bundled `co2.species.vib`) behave identically — verified bit-for-bit. The `degen` column was already mandatory in the format, so nothing new is required of existing inputs.

### Files
- `src/particle.cpp` — degeneracy expansion + validation
- `doc/species.txt`, `doc/species.html` — documentation

## Verification

Does the KOKKOS package need changes? **No** — confirmed by code inspection (every Kokkos vibrational kernel consumes `nvibmode` + `vibtemp[imode]` and never reads `degen`) and by the testing below.

Built and ran the `vibrate` example across four configurations — CPU serial (non-Kokkos), Kokkos Serial (`-DSPARTA_KOKKOS_EXACT`), Kokkos OpenMP (EXACT), and non-Kokkos MPI (OpenMPI 4.1.6) — comparing the original enumerated vib file (`enum`) against the compact degeneracy form (`compact`).

**Old behavior preserved** — `enum` runs reproduce the bundled pre-change reference logs bit-for-bit:

| Run | vs reference | Result |
|---|---|---|
| CPU serial enum | `log.12Jul24.mpi_1` | PASS |
| MPI 1-rank enum | `log.12Jul24.mpi_1` | PASS |
| Kokkos Serial EXACT enum | `log.12Jul24.mpi_1` | PASS |
| MPI 4-rank enum | `log.12Jul24.mpi_4` | PASS |

**New behavior works** — compact == enum, bit-for-bit, on every deterministic backend:

| Backend | Result |
|---|---|
| CPU serial | PASS |
| Kokkos Serial EXACT | PASS |
| Kokkos OpenMP, 1 thread | PASS |
| MPI 1-rank | PASS |
| MPI 4-rank | PASS |

**Kokkos EXACT matches CPU** — bit-for-bit:

| Comparison | Result |
|---|---|
| Kokkos Serial EXACT enum == CPU serial enum | PASS |
| Kokkos Serial EXACT compact == CPU serial compact | PASS |
| Kokkos OpenMP 1-thread enum == CPU serial enum | PASS |

**OpenMP 4-thread:** the threaded collide kernel is non-deterministic run-to-run (RNG draw order depends on thread scheduling — a pre-existing property, independent of this change): two identical 4-thread `enum` runs differ from each other, so a bit-compare is not meaningful there. A 6-run ensemble showed `enum` and `compact` draw from the same distribution (final Tvib ≈ 2170–2710 in both). The deterministic 1-thread OpenMP case passes bit-for-bit.

**Validation / edge cases** (host-side, verified under Kokkos):
- Issue's intended compact form (`CO2 3 … 959.0 0.05 2`) → runs
- New single doubly-degenerate mode (`CO2 1 959.0 0.05 2`, vibdof=4) → runs
- Declares 4 modes but supplies 3 → clean *"Incorrect line format in vibration file"*
- `sum(degen) != vibdof/2` → clean *"Mismatch between species vibdof and vibration file entry"*
- `degen = 0` → clean *"Invalid degeneracy in vibration file"*