### PR TITLE
Flag invalid use of wildcard character in compute/fix/etc args used as inputs by various commands

### DIFF
--- a/examples/ablation/in.ablation.multi.inner.3d
+++ b/examples/ablation/in.ablation.multi.inner.3d
@@ -50,7 +50,7 @@ create_isurf            all fablate 100.5 multi
 timestep		0.001
 
 compute 1 property/grid all vol
-compute 1r reduce sum c_1[*]
+compute 1r reduce sum c_1
 
 #variable vout equal c_1r
 #fix massr print 5 "${vout}" append vol_inner_multi.dat screen no

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -637,7 +637,6 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
         if (ptr2) {
           *ptr2 = '\0';
           if (strchr(ptr1,'*')) {
-            nmax = 0;
 
             // compute
 

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -637,6 +637,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
         if (ptr2) {
           *ptr2 = '\0';
           if (strchr(ptr1,'*')) {
+            nmax = 0;
 
             // compute
 
@@ -671,7 +672,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                            modify->compute[icompute]->size_per_tally_cols) {
                   nmax = modify->compute[icompute]->size_per_tally_cols;
                   expandflag = 1;
-                }
+                } else expandflag = -1;
               }
 
             // fix
@@ -703,7 +704,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                            modify->fix[ifix]->size_per_surf_cols) {
                   nmax = modify->fix[ifix]->size_per_surf_cols;
                   expandflag = 1;
-                }
+                } else expandflag = -1;
               }
 
             // per-particle custom attribute
@@ -717,7 +718,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                 if (particle->esize[icustom]) {
                   nmax = particle->esize[icustom];
                   expandflag = 1;
-                }
+                } else expandflag = -1;
               }
 
             // per-grid custom attribute
@@ -731,7 +732,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                 if (grid->esize[icustom]) {
                   nmax = grid->esize[icustom];
                   expandflag = 1;
-                }
+                } else expandflag = -1;
               }
 
             // per-surf custom attribute
@@ -745,7 +746,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                 if (surf->esize[icustom]) {
                   nmax = surf->esize[icustom];
                   expandflag = 1;
-                }
+                } else expandflag = -1;
               }
             }
           }
@@ -754,6 +755,13 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
       }
     }
 
+    if (expandflag < 0) {
+      char str[256];
+      sprintf(str,"Cannot use wildcard with %s because it "
+              "does not produce multiple values",arg[iarg]);
+      error->all(FLERR,str);
+    }
+    
     if (expandflag) {
       *ptr2 = '\0';
       bounds(ptr1+1,nmax,nlo,nhi);


### PR DESCRIPTION
## Purpose

Dump and other commands allow input args with a wildcard "*" to expand to represent one or more inputs.  This was allowed in some cases even when the input arg represented a single value, e.g. a per-grid vector and not a per-grid array.  In the case of dump commands this means the input arg was echoed into the dump file column headers with the wildcard, which is confusing.  The solution is to not allow use of a wildcard when it does not make sense, e.g. when a per-grid vector is referenced,

This PR enforces that convention.  It resolves issue #614.

Fixes #614 

## Author(s)

Steve

## Backward Compatibility

Enforcing this convention could trigger errors for input scripts which are using a wildcard incorrectly, but otherwise ran fine.  I.e. they produced a dump file with incorrect column header names, but the simulation and data in the dump file was correct.

## Implementation Notes

_Provide any relevant details about how the changes are implemented, how correctness was verified, how other features - if any - in SPARTA are affected_

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [ ] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

_Put any additional information here, attach relevant text or image files, and URLs to external sites (e.g. DOIs or webpages)_


