### PR TITLE
Library interface, embedding support, and dump image enhancements, mostly ported from LAMMPS

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -26,6 +26,32 @@ if(PKG_KOKKOS AND (CMAKE_CXX_STANDARD LESS 20))
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Use compiler extensions")
+
+# C++11 is guaranteed above, so use std::unordered_map for the grid/surf
+# hashes instead of the pre-C++11 TR1 fallback, which no longer exists in
+# some standard libraries (e.g. libc++ on macOS)
+add_compile_definitions(SPARTA_UNORDERED_MAP)
+
+# Optional git provenance: stamp the build with the commit hash and branch so
+# `sparta -help` and the library's extract_global("git_commit"/"git_branch")
+# can report it.  Entirely optional -- a plain (non-git, e.g. tarball) build
+# simply skips this and the source falls back to "(unknown)"/"".
+find_package(Git QUIET)
+if(Git_FOUND)
+  execute_process(COMMAND ${GIT_EXECUTABLE} describe --always --dirty --abbrev=10
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+    OUTPUT_VARIABLE SPARTA_GIT_COMMIT OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET RESULT_VARIABLE _sparta_git_rc)
+  execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+    OUTPUT_VARIABLE SPARTA_GIT_BRANCH OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET)
+  if(_sparta_git_rc EQUAL 0 AND SPARTA_GIT_COMMIT)
+    add_compile_definitions(
+      SPARTA_GIT_COMMIT="${SPARTA_GIT_COMMIT}"
+      SPARTA_GIT_BRANCH="${SPARTA_GIT_BRANCH}")
+  endif()
+endif()
 # ugly hacks for MSVC which by default always reports an old C++ standard in the __cplusplus macro
 # and prints lots of pointless warnings about "unsafe" functions
 if(MSVC)

--- a/doc/Section_howto.html
+++ b/doc/Section_howto.html
@@ -489,7 +489,7 @@ internal SPARTA operations.  Note that SPARTA classes are defined
 within a SPARTA namespace (SPARTA_NS) if you use them from another C++
 application.
 </P>
-<P>Library.cpp contains these 4 functions:
+<P>Library.cpp provides these core functions:
 </P>
 <PRE>void sparta_open(int, char **, MPI_Comm, void **);
 void sparta_close(void *);
@@ -526,15 +526,30 @@ interleaving the sparta_command() calls with other calls to extract
 information from SPARTA, perform its own operations, or call another
 code's library.
 </P>
-<P>Other useful functions are also included in library.cpp. For example:
-</P>
-<PRE>void *sparta_extract_global(void *, char *)
-void *sparta_extract_compute(void *, char *, int, int)
-void *sparta_extract_variable(void *, char *, char *) 
-</PRE>
-<P>This can extract various global quantities from SPARTA as well as
-values calculated by a compute or variable.  See the library.cpp file
-and its associated header file library.h for details.
+<P>Beyond these, library.cpp provides many additional functions so a
+driver program can run SPARTA, read its output, handle errors, and
+introspect its build.  Briefly, these include: functions to execute a
+multi-line command string (sparta_commands_string) and to query or
+interrupt a run (sparta_is_running, sparta_force_timeout); functions to
+read thermodynamic output, both live (sparta_get_thermo) and from a
+cached snapshot of the most recent output that can be read while a run
+is in progress (sparta_last_thermo); error-handling functions that let
+a driver recover from an error instead of aborting the process, when
+SPARTA is built with exceptions (sparta_has_error,
+sparta_get_last_error_message); data-extraction functions for global
+quantities and settings such as box bounds, units, the version, the
+git commit and branch, and per-surface counts (sparta_extract_global,
+sparta_extract_setting) and for per-particle, per-grid, per-surface or
+global data produced by a compute or fix (sparta_extract_compute,
+sparta_extract_fix, sparta_extract_variable); introspection functions
+to enumerate the styles compiled into the executable (sparta_style_count,
+sparta_style_name) and the currently defined computes, fixes, dumps,
+regions, variables, mixtures and surface collision/reaction models
+(sparta_id_count, sparta_id_name); and build-configuration queries
+(sparta_version, sparta_config_has_package, sparta_config_accelerator,
+and the sparta_config_has_*_support functions for MPI, PNG, JPEG,
+FFmpeg and gzip support).  See the library.cpp file and its associated
+header file library.h for the full list and exact signatures.
 </P>
 <P>Other functions may be added to the library interface as needed to
 allow reading from or writing to internal SPARTA data structures. 

--- a/doc/Section_howto.txt
+++ b/doc/Section_howto.txt
@@ -479,7 +479,7 @@ internal SPARTA operations.  Note that SPARTA classes are defined
 within a SPARTA namespace (SPARTA_NS) if you use them from another C++
 application.
 
-Library.cpp contains these 4 functions:
+Library.cpp provides these core functions:
 
 void sparta_open(int, char **, MPI_Comm, void **);
 void sparta_close(void *);
@@ -516,15 +516,30 @@ interleaving the sparta_command() calls with other calls to extract
 information from SPARTA, perform its own operations, or call another
 code's library.
 
-Other useful functions are also included in library.cpp. For example:
-
-void *sparta_extract_global(void *, char *)
-void *sparta_extract_compute(void *, char *, int, int)
-void *sparta_extract_variable(void *, char *, char *) :pre
-
-This can extract various global quantities from SPARTA as well as
-values calculated by a compute or variable.  See the library.cpp file
-and its associated header file library.h for details.
+Beyond these, library.cpp provides many additional functions so a
+driver program can run SPARTA, read its output, handle errors, and
+introspect its build.  Briefly, these include: functions to execute a
+multi-line command string (sparta_commands_string) and to query or
+interrupt a run (sparta_is_running, sparta_force_timeout); functions to
+read thermodynamic output, both live (sparta_get_thermo) and from a
+cached snapshot of the most recent output that can be read while a run
+is in progress (sparta_last_thermo); error-handling functions that let
+a driver recover from an error instead of aborting the process, when
+SPARTA is built with exceptions (sparta_has_error,
+sparta_get_last_error_message); data-extraction functions for global
+quantities and settings such as box bounds, units, the version, the
+git commit and branch, and per-surface counts (sparta_extract_global,
+sparta_extract_setting) and for per-particle, per-grid, per-surface or
+global data produced by a compute or fix (sparta_extract_compute,
+sparta_extract_fix, sparta_extract_variable); introspection functions
+to enumerate the styles compiled into the executable (sparta_style_count,
+sparta_style_name) and the currently defined computes, fixes, dumps,
+regions, variables, mixtures and surface collision/reaction models
+(sparta_id_count, sparta_id_name); and build-configuration queries
+(sparta_version, sparta_config_has_package, sparta_config_accelerator,
+and the sparta_config_has_*_support functions for MPI, PNG, JPEG,
+FFmpeg and gzip support).  See the library.cpp file and its associated
+header file library.h for the full list and exact signatures.
 
 Other functions may be added to the library interface as needed to
 allow reading from or writing to internal SPARTA data structures. 

--- a/doc/Section_start.html
+++ b/doc/Section_start.html
@@ -1397,9 +1397,14 @@ since multiple processors cannot all read from stdin.
 </P>
 <PRE>-help 
 </PRE>
-<P>Print a list of options compiled into this executable for each SPARTA
-style (fix, compute, collide, etc).  SPARTA will print the info and
-immediately exit if this switch is used.
+<P>Print a detailed report about this executable and immediately exit.
+The report includes a banner (the SPARTA version, the git commit and
+branch it was built from, the build date, the compiler and C++
+standard, and the target operating system and architecture), the build
+configuration (serial vs. MPI, the KOKKOS accelerator, and PNG, JPEG,
+FFmpeg and gzip support), the list of command-line switches, and the
+list of options (fix, compute, collide, etc.) compiled into this
+executable.
 </P>
 <PRE>-kokkos on/off keyword/value ... 
 </PRE>

--- a/doc/Section_start.txt
+++ b/doc/Section_start.txt
@@ -1418,9 +1418,14 @@ since multiple processors cannot all read from stdin.
 
 -help :pre
 
-Print a list of options compiled into this executable for each SPARTA
-style (fix, compute, collide, etc).  SPARTA will print the info and
-immediately exit if this switch is used.
+Print a detailed report about this executable and immediately exit.
+The report includes a banner (the SPARTA version, the git commit and
+branch it was built from, the build date, the compiler and C++
+standard, and the target operating system and architecture), the build
+configuration (serial vs. MPI, the KOKKOS accelerator, and PNG, JPEG,
+FFmpeg and gzip support), the list of command-line switches, and the
+list of options (fix, compute, collide, etc.) compiled into this
+executable.
 
 -kokkos on/off keyword/value ... :pre
 

--- a/doc/dump_image.html
+++ b/doc/dump_image.html
@@ -33,7 +33,7 @@
 
 <LI>zero or more keyword/value pairs may be appended 
 
-<LI>keyword = <I>particle</I> or <I>pdiam</I> or <I>grid</I> or <I>gridx</I> or <I>gridy</I> or <I>gridz</I> or <I>surf</I> or <I>size</I> or <I>view</I> or <I>center</I> or <I>up</I> or <I>zoom</I> or <I>persp</I> or <I>box</I> or <I>gline</I> or <I>sline</I> or <I>axes</I> or <I>shiny</I> or <I>ssao</I> 
+<LI>keyword = <I>particle</I> or <I>pdiam</I> or <I>grid</I> or <I>gridx</I> or <I>gridy</I> or <I>gridz</I> or <I>surf</I> or <I>size</I> or <I>view</I> or <I>center</I> or <I>up</I> or <I>zoom</I> or <I>persp</I> or <I>box</I> or <I>subbox</I> or <I>gline</I> or <I>sline</I> or <I>axes</I> or <I>shiny</I> or <I>ssao</I> or <I>fsaa</I> 
 
 <PRE>  <I>particle</I> = yes/no = do or do not draw particles
   <I>pdiam</I> value = number = numeric value for particle diameter (distance units)
@@ -74,6 +74,9 @@
   <I>box</I> values = yes/no diam = draw outline of simulation box
     yes/no = do or do not draw simulation box lines
     diam = diameter of box lines as fraction of shortest box length
+  <I>subbox</I> values = yes/no diam = draw outline of processor sub-boxes
+    yes/no = do or do not draw processor sub-box lines
+    diam = diameter of sub-box lines as fraction of shortest box length
   <I>gline</I> values = yes/no diam = draw outline of each grid cell
     yes/no = do or do not draw grid cell outlines
     diam = diameter of grid outlines as fraction of shortest box length
@@ -89,7 +92,9 @@
   <I>ssao</I> value = yes/no seed dfactor = SSAO depth shading
     yes/no = turn depth shading on/off
     seed = random # seed (positive integer)
-    dfactor = strength of shading from 0.0 to 1.0 
+    dfactor = strength of shading from 0.0 to 1.0
+  <I>fsaa</I> value = yes/no = full scene anti-aliasing
+    yes/no = do or do not anti-alias the image 
 </PRE>
 
 </UL>
@@ -500,6 +505,17 @@ fraction of the shortest box length in x,y,z (for 3d) or x,y (for 2d).
 The color of the box boundaries can be set with the <A HREF = "dump_modify.html">dump_modify
 boxcolor</A> command.
 </P>
+<P>The <I>subbox</I> keyword determines how the boundaries of each
+processor's sub-domain are rendered as thin cylinders in the image,
+in the same manner as the <I>box</I> keyword.  Sub-domain boundaries can
+only be drawn if a recursive coordinate bisectioning (RCB) balance
+has assigned a sub-box to each processor, via the
+<A HREF = "balance_grid.html">balance_grid rcb</A> or <A HREF = "fix_balance.html">fix balance rcb</A>
+commands; otherwise this keyword is ignored.  This can be used to
+visualize the parallel load balance of a simulation.  The color of
+the sub-box boundaries can be set with the <A HREF = "dump_modify.html">dump_modify
+subboxcolor</A> command.
+</P>
 <P>The <I>gline</I> keyword determines how the outlines of grid cells are
 rendered as thin cylinders in the image.  If the <I>gridx</I> or <I>gridy</I> or
 <I>gridz</I> keywords are specified to draw a plane(s) of grid cells, then
@@ -549,6 +565,14 @@ which is perceived as depth.  The calculation of this effect can
 increase the cost of computing the image by roughly 2x.  The strength
 of the effect can be scaled by the <I>dfactor</I> parameter.  If <I>no</I> is
 set, no depth shading is performed.
+</P>
+<P>The <I>fsaa</I> keyword turns on/off full scene anti-aliasing (FSAA).  If
+<I>yes</I> is set, the image is rendered internally at twice the requested
+size and then scaled back down by averaging, which smooths jagged
+edges of rendered objects.  This increases the cost of computing the
+image by roughly 4x.  The written image has the size requested by the
+<I>size</I> keyword, regardless of this setting.  If <I>no</I> is set, no
+anti-aliasing is performed.
 </P>
 <HR>
 
@@ -684,10 +708,12 @@ mp4).
 <LI>zoom = 1.0
 <LI>persp = 0.0
 <LI>box = yes 0.02
+<LI>subbox = no 0.02
 <LI>gline = no 0.0
 <LI>sline = no 0.0
 <LI>axes = no 0.0 0.0
 <LI>shiny = 1.0
-<LI>ssao = no 
+<LI>ssao = no
+<LI>fsaa = no 
 </UL>
 </HTML>

--- a/doc/dump_image.txt
+++ b/doc/dump_image.txt
@@ -21,7 +21,7 @@ file = name of file to write image to :l
 color = particle attribute that determines color of each particle :l
 diameter = particle attribute that determines size of each particle :l
 zero or more keyword/value pairs may be appended :l
-keyword = {particle} or {pdiam} or {grid} or {gridx} or {gridy} or {gridz} or {surf} or {size} or {view} or {center} or {up} or {zoom} or {persp} or {box} or {gline} or {sline} or {axes} or {shiny} or {ssao} :l
+keyword = {particle} or {pdiam} or {grid} or {gridx} or {gridy} or {gridz} or {surf} or {size} or {view} or {center} or {up} or {zoom} or {persp} or {box} or {subbox} or {gline} or {sline} or {axes} or {shiny} or {ssao} or {fsaa} :l
   {particle} = yes/no = do or do not draw particles
   {pdiam} value = number = numeric value for particle diameter (distance units)
   {grid} values = color
@@ -61,6 +61,9 @@ keyword = {particle} or {pdiam} or {grid} or {gridx} or {gridy} or {gridz} or {s
   {box} values = yes/no diam = draw outline of simulation box
     yes/no = do or do not draw simulation box lines
     diam = diameter of box lines as fraction of shortest box length
+  {subbox} values = yes/no diam = draw outline of processor sub-boxes
+    yes/no = do or do not draw processor sub-box lines
+    diam = diameter of sub-box lines as fraction of shortest box length
   {gline} values = yes/no diam = draw outline of each grid cell
     yes/no = do or do not draw grid cell outlines
     diam = diameter of grid outlines as fraction of shortest box length
@@ -76,7 +79,9 @@ keyword = {particle} or {pdiam} or {grid} or {gridx} or {gridy} or {gridz} or {s
   {ssao} value = yes/no seed dfactor = SSAO depth shading
     yes/no = turn depth shading on/off
     seed = random # seed (positive integer)
-    dfactor = strength of shading from 0.0 to 1.0 :pre
+    dfactor = strength of shading from 0.0 to 1.0
+  {fsaa} value = yes/no = full scene anti-aliasing
+    yes/no = do or do not anti-alias the image :pre
 :ule
 
 [Examples:]
@@ -484,6 +489,17 @@ fraction of the shortest box length in x,y,z (for 3d) or x,y (for 2d).
 The color of the box boundaries can be set with the "dump_modify
 boxcolor"_dump_modify.html command.
 
+The {subbox} keyword determines how the boundaries of each
+processor's sub-domain are rendered as thin cylinders in the image,
+in the same manner as the {box} keyword.  Sub-domain boundaries can
+only be drawn if a recursive coordinate bisectioning (RCB) balance
+has assigned a sub-box to each processor, via the
+"balance_grid rcb"_balance_grid.html or "fix balance rcb"_fix_balance.html
+commands; otherwise this keyword is ignored.  This can be used to
+visualize the parallel load balance of a simulation.  The color of
+the sub-box boundaries can be set with the "dump_modify
+subboxcolor"_dump_modify.html command.
+
 The {gline} keyword determines how the outlines of grid cells are
 rendered as thin cylinders in the image.  If the {gridx} or {gridy} or
 {gridz} keywords are specified to draw a plane(s) of grid cells, then
@@ -533,6 +549,14 @@ which is perceived as depth.  The calculation of this effect can
 increase the cost of computing the image by roughly 2x.  The strength
 of the effect can be scaled by the {dfactor} parameter.  If {no} is
 set, no depth shading is performed.
+
+The {fsaa} keyword turns on/off full scene anti-aliasing (FSAA).  If
+{yes} is set, the image is rendered internally at twice the requested
+size and then scaled back down by averaging, which smooths jagged
+edges of rendered objects.  This increases the cost of computing the
+image by roughly 4x.  The written image has the size requested by the
+{size} keyword, regardless of this setting.  If {no} is set, no
+anti-aliasing is performed.
 
 :line
 
@@ -668,8 +692,10 @@ up = 0 1 0 (for 2d)
 zoom = 1.0
 persp = 0.0
 box = yes 0.02
+subbox = no 0.02
 gline = no 0.0
 sline = no 0.0
 axes = no 0.0 0.0
 shiny = 1.0
-ssao = no :ul
+ssao = no
+fsaa = no :ul

--- a/doc/dump_modify.html
+++ b/doc/dump_modify.html
@@ -47,10 +47,12 @@
 </PRE>
 <LI>these keywords apply only to the (image</I> and <I>movie</I> <A HREF = "dump_image.html">styles</A> 
 
-<LI>keyword = <I>bcolor</I> or <I>bdiam</I> or <I>backcolor</I> or <I>bitrate</I> or <I>boxcolor</I> or <I>cmap</I> or <I>color</I> or <I>framerate</I> or <I>gcolor</I> or <I>glinecolor</I> or <I>pcolor</I> or <I>pdiam</I> or <I>scolor</I> or <I>slinecolor</I> 
+<LI>keyword = <I>backcolor</I> or <I>backcolor2</I> or <I>bitrate</I> or <I>boxcolor</I> or <I>cmap</I> or <I>color</I> or <I>framerate</I> or <I>gcolor</I> or <I>glinecolor</I> or <I>gridgroup</I> or <I>lights</I> or <I>pcolor</I> or <I>pdiam</I> or <I>scolor</I> or <I>slinecolor</I> or <I>subboxcolor</I> or <I>surfgroup</I> 
 
 <PRE>  <I>backcolor</I> arg = color
     color = name of color for background
+  <I>backcolor2</I> arg = color
+    color = name of second color for background gradient, or <I>none</I>
   <I>bitrate</I> arg = rate
     rate = target bitrate for movie in kbps
   <I>boxcolor</I> arg = color
@@ -88,6 +90,11 @@
     color = name of color for grid cell outlines
   <I>gridgroup</I> arg = group-ID
     group-ID = name of a user-defined grid group, see the <A HREF = "group.html">group</A> command
+  <I>lights</I> args = ambient key fill back
+    ambient = intensity of ambient light from 0.0 to 1.0
+    key = intensity of key light from 0.0 to 1.0
+    fill = intensity of fill light from 0.0 to 1.0
+    back = intensity of back light from 0.0 to 1.0
   <I>pcolor</I> args = type color
     type = particle type or range of types or proc ID or range of IDs (see below)
     color = name of color or color1/color2/...
@@ -99,6 +106,8 @@
     color = name of color for surf one option
   <I>slinecolor</I> arg = color
     color = name of color for surface element outlines
+  <I>subboxcolor</I> arg = color
+    color = name of color for processor sub-box lines
   <I>surfgroup</I> arg = group-ID
     group-ID = name of a user-defined surf group, see the <A HREF = "group.html">group</A> command 
 </PRE>
@@ -316,6 +325,17 @@ below) or a color name defined by the dump_modify color option.
 </P>
 <HR>
 
+<P>The <I>backcolor2</I> keyword can be used with the <A HREF = "dump_image.html">dump
+image</A> command to set a second background color.  If
+set to a color name, the background of the images becomes a vertical
+gradient from the <I>backcolor</I> color at the bottom of the image to the
+<I>backcolor2</I> color at the top.  If set to <I>none</I>, the gradient is
+turned off and the uniform <I>backcolor</I> color is used.  The color name
+can be any of the 140 pre-defined colors (see below) or a color name
+defined by the dump_modify color option.
+</P>
+<HR>
+
 <P>The <I>bitrate</I> keyword can be used with the <A HREF = "dump_image.html">dump
 movie</A> command to define the size of the resulting
 movie file and its quality via setting how many kbits per second are
@@ -526,6 +546,15 @@ group-ID argument can be any valid grid group name, as defined by the
 </P>
 <HR>
 
+<P>The <I>lights</I> keyword can be used with the <A HREF = "dump_image.html">dump
+image</A> command to adjust the lighting of the rendered
+scene.  The scene is illuminated by an ambient light, a key light, a
+fill light, and a back light, whose grayscale intensities are set by
+the four arguments, each a value from 0.0 (off) to 1.0 (brightest).
+The default lighting is ambient 0.0, key 0.9, fill 0.45, back 0.9.
+</P>
+<HR>
+
 <P>The <I>pcolor</I> keyword can be used one or more times with the <A HREF = "dump_image.html">dump
 image</A> command, only when its particle color setting is
 <I>type</I> or <I>procs</I>, to set the color that particles will be drawn in
@@ -615,6 +644,15 @@ option.
 </P>
 <HR>
 
+<P>The <I>subboxcolor</I> keyword can be used with the <A HREF = "dump_image.html">dump
+image</A> command to set the color of the processor
+sub-box boundaries drawn in each image.  See the "dump image subbox"
+command for how to specify that sub-box boundaries be drawn.  The
+color name can be any of the 140 pre-defined colors (see below) or a
+color name defined by the dump_modify color option.
+</P>
+<HR>
+
 <P>The <I>surfgroup</I> keyword can be used with the <A HREF = "dump_image.html">dump
 image</A> command to only draw a subset of the surface
 elements in the simulation.  By default all the surface elements are
@@ -636,7 +674,10 @@ defined by the <A HREF = "group.html">group surf</A> command.
 <UL><LI>append = no
 <LI>buffer = yes for all dump styles except <I>image</I> and <I>movie</I>
 <LI>backcolor = black
+<LI>backcolor2 = none
 <LI>boxcolor = yellow
+<LI>subboxcolor = yellow
+<LI>lights = 0.0 0.9 0.45 0.9
 <LI>cmap = mode min max cf 0.0 2 min blue max red, for all modes
 <LI>color = 140 color names are pre-defined as listed below
 <LI>every = whatever it was set to via the <A HREF = "dump.html">dump</A> command

--- a/doc/dump_modify.txt
+++ b/doc/dump_modify.txt
@@ -38,9 +38,11 @@ keyword = {append} or {buffer} or {every} or {fileper} or {first} or {flush} or 
     value = numeric value to compare to
     these 3 args can be replaced by the word "none" to turn off thresholding :pre
 these keywords apply only to the (image} and {movie} "styles"_dump_image.html :l
-keyword = {bcolor} or {bdiam} or {backcolor} or {bitrate} or {boxcolor} or {cmap} or {color} or {framerate} or {gcolor} or {glinecolor} or {pcolor} or {pdiam} or {scolor} or {slinecolor} :l
+keyword = {backcolor} or {backcolor2} or {bitrate} or {boxcolor} or {cmap} or {color} or {framerate} or {gcolor} or {glinecolor} or {gridgroup} or {lights} or {pcolor} or {pdiam} or {scolor} or {slinecolor} or {subboxcolor} or {surfgroup} :l
   {backcolor} arg = color
     color = name of color for background
+  {backcolor2} arg = color
+    color = name of second color for background gradient, or {none}
   {bitrate} arg = rate
     rate = target bitrate for movie in kbps
   {boxcolor} arg = color
@@ -78,6 +80,11 @@ keyword = {bcolor} or {bdiam} or {backcolor} or {bitrate} or {boxcolor} or {cmap
     color = name of color for grid cell outlines
   {gridgroup} arg = group-ID
     group-ID = name of a user-defined grid group, see the "group"_group.html command
+  {lights} args = ambient key fill back
+    ambient = intensity of ambient light from 0.0 to 1.0
+    key = intensity of key light from 0.0 to 1.0
+    fill = intensity of fill light from 0.0 to 1.0
+    back = intensity of back light from 0.0 to 1.0
   {pcolor} args = type color
     type = particle type or range of types or proc ID or range of IDs (see below)
     color = name of color or color1/color2/...
@@ -89,6 +96,8 @@ keyword = {bcolor} or {bdiam} or {backcolor} or {bitrate} or {boxcolor} or {cmap
     color = name of color for surf one option
   {slinecolor} arg = color
     color = name of color for surface element outlines
+  {subboxcolor} arg = color
+    color = name of color for processor sub-box lines
   {surfgroup} arg = group-ID
     group-ID = name of a user-defined surf group, see the "group"_group.html command :pre
 :ule
@@ -303,6 +312,17 @@ below) or a color name defined by the dump_modify color option.
 
 :line
 
+The {backcolor2} keyword can be used with the "dump
+image"_dump_image.html command to set a second background color.  If
+set to a color name, the background of the images becomes a vertical
+gradient from the {backcolor} color at the bottom of the image to the
+{backcolor2} color at the top.  If set to {none}, the gradient is
+turned off and the uniform {backcolor} color is used.  The color name
+can be any of the 140 pre-defined colors (see below) or a color name
+defined by the dump_modify color option.
+
+:line
+
 The {bitrate} keyword can be used with the "dump
 movie"_dump_image.html command to define the size of the resulting
 movie file and its quality via setting how many kbits per second are
@@ -513,6 +533,15 @@ group-ID argument can be any valid grid group name, as defined by the
 
 :line
 
+The {lights} keyword can be used with the "dump
+image"_dump_image.html command to adjust the lighting of the rendered
+scene.  The scene is illuminated by an ambient light, a key light, a
+fill light, and a back light, whose grayscale intensities are set by
+the four arguments, each a value from 0.0 (off) to 1.0 (brightest).
+The default lighting is ambient 0.0, key 0.9, fill 0.45, back 0.9.
+
+:line
+
 The {pcolor} keyword can be used one or more times with the "dump
 image"_dump_image.html command, only when its particle color setting is
 {type} or {procs}, to set the color that particles will be drawn in
@@ -602,6 +631,15 @@ option.
 
 :line
 
+The {subboxcolor} keyword can be used with the "dump
+image"_dump_image.html command to set the color of the processor
+sub-box boundaries drawn in each image.  See the "dump image subbox"
+command for how to specify that sub-box boundaries be drawn.  The
+color name can be any of the 140 pre-defined colors (see below) or a
+color name defined by the dump_modify color option.
+
+:line
+
 The {surfgroup} keyword can be used with the "dump
 image"_dump_image.html command to only draw a subset of the surface
 elements in the simulation.  By default all the surface elements are
@@ -623,7 +661,10 @@ The option defaults are
 append = no
 buffer = yes for all dump styles except {image} and {movie}
 backcolor = black
+backcolor2 = none
 boxcolor = yellow
+subboxcolor = yellow
+lights = 0.0 0.9 0.45 0.9
 cmap = mode min max cf 0.0 2 min blue max red, for all modes
 color = 140 color names are pre-defined as listed below
 every = whatever it was set to via the "dump"_dump.html command

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,10 +57,15 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_SPARTA_LIB_LINK}
 
 add_executable(${TARGET_SPARTA} main.cpp)
 target_link_libraries(${TARGET_SPARTA} LINK_PRIVATE ${TARGET_SPARTA_LIB})
-add_custom_command(
-  TARGET ${TARGET_SPARTA}
-  POST_BUILD
-  COMMAND size ${TARGET_SPARTA})
+# print the binary size after linking (informational). Skip when cross-
+# compiling: the command uses the bare target name, but on Windows the file is
+# spa_.exe, so `size spa_` fails the build during a MinGW64 cross-compile.
+if(NOT CMAKE_CROSSCOMPILING)
+  add_custom_command(
+    TARGET ${TARGET_SPARTA}
+    POST_BUILD
+    COMMAND size ${TARGET_SPARTA})
+endif()
 install(TARGETS ${TARGET_SPARTA} DESTINATION bin)
 # ######### END   GENERATION COMMANDS ##########
 

--- a/src/KOKKOS/kokkos.cpp
+++ b/src/KOKKOS/kokkos.cpp
@@ -24,6 +24,19 @@
 
 using namespace SPARTA_NS;
 
+// Kokkos may be initialized at most once per process and, once finalized, can
+// never be initialized again. When SPARTA is embedded as a library (a host
+// application reusing one process across many open/close cycles) Kokkos must be
+// initialized on first use and finalized once at process exit -- not in the
+// KokkosSPARTA destructor. These file-scope helpers track that lifetime.
+
+static int kokkos_initialized_nthreads = 0;
+
+static void sparta_kokkos_atexit()
+{
+  if (Kokkos::is_initialized() && !Kokkos::is_finalized()) Kokkos::finalize();
+}
+
 /* ---------------------------------------------------------------------- */
 
 KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(sparta)
@@ -144,7 +157,22 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
   args.set_num_threads(nthreads);
   args.set_device_id(device);
 
-  Kokkos::initialize(args);
+  // Initialize Kokkos only once per process (it can be initialized at most
+  // once), and register a one-time handler to finalize it at process exit.
+  // On any later re-open the requested thread count cannot be changed, so keep
+  // the count Kokkos was actually initialized with -- otherwise the atomics
+  // decision below would be made for the wrong number of threads.
+  if (!Kokkos::is_initialized()) {
+    Kokkos::initialize(args);
+    kokkos_initialized_nthreads = nthreads;
+    atexit(sparta_kokkos_atexit);
+  } else {
+    if (nthreads != kokkos_initialized_nthreads && me == 0)
+      error->warning(FLERR,"Kokkos is already initialized in this process; "
+                     "ignoring the new thread count. Restart to change the "
+                     "number of threads.");
+    nthreads = kokkos_initialized_nthreads;
+  }
 
   // default settings for package kokkos command
 
@@ -180,9 +208,10 @@ KokkosSPARTA::KokkosSPARTA(SPARTA *sparta, int narg, char **arg) : Pointers(spar
 
 KokkosSPARTA::~KokkosSPARTA()
 {
-  // finalize Kokkos
-
-  Kokkos::finalize();
+  // Kokkos is finalized once at process exit (see sparta_kokkos_atexit,
+  // registered in the constructor), not here, so a library embedder can
+  // destroy and re-create SPARTA in the same process without tripping over
+  // Kokkos's initialize-at-most-once restriction.
 }
 
 /* ----------------------------------------------------------------------

--- a/src/STUBS/CMakeLists.txt
+++ b/src/STUBS/CMakeLists.txt
@@ -1,8 +1,16 @@
 if(PKG_MPI_STUBS)
   # ######### BEGIN TARGET_SPARTA_BUILD_MPI_STUBS ##########
-  set(CMAKE_CXX_COMPILER "g++")
-  set(CMAKE_CXX_FLAGS "-O -fPIC")
-  set(CMAKE_AR "ar")
+  # Force the plain host compiler/archiver for the trivial MPI stubs when
+  # building natively (e.g. so a Kokkos/CUDA wrapper compiler is not used for
+  # them). Do NOT do this when cross-compiling: the stubs must be built with
+  # the same cross toolchain as the rest of SPARTA, otherwise they produce
+  # host-format objects that the target linker cannot use and the MPI_* symbols
+  # go missing from libsparta (e.g. the MinGW64 Windows DLL link).
+  if(NOT CMAKE_CROSSCOMPILING)
+    set(CMAKE_CXX_COMPILER "g++")
+    set(CMAKE_CXX_FLAGS "-O -fPIC")
+    set(CMAKE_AR "ar")
+  endif()
 
   # message(VERBOSE "${CMAKE_CURRENT_SOURCE_DIR}:
   # CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")

--- a/src/balance_grid.cpp
+++ b/src/balance_grid.cpp
@@ -331,18 +331,15 @@ void BalanceGrid::command(int narg, char **arg, int outflag)
 
     rcb->compute(nbalance,x,wt,eligible,rcbflip);
 
-    // DEBUG info for dump image
+    // store this proc's RCB sub-box for the dump image subbox keyword
 
-#ifdef RCB_DEBUG
-
+    update->rcbflag = 1;
     update->rcblo[0] = rcb->lo[0];
     update->rcblo[1] = rcb->lo[1];
     update->rcblo[2] = rcb->lo[2];
     update->rcbhi[0] = rcb->hi[0];
     update->rcbhi[1] = rcb->hi[1];
     update->rcbhi[2] = rcb->hi[2];
-
-#endif
 
     rcb->invert();
 

--- a/src/dump.cpp
+++ b/src/dump.cpp
@@ -60,6 +60,8 @@ Dump::Dump(SPARTA *sparta, int, char **arg) : Pointers(sparta)
   filename = new char[n];
   strcpy(filename,arg[4]);
 
+  filelast = NULL;
+
   first_flag = 0;
   flush_flag = 1;
 
@@ -132,6 +134,7 @@ Dump::~Dump()
   delete [] style;
   delete [] filename;
   delete [] multiname;
+  delete [] filelast;
 
   delete [] format;
   delete [] format_default;
@@ -421,6 +424,12 @@ void Dump::openfile()
 
     if (fp == NULL) error->one(FLERR,"Cannot open dump file");
   } else fp = NULL;
+
+  // remember name of the opened file, e.g. for a GUI to display
+
+  delete [] filelast;
+  filelast = new char[strlen(filecurrent) + 1];
+  strcpy(filelast,filecurrent);
 
   // delete string with timestep replaced
 

--- a/src/dump.h
+++ b/src/dump.h
@@ -52,6 +52,7 @@ class Dump : protected Pointers {
   int filewriter;            // 1 if this proc writes a file, else 0
   int fileproc;              // ID of proc in my cluster who writes to file
   char *multiname;           // filename with % converted to cluster ID
+  char *filelast;            // name of most recently opened dump file
   MPI_Comm clustercomm;      // MPI communicator within my cluster of procs
 
   int header_flag;           // 0 = item, 2 = xyz

--- a/src/dump_image.cpp
+++ b/src/dump_image.cpp
@@ -31,6 +31,9 @@
 #include "compute.h"
 #include "math_extra.h"
 #include "math_const.h"
+#include "update.h"
+#include "output.h"
+#include "stats.h"
 #include "error.h"
 #include "memory.h"
 
@@ -109,6 +112,7 @@ DumpImage::DumpImage(SPARTA *sparta, int narg, char **arg) :
   }
 
   boxcolor = image->color2rgb("yellow");
+  subboxcolor = image->color2rgb("yellow");
   surfcolorone = image->color2rgb("gray");
   glinecolor = image->color2rgb("white");
   slinecolor = image->color2rgb("white");
@@ -131,6 +135,8 @@ DumpImage::DumpImage(SPARTA *sparta, int narg, char **arg) :
   perspstr = NULL;
   boxflag = 1;
   boxdiam = 0.02;
+  subboxflag = 0;
+  subboxdiam = 0.02;
   glineflag = 0;
   slineflag = 0;
   axesflag = 0;
@@ -324,8 +330,13 @@ DumpImage::DumpImage(SPARTA *sparta, int narg, char **arg) :
       int height = atoi(arg[iarg+2]);
       if (width <= 0 || height <= 0)
         error->all(FLERR,"Illegal dump image command");
-      image->width = width;
-      image->height = height;
+      if (image->fsaa) {
+        image->width = width*2;
+        image->height = height*2;
+      } else {
+        image->width = width;
+        image->height = height;
+      }
       iarg += 3;
 
     } else if (strcmp(arg[iarg],"view") == 0) {
@@ -432,6 +443,15 @@ DumpImage::DumpImage(SPARTA *sparta, int narg, char **arg) :
       if (boxdiam < 0.0) error->all(FLERR,"Illegal dump image command");
       iarg += 3;
 
+    } else if (strcmp(arg[iarg],"subbox") == 0) {
+      if (iarg+3 > narg) error->all(FLERR,"Illegal dump image command");
+      if (strcmp(arg[iarg+1],"yes") == 0) subboxflag = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) subboxflag = 0;
+      else error->all(FLERR,"Illegal dump image command");
+      subboxdiam = atof(arg[iarg+2]);
+      if (subboxdiam < 0.0) error->all(FLERR,"Illegal dump image command");
+      iarg += 3;
+
     } else if (strcmp(arg[iarg],"gline") == 0) {
       if (iarg+3 > narg) error->all(FLERR,"Illegal dump image command");
       if (strcmp(arg[iarg+1],"yes") == 0) glineflag = 1;
@@ -482,6 +502,26 @@ DumpImage::DumpImage(SPARTA *sparta, int narg, char **arg) :
         error->all(FLERR,"Illegal dump image command");
       image->ssaoint = ssaoint;
       iarg += 4;
+
+    } else if (strcmp(arg[iarg],"fsaa") == 0) {
+
+      // with FSAA the image is rendered at twice the requested size,
+      // then scaled back down when it is written
+
+      if (iarg+2 > narg) error->all(FLERR,"Illegal dump image command");
+      int aa;
+      if (strcmp(arg[iarg+1],"yes") == 0) aa = 1;
+      else if (strcmp(arg[iarg+1],"no") == 0) aa = 0;
+      else error->all(FLERR,"Illegal dump image command");
+      if (aa && !image->fsaa) {
+        image->width = image->width*2;
+        image->height = image->height*2;
+      } else if (!aa && image->fsaa) {
+        image->width = image->width/2;
+        image->height = image->height/2;
+      }
+      image->fsaa = aa;
+      iarg += 2;
 
     } else error->all(FLERR,"Illegal dump image command");
   }
@@ -1058,6 +1098,10 @@ void DumpImage::write()
       fp = NULL;
     }
   }
+
+  // record completed image filename, e.g. for a GUI to display
+
+  output->stats->set_last_image(filelast);
 }
 
 /* ----------------------------------------------------------------------
@@ -1718,27 +1762,38 @@ void DumpImage::create_image()
     image->draw_axes(axes,diameter);
   }
 
-  // DEBUG - render each proc's RCB box
-  // need to add logic for 3d to this
+  // render each proc's RCB sub-box
+  // only possible if an RCB balance has assigned a sub-box to each proc,
+  // e.g. via balance_grid rcb or fix balance rcb
 
-#ifdef RCB_DEBUG
+  if (subboxflag && update->rcbflag) {
+    diameter = MIN(boxxhi-boxxlo,boxyhi-boxylo);
+    if (domain->dimension == 3) diameter = MIN(diameter,boxzhi-boxzlo);
+    diameter *= subboxdiam;
 
-  diameter = MIN(boxxhi-boxxlo,boxyhi-boxylo);
-  if (domain->dimension == 3) diameter = MIN(diameter,boxzhi-boxzlo);
-  diameter *= 0.5*boxdiam;
+    double *rcblo = update->rcblo;
+    double *rcbhi = update->rcbhi;
 
-  double *rcblo = update->rcblo;
-  double *rcbhi = update->rcbhi;
-
-  double box[4][3];
-  box[0][0] = rcblo[0]; box[0][1] = rcblo[1]; box[0][2] = boxzhi;
-  box[1][0] = rcbhi[0]; box[1][1] = rcblo[1]; box[1][2] = boxzhi;
-  box[2][0] = rcblo[0]; box[2][1] = rcbhi[1]; box[2][2] = boxzhi;
-  box[3][0] = rcbhi[0]; box[3][1] = rcbhi[1]; box[3][2] = boxzhi;
-  image->draw_box2d(box,boxcolor,diameter);
-
-#endif
-
+    if (domain->dimension == 2) {
+      double box[4][3];
+      box[0][0] = rcblo[0]; box[0][1] = rcblo[1]; box[0][2] = boxzhi;
+      box[1][0] = rcbhi[0]; box[1][1] = rcblo[1]; box[1][2] = boxzhi;
+      box[2][0] = rcblo[0]; box[2][1] = rcbhi[1]; box[2][2] = boxzhi;
+      box[3][0] = rcbhi[0]; box[3][1] = rcbhi[1]; box[3][2] = boxzhi;
+      image->draw_box2d(box,subboxcolor,diameter);
+    } else {
+      double box[8][3];
+      box[0][0] = rcblo[0]; box[0][1] = rcblo[1]; box[0][2] = rcblo[2];
+      box[1][0] = rcbhi[0]; box[1][1] = rcblo[1]; box[1][2] = rcblo[2];
+      box[2][0] = rcblo[0]; box[2][1] = rcbhi[1]; box[2][2] = rcblo[2];
+      box[3][0] = rcbhi[0]; box[3][1] = rcbhi[1]; box[3][2] = rcblo[2];
+      box[4][0] = rcblo[0]; box[4][1] = rcblo[1]; box[4][2] = rcbhi[2];
+      box[5][0] = rcbhi[0]; box[5][1] = rcblo[1]; box[5][2] = rcbhi[2];
+      box[6][0] = rcblo[0]; box[6][1] = rcbhi[1]; box[6][2] = rcbhi[2];
+      box[7][0] = rcbhi[0]; box[7][1] = rcbhi[1]; box[7][2] = rcbhi[2];
+      image->draw_box(box,subboxcolor,diameter);
+    }
+  }
 }
 
 /* ---------------------------------------------------------------------- */
@@ -1758,12 +1813,62 @@ int DumpImage::modify_param(int narg, char **arg)
     return 2;
   }
 
+  if (strcmp(arg[0],"backcolor2") == 0) {
+
+    // second background color for a vertical gradient
+    // "none" turns the gradient off
+
+    if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
+    if (strcmp(arg[1],"none") == 0) {
+      image->background2[0] = image->background2[1] =
+        image->background2[2] = -1;
+      return 2;
+    }
+    double *color = image->color2rgb(arg[1]);
+    if (color == NULL) error->all(FLERR,"Invalid color in dump_modify command");
+    image->background2[0] = static_cast<int> (color[0]*255.0);
+    image->background2[1] = static_cast<int> (color[1]*255.0);
+    image->background2[2] = static_cast<int> (color[2]*255.0);
+    return 2;
+  }
+
   if (strcmp(arg[0],"boxcolor") == 0) {
     if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
     boxcolor = image->color2rgb(arg[1]);
     if (boxcolor == NULL)
       error->all(FLERR,"Invalid color in dump_modify command");
     return 2;
+  }
+
+  if (strcmp(arg[0],"subboxcolor") == 0) {
+    if (narg < 2) error->all(FLERR,"Illegal dump_modify command");
+    subboxcolor = image->color2rgb(arg[1]);
+    if (subboxcolor == NULL)
+      error->all(FLERR,"Invalid color in dump_modify command");
+    return 2;
+  }
+
+  if (strcmp(arg[0],"lights") == 0) {
+
+    // grayscale intensities of the ambient, key, fill, and back lights
+
+    if (narg < 5) error->all(FLERR,"Illegal dump_modify command");
+    double ambient = atof(arg[1]);
+    double key = atof(arg[2]);
+    double fill = atof(arg[3]);
+    double back = atof(arg[4]);
+    if (ambient < 0.0 || ambient > 1.0 || key < 0.0 || key > 1.0 ||
+        fill < 0.0 || fill > 1.0 || back < 0.0 || back > 1.0)
+      error->all(FLERR,"Illegal dump_modify command");
+    image->ambientColor[0] = image->ambientColor[1] =
+      image->ambientColor[2] = ambient;
+    image->keyLightColor[0] = image->keyLightColor[1] =
+      image->keyLightColor[2] = key;
+    image->fillLightColor[0] = image->fillLightColor[1] =
+      image->fillLightColor[2] = fill;
+    image->backLightColor[0] = image->backLightColor[1] =
+      image->backLightColor[2] = back;
+    return 5;
   }
 
   if (strcmp(arg[0],"cmap") == 0) {
@@ -1777,8 +1882,11 @@ int DumpImage::modify_param(int narg, char **arg)
     else if (strcmp(arg[1],"gridz") == 0) which = ZPLANE;
     else error->all(FLERR,"Illegal dump_modify command");
     if (strlen(arg[4]) != 2) error->all(FLERR,"Illegal dump_modify command");
-    int factor = 2;
+    int factor;
     if (arg[4][0] == 's') factor = 1;
+    else if (arg[4][0] == 'c') factor = 2;
+    else if (arg[4][0] == 'd') factor = 3;
+    else error->all(FLERR,"Illegal dump_modify command");
     int nentry = atoi(arg[6]);
     if (nentry < 1) error->all(FLERR,"Illegal dump_modify command");
     int n = 7 + factor*nentry;

--- a/src/dump_image.h
+++ b/src/dump_image.h
@@ -46,6 +46,9 @@ class DumpImage : public DumpParticle {
   int zoomvar,perspvar;            // index to zoom,persp vars
   int boxflag,axesflag;            // 0/1 for draw box and axes
   double boxdiam,axeslen,axesdiam; // params for drawing box and axes
+  int subboxflag;                  // 0/1 for draw per-proc RCB sub-boxes
+  double subboxdiam;               // params for drawing sub-boxes
+  double *subboxcolor;
   double *boxcolor;                // colors for drawing box/grid/surf lines
 
   int viewflag;                    // overall view is static or dynamic

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -14,7 +14,9 @@
 
 #include "mpi.h"
 #include "stdlib.h"
+#include "stdio.h"
 #include "error.h"
+#include "spaexception.h"
 #include "universe.h"
 #include "output.h"
 #include "memory.h"
@@ -22,13 +24,39 @@
 
 using namespace SPARTA_NS;
 
+// helper to format "message (file:line)" like the printed error text
+
+static std::string truncpath(const char *path)
+{
+  if (path) {
+    std::string full(path);
+    std::size_t src = full.rfind("src/");
+    if (src != std::string::npos) return full.substr(src);
+    return full;
+  }
+  return "(unknown)";
+}
+
+static std::string fmt_error(const char *str, const char *file, int line)
+{
+  std::string msg = str ? str : "(unknown error)";
+  msg += " (";
+  msg += truncpath(file);
+  msg += ":";
+  msg += std::to_string(line);
+  msg += ")";
+  return msg;
+}
+
 /* ---------------------------------------------------------------------- */
 
 Error::Error(SPARTA *sparta) : Pointers(sparta) {}
 
 /* ----------------------------------------------------------------------
    called by all procs in universe
-   close all output, screen, and log files in world and universe
+   write error message to universe screen and logfile
+   throw SpartaException, which all procs in the universe unwind to,
+   either main() which terminates or the library interface which recovers
 ------------------------------------------------------------------------- */
 
 void Error::universe_all(const char *file, int line, const char *str)
@@ -40,22 +68,19 @@ void Error::universe_all(const char *file, int line, const char *str)
                                    "ERROR: %s (%s:%d)\n",str,file,line);
     if (universe->ulogfile) fprintf(universe->ulogfile,
                                     "ERROR: %s (%s:%d)\n",str,file,line);
+    if (universe->uscreen) fflush(universe->uscreen);
+    if (universe->ulogfile) fflush(universe->ulogfile);
   }
 
-  if (output) delete output;
-  if (universe->nworlds > 1) {
-    if (screen && screen != stdout) fclose(screen);
-    if (logfile) fclose(logfile);
-  }
-  if (universe->ulogfile) fclose(universe->ulogfile);
-
-  if (sparta->kokkos) Kokkos::finalize();
-  MPI_Finalize();
-  exit(1);
+  std::string msg = fmt_error(str,file,line);
+  set_last_error(msg.c_str(),ERROR_NORMAL);
+  throw SpartaException(msg);
 }
 
 /* ----------------------------------------------------------------------
    called by one proc in universe
+   throw SpartaAbortException; catch site must MPI_Abort if parallel,
+   can recover if serial
 ------------------------------------------------------------------------- */
 
 void Error::universe_one(const char *file, int line, const char *str)
@@ -65,12 +90,17 @@ void Error::universe_one(const char *file, int line, const char *str)
             universe->me,str,file,line);
     fflush(universe->uscreen);
   }
-  MPI_Abort(universe->uworld,1);
+
+  std::string msg = fmt_error(str,file,line);
+  set_last_error(msg.c_str(),ERROR_ABORT);
+  throw SpartaAbortException(msg,universe->uworld);
 }
 
 /* ----------------------------------------------------------------------
    called by all procs in one world
-   close all output, screen, and log files in world
+   write error message to world screen and logfile
+   throw SpartaException, which all procs in the world unwind to,
+   either main() which terminates or the library interface which recovers
 ------------------------------------------------------------------------- */
 
 void Error::all(const char *file, int line, const char *str)
@@ -83,21 +113,21 @@ void Error::all(const char *file, int line, const char *str)
   if (me == 0) {
     if (screen) fprintf(screen,"ERROR: %s (%s:%d)\n",str,file,line);
     if (logfile) fprintf(logfile,"ERROR: %s (%s:%d)\n",str,file,line);
+    if (screen) fflush(screen);
+    if (logfile) fflush(logfile);
   }
 
-  if (output) delete output;
-  if (screen && screen != stdout) fclose(screen);
-  if (logfile) fclose(logfile);
-
-  if (sparta->kokkos) Kokkos::finalize();
-  MPI_Finalize();
-  exit(1);
+  std::string msg = fmt_error(str,file,line);
+  set_last_error(msg.c_str(),ERROR_NORMAL);
+  throw SpartaException(msg);
 }
 
 /* ----------------------------------------------------------------------
    called by one proc in world
    write to world screen only if non-NULL on this proc
    always write to universe screen
+   throw SpartaAbortException; catch site must MPI_Abort if parallel,
+   can recover if serial
 ------------------------------------------------------------------------- */
 
 void Error::one(const char *file, int line, const char *str)
@@ -114,7 +144,10 @@ void Error::one(const char *file, int line, const char *str)
             universe->me,str,file,line);
     fflush(universe->uscreen);
   }
-  MPI_Abort(world,1);
+
+  std::string msg = fmt_error(str,file,line);
+  set_last_error(msg.c_str(),ERROR_ABORT);
+  throw SpartaAbortException(msg,world);
 }
 
 /* ----------------------------------------------------------------------
@@ -143,6 +176,7 @@ void Error::message(const char *file, int line, const char *str, int logflag)
 /* ----------------------------------------------------------------------
    called by all procs in one world
    close all output, screen, and log files in world
+   this terminates the process and is only invoked by the quit command
 ------------------------------------------------------------------------- */
 
 void Error::done()
@@ -156,4 +190,20 @@ void Error::done()
   if (sparta->kokkos) Kokkos::finalize();
   MPI_Finalize();
   exit(1);
+}
+
+/* ----------------------------------------------------------------------
+   store the last error message and its type
+   for retrieval via the library interface
+------------------------------------------------------------------------- */
+
+void Error::set_last_error(const char *msg, int type)
+{
+  if (msg) {
+    last_error_message = msg;
+    last_error_type = type;
+  } else {
+    last_error_message.clear();
+    last_error_type = ERROR_NONE;
+  }
 }

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -15,8 +15,10 @@
 #include "mpi.h"
 #include "stdlib.h"
 #include "stdio.h"
+#include "string.h"
 #include "error.h"
 #include "spaexception.h"
+#include "input.h"
 #include "universe.h"
 #include "output.h"
 #include "memory.h"
@@ -47,6 +49,16 @@ static std::string fmt_error(const char *str, const char *file, int line)
   msg += ")";
   return msg;
 }
+
+// the input-script line being processed when the error occurred, so the
+// message can echo it as "Last command: ..." (matches the LAMMPS behavior)
+
+static std::string last_command(Input *input)
+{
+  if (input && input->line && strlen(input->line)) return input->line;
+  return "(unknown)";
+}
+
 
 /* ---------------------------------------------------------------------- */
 
@@ -110,14 +122,23 @@ void Error::all(const char *file, int line, const char *str)
   int me;
   MPI_Comm_rank(world,&me);
 
+  std::string lastcmd = last_command(input);
+
   if (me == 0) {
-    if (screen) fprintf(screen,"ERROR: %s (%s:%d)\n",str,file,line);
-    if (logfile) fprintf(logfile,"ERROR: %s (%s:%d)\n",str,file,line);
-    if (screen) fflush(screen);
-    if (logfile) fflush(logfile);
+    if (screen) {
+      fprintf(screen,"ERROR: %s (%s:%d)\n",str,file,line);
+      fprintf(screen,"Last command: %s\n",lastcmd.c_str());
+      fflush(screen);
+    }
+    if (logfile) {
+      fprintf(logfile,"ERROR: %s (%s:%d)\n",str,file,line);
+      fprintf(logfile,"Last command: %s\n",lastcmd.c_str());
+      fflush(logfile);
+    }
   }
 
   std::string msg = fmt_error(str,file,line);
+  msg += "\nLast command: " + lastcmd;
   set_last_error(msg.c_str(),ERROR_NORMAL);
   throw SpartaException(msg);
 }
@@ -134,18 +155,24 @@ void Error::one(const char *file, int line, const char *str)
 {
   int me;
   MPI_Comm_rank(world,&me);
+
+  std::string lastcmd = last_command(input);
+
   if (screen) {
     fprintf(screen,"ERROR on proc %d: %s (%s:%d)\n",
             me,str,file,line);
+    fprintf(screen,"Last command: %s\n",lastcmd.c_str());
     fflush(screen);
   }
   if (universe->nworlds > 1) {
     fprintf(universe->uscreen,"ERROR on proc %d: %s (%s:%d)\n",
             universe->me,str,file,line);
+    fprintf(universe->uscreen,"Last command: %s\n",lastcmd.c_str());
     fflush(universe->uscreen);
   }
 
   std::string msg = fmt_error(str,file,line);
+  msg += "\nLast command: " + lastcmd;
   set_last_error(msg.c_str(),ERROR_ABORT);
   throw SpartaAbortException(msg,world);
 }

--- a/src/error.h
+++ b/src/error.h
@@ -17,10 +17,14 @@
 
 #include "pointers.h"
 
+#include <string>
+
 namespace SPARTA_NS {
 
 class Error : protected Pointers {
  public:
+  enum { ERROR_NONE = 0, ERROR_NORMAL = 1, ERROR_ABORT = 2 };
+
   Error(class SPARTA *);
 
   void universe_all(const char *, int, const char *);
@@ -31,6 +35,16 @@ class Error : protected Pointers {
   void warning(const char *, int, const char *, int = 1);
   void message(const char *, int, const char *, int = 1);
   void done();
+
+  // last error message handling for the library interface
+
+  void set_last_error(const char *msg, int type = ERROR_NORMAL);
+  const char *get_last_error() const { return last_error_message.c_str(); }
+  int get_last_error_type() const { return last_error_type; }
+
+ private:
+  std::string last_error_message;
+  int last_error_type = ERROR_NONE;
 };
 
 }

--- a/src/fix_balance.cpp
+++ b/src/fix_balance.cpp
@@ -264,6 +264,17 @@ void FixBalance::end_of_step()
     }
 
     rcb->compute(nbalance,x,wt,eligible,rcbflip);
+
+    // store this proc's RCB sub-box for the dump image subbox keyword
+
+    update->rcbflag = 1;
+    update->rcblo[0] = rcb->lo[0];
+    update->rcblo[1] = rcb->lo[1];
+    update->rcblo[2] = rcb->lo[2];
+    update->rcbhi[0] = rcb->hi[0];
+    update->rcbhi[1] = rcb->hi[1];
+    update->rcbhi[2] = rcb->hi[2];
+
     rcb->invert();
 
     nbalance = 0;

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -70,6 +70,7 @@ Image::Image(SPARTA *sparta, int nmap_caller) : Pointers(sparta)
   persp = 0.0;
   shiny = 1.0;
   ssao = NO;
+  fsaa = NO;
 
   up[0] = 0.0;
   up[1] = 0.0;
@@ -83,6 +84,7 @@ Image::Image(SPARTA *sparta, int nmap_caller) : Pointers(sparta)
 
   boxcolor = color2rgb("yellow");
   background[0] = background[1] = background[2] = 0;
+  background2[0] = background2[1] = background2[2] = -1;
 
   // define nmap colormaps, all with default settings
 
@@ -291,13 +293,35 @@ void Image::clear()
   int blue = background[2];
 
   int ix,iy;
-  for (iy = 0; iy < height; iy ++)
-    for (ix = 0; ix < width; ix ++) {
-      imageBuffer[iy * width * 3 + ix * 3 + 0] = red;
-      imageBuffer[iy * width * 3 + ix * 3 + 1] = green;
-      imageBuffer[iy * width * 3 + ix * 3 + 2] = blue;
-      depthBuffer[iy * width + ix] = -1;
+
+  if (background2[0] < 0) {
+    for (iy = 0; iy < height; iy ++)
+      for (ix = 0; ix < width; ix ++) {
+        imageBuffer[iy * width * 3 + ix * 3 + 0] = red;
+        imageBuffer[iy * width * 3 + ix * 3 + 1] = green;
+        imageBuffer[iy * width * 3 + ix * 3 + 2] = blue;
+        depthBuffer[iy * width + ix] = -1;
+      }
+
+  // vertical gradient from background at bottom to background2 at top
+
+  } else {
+    for (iy = 0; iy < height; iy ++) {
+      double fraction = (double) iy / (double) height;
+      red = static_cast<int>
+        (fraction*background2[0] + (1.0-fraction)*background[0]);
+      green = static_cast<int>
+        (fraction*background2[1] + (1.0-fraction)*background[1]);
+      blue = static_cast<int>
+        (fraction*background2[2] + (1.0-fraction)*background[2]);
+      for (ix = 0; ix < width; ix ++) {
+        imageBuffer[iy * width * 3 + ix * 3 + 0] = red;
+        imageBuffer[iy * width * 3 + ix * 3 + 1] = green;
+        imageBuffer[iy * width * 3 + ix * 3 + 2] = blue;
+        depthBuffer[iy * width + ix] = -1;
+      }
     }
+  }
 }
 
 /* ----------------------------------------------------------------------
@@ -385,6 +409,29 @@ void Image::merge()
     writeBuffer = rgbcopy;
   } else {
     writeBuffer = imageBuffer;
+  }
+
+  // scale down image for anti-aliasing
+  // can be done in place with simple averaging
+
+  if (fsaa) {
+    for (int h = 0; h < height; h += 2) {
+      for (int w = 0; w < width; w += 2) {
+        int idx1 = 3*width*h + 3*w;
+        int idx2 = 3*width*h + 3*(w+1);
+        int idx3 = 3*width*(h+1) + 3*w;
+        int idx4 = 3*width*(h+1) + 3*(w+1);
+
+        int out = 3*(width/2)*(h/2) + 3*(w/2);
+        for (int i = 0; i < 3; ++i) {
+          writeBuffer[out+i] = (unsigned char)
+            (0.25*((int)(unsigned char)writeBuffer[idx1+i]
+                   +(int)(unsigned char)writeBuffer[idx2+i]
+                   +(int)(unsigned char)writeBuffer[idx3+i]
+                   +(int)(unsigned char)writeBuffer[idx4+i]));
+        }
+      }
+    }
   }
 }
 
@@ -1090,11 +1137,17 @@ void Image::write_JPG(FILE *fp)
   struct jpeg_error_mgr jerr;
   JSAMPROW row_pointer;
 
+  // with FSAA the image was rendered at 2x and downsampled in merge()
+
+  const int aafactor = fsaa ? 2 : 1;
+  const int outwidth = width/aafactor;
+  const int outheight = height/aafactor;
+
   cinfo.err = jpeg_std_error(&jerr);
   jpeg_create_compress(&cinfo);
   jpeg_stdio_dest(&cinfo,fp);
-  cinfo.image_width = width;
-  cinfo.image_height = height;
+  cinfo.image_width = outwidth;
+  cinfo.image_height = outheight;
   cinfo.input_components = 3;
   cinfo.in_color_space = JCS_RGB;
 
@@ -1104,7 +1157,8 @@ void Image::write_JPG(FILE *fp)
 
   while (cinfo.next_scanline < cinfo.image_height) {
     row_pointer = (JSAMPROW)
-      &writeBuffer[(cinfo.image_height - 1 - cinfo.next_scanline) * 3 * width];
+      &writeBuffer[(cinfo.image_height - 1 - cinfo.next_scanline) *
+                   3 * outwidth];
     jpeg_write_scanlines(&cinfo,&row_pointer,1);
   }
 
@@ -1140,9 +1194,15 @@ void Image::write_PNG(FILE *fp)
     return;
   }
 
+  // with FSAA the image was rendered at 2x and downsampled in merge()
+
+  const int aafactor = fsaa ? 2 : 1;
+  const int outwidth = width/aafactor;
+  const int outheight = height/aafactor;
+
   png_init_io(png_ptr, fp);
   png_set_compression_level(png_ptr,Z_BEST_COMPRESSION);
-  png_set_IHDR(png_ptr,info_ptr,width,height,8,PNG_COLOR_TYPE_RGB,
+  png_set_IHDR(png_ptr,info_ptr,outwidth,outheight,8,PNG_COLOR_TYPE_RGB,
     PNG_INTERLACE_NONE,PNG_COMPRESSION_TYPE_DEFAULT,PNG_FILTER_TYPE_DEFAULT);
 
   png_text text_ptr[2];
@@ -1162,9 +1222,9 @@ void Image::write_PNG(FILE *fp)
   png_set_text(png_ptr,info_ptr,text_ptr,1);
   png_write_info(png_ptr,info_ptr);
 
-  png_bytep row_pointers[height];
-  for (int i=0; i < height; ++i)
-    row_pointers[i] = (png_bytep) &writeBuffer[(height-i-1)*3*width];
+  png_bytep row_pointers[outheight];
+  for (int i=0; i < outheight; ++i)
+    row_pointers[i] = (png_bytep) &writeBuffer[(outheight-i-1)*3*outwidth];
 
   png_write_image(png_ptr, row_pointers);
   png_write_end(png_ptr, info_ptr);
@@ -1181,11 +1241,17 @@ void Image::write_PNG(FILE *)
 
 void Image::write_PPM(FILE *fp)
 {
-  fprintf(fp,"P6\n%d %d\n255\n",width,height);
+  // with FSAA the image was rendered at 2x and downsampled in merge()
+
+  const int aafactor = fsaa ? 2 : 1;
+  const int outwidth = width/aafactor;
+  const int outheight = height/aafactor;
+
+  fprintf(fp,"P6\n%d %d\n255\n",outwidth,outheight);
 
   int y;
-  for (y = height-1; y >= 0; y--)
-    fwrite(&writeBuffer[y*width*3],3,width,fp);
+  for (y = outheight-1; y >= 0; y--)
+    fwrite(&writeBuffer[y*outwidth*3],3,outwidth,fp);
 }
 
 /* ----------------------------------------------------------------------

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -1855,14 +1855,14 @@ int ColorMap::reset(int narg, char **arg)
       if (!islower(arg[n][0])) {
         mentry[i].lo = NUMERIC;
         mentry[i].lvalue = atof(arg[n]);
-      } else if (strcmp(arg[n],"min") == 0) mentry[i].single = MINVALUE;
-      else if (strcmp(arg[n],"max") == 0) mentry[i].single = MAXVALUE;
+      } else if (strcmp(arg[n],"min") == 0) mentry[i].lo = MINVALUE;
+      else if (strcmp(arg[n],"max") == 0) mentry[i].lo = MAXVALUE;
       else return 1;
       if (!islower(arg[n+1][0])) {
         mentry[i].hi = NUMERIC;
         mentry[i].hvalue = atof(arg[n+1]);
-      } else if (strcmp(arg[n+1],"min") == 0) mentry[i].single = MINVALUE;
-      else if (strcmp(arg[n+1],"max") == 0) mentry[i].single = MAXVALUE;
+      } else if (strcmp(arg[n+1],"min") == 0) mentry[i].hi = MINVALUE;
+      else if (strcmp(arg[n+1],"max") == 0) mentry[i].hi = MAXVALUE;
       else return 1;
       mentry[i].color = image->color2rgb(arg[n+2]);
       n += 3;

--- a/src/image.h
+++ b/src/image.h
@@ -33,9 +33,17 @@ class Image : protected Pointers {
   int ssao;                     // SSAO on or off
   int seed;                     // RN seed for SSAO
   double ssaoint;               // strength of shading from 0 to 1
+  int fsaa;                     // full scene anti-aliasing on or off
   double *boxcolor;             // color to draw box outline with
   double *gridcolor;            // color to draw grid lines with
   int background[3];            // RGB values of background
+  int background2[3];           // RGB values of second background color
+                                // for a gradient (off if < 0)
+
+  double ambientColor[3];       // light color settings
+  double keyLightColor[3];      //   adjustable via dump_modify lights
+  double fillLightColor[3];
+  double backLightColor[3];
 
   Image(class SPARTA *, int);
   ~Image();
@@ -85,19 +93,15 @@ class Image : protected Pointers {
   // constant view params
 
   double FOV;
-  double ambientColor[3];
 
   double keyLightTheta;
   double keyLightPhi;
-  double keyLightColor[3];
 
   double fillLightTheta;
   double fillLightPhi;
-  double fillLightColor[3];
 
   double backLightTheta;
   double backLightPhi;
-  double backLightColor[3];
 
   double specularHardness;
   double specularIntensity;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -59,6 +59,7 @@ Input::Input(SPARTA *sparta, int argc, char **argv) : Pointers(sparta)
   line = copy = work = NULL;
   narg = maxarg = 0;
   arg = NULL;
+  line_num = 0;
 
   echo_screen = 0;
   echo_log = 1;
@@ -218,6 +219,7 @@ void Input::file()
 
     if (n > maxline) reallocate(line,maxline,n);
     MPI_Bcast(line,n,MPI_CHAR,0,world);
+    line_num++;
 
     // echo the command unless scanning for label
 

--- a/src/input.h
+++ b/src/input.h
@@ -25,6 +25,8 @@ class Input : protected Pointers {
   int narg;                    // # of command args
   char **arg;                  // parsed args for command
   class Variable *variable;    // defined variables
+  int line_num;                // line number of current command,
+                               // maintained for the library interface
 
   Input(class SPARTA *, int, char **);
   ~Input();
@@ -112,7 +114,6 @@ class Input : protected Pointers {
   void undump();
   void unfix();
   void units();
-  void weight();
 };
 
 }

--- a/src/input.h
+++ b/src/input.h
@@ -27,6 +27,10 @@ class Input : protected Pointers {
   class Variable *variable;    // defined variables
   int line_num;                // line number of current command,
                                // maintained for the library interface
+  char *line;                  // input line currently being processed, so an
+                               // error can echo it as "Last command: ..."
+                               // (public, as in LAMMPS); NULL before the
+                               // first command
 
   Input(class SPARTA *, int, char **);
   ~Input();
@@ -47,7 +51,7 @@ class Input : protected Pointers {
   int me;                      // proc ID
   char *command;               // ptr to current command
   int maxarg;                  // max # of args in arg
-  char *line,*copy,*work;      // input line & copy and work string
+  char *copy,*work;            // copy and work strings
   int maxline,maxcopy,maxwork; // max lengths of char strings
   int echo_screen;             // 0 = no, 1 = yes
   int echo_log;                // 0 = no, 1 = yes

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -14,31 +14,208 @@
 
 // C or Fortran style library interface to SPARTA
 // customize by adding new SPARTA-specific functions
+//
+// the function names and semantics mirror the LAMMPS C library
+// interface (lammps_* -> sparta_*) where a LAMMPS equivalent exists
 
 #include "spatype.h"
 #include "mpi.h"
 #include "string.h"
 #include "stdlib.h"
+#include "stdio.h"
 #include "library.h"
 #include "sparta.h"
+#include "spaexception.h"
 #include "input.h"
 #include "update.h"
 #include "particle.h"
+#include "mixture.h"
+#include "domain.h"
+#include "region.h"
+#include "grid.h"
+#include "surf.h"
+#include "surf_collide.h"
+#include "surf_react.h"
 #include "modify.h"
 #include "compute.h"
+#include "fix.h"
+#include "output.h"
+#include "dump.h"
+#include "stats.h"
+#include "timer.h"
 #include "variable.h"
+#include "error.h"
+#include "version.h"
+
+#include <map>
+#include <string>
+#include <vector>
 
 using namespace SPARTA_NS;
+
+// ----------------------------------------------------------------------
+// utility macros and functions
+// ----------------------------------------------------------------------
+
+// wrap library function bodies so that errors thrown by the Error
+// class are caught and recorded instead of aborting the process.
+// for an error thrown by Error::one() in a parallel run the other
+// MPI ranks cannot be unwound, so abort as before
+
+#define BEGIN_CAPTURE try
+
+#define END_CAPTURE(sparta) \
+  catch (SpartaAbortException &e) { \
+    SPARTA *_spa = (SPARTA *) sparta; \
+    _spa->error->set_last_error(e.what(),Error::ERROR_ABORT); \
+    int _nprocs; \
+    MPI_Comm_size(_spa->world,&_nprocs); \
+    if (_nprocs > 1) MPI_Abort(e.get_universe(),1); \
+  } \
+  catch (SpartaException &e) { \
+    ((SPARTA *) sparta)->error->set_last_error(e.what(),Error::ERROR_NORMAL); \
+  } \
+  catch (std::exception &e) { \
+    ((SPARTA *) sparta)->error->set_last_error(e.what(),Error::ERROR_NORMAL); \
+  }
+
+/* copy a C string into a fixed-size buffer, always NULL terminated
+   return 1 if successful, 0 if not */
+
+static int copy_string(const char *src, char *buffer, int buf_size)
+{
+  if (!src || !buffer || buf_size <= 0) return 0;
+  strncpy(buffer,src,buf_size-1);
+  buffer[buf_size-1] = '\0';
+  return 1;
+}
+
+/* convert version string "24 Sep 2025" to numeric 20250924 */
+
+static int version2num(const char *version)
+{
+  static const char *months[] = {"Jan","Feb","Mar","Apr","May","Jun",
+                                 "Jul","Aug","Sep","Oct","Nov","Dec"};
+  int day,year;
+  char month[16];
+  if (sscanf(version,"%d %15s %d",&day,month,&year) != 3) return 0;
+  int imonth = 0;
+  for (int i = 0; i < 12; i++)
+    if (strncmp(month,months[i],3) == 0) imonth = i+1;
+  if (imonth == 0) return 0;
+  return 10000*year + 100*imonth + day;
+}
+
+/* build table of styles for each style category,
+   extracted from the generated style_*.h header files.
+   defining the *_CLASS macros makes each per-style header expand to
+   just its Style(key,Class) macro line, and the Style macros below
+   record the style name, so no class code is instantiated here */
+
+static const std::map<std::string,std::vector<std::string> > &style_map()
+{
+  static std::map<std::string,std::vector<std::string> > smap;
+
+  if (smap.empty()) {
+    {
+      std::vector<std::string> &v = smap["command"];
+#define COMMAND_CLASS
+#define CommandStyle(key,Class) v.push_back(#key);
+#include "style_command.h"
+#undef CommandStyle
+#undef COMMAND_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["compute"];
+#define COMPUTE_CLASS
+#define ComputeStyle(key,Class) v.push_back(#key);
+#include "style_compute.h"
+#undef ComputeStyle
+#undef COMPUTE_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["fix"];
+#define FIX_CLASS
+#define FixStyle(key,Class) v.push_back(#key);
+#include "style_fix.h"
+#undef FixStyle
+#undef FIX_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["dump"];
+#define DUMP_CLASS
+#define DumpStyle(key,Class) v.push_back(#key);
+#include "style_dump.h"
+#undef DumpStyle
+#undef DUMP_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["region"];
+#define REGION_CLASS
+#define RegionStyle(key,Class) v.push_back(#key);
+#include "style_region.h"
+#undef RegionStyle
+#undef REGION_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["collide"];
+#define COLLIDE_CLASS
+#define CollideStyle(key,Class) v.push_back(#key);
+#include "style_collide.h"
+#undef CollideStyle
+#undef COLLIDE_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["react"];
+#define REACT_CLASS
+#define ReactStyle(key,Class) v.push_back(#key);
+#include "style_react.h"
+#undef ReactStyle
+#undef REACT_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["surf_collide"];
+#define SURF_COLLIDE_CLASS
+#define SurfCollideStyle(key,Class) v.push_back(#key);
+#include "style_surf_collide.h"
+#undef SurfCollideStyle
+#undef SURF_COLLIDE_CLASS
+    }
+    {
+      std::vector<std::string> &v = smap["surf_react"];
+#define SURF_REACT_CLASS
+#define SurfReactStyle(key,Class) v.push_back(#key);
+#include "style_surf_react.h"
+#undef SurfReactStyle
+#undef SURF_REACT_CLASS
+    }
+  }
+  return smap;
+}
+
+// ----------------------------------------------------------------------
+// library initialization and finalization
+// ----------------------------------------------------------------------
 
 /* ----------------------------------------------------------------------
    create an instance of SPARTA and return pointer to it
    pass in command-line args and MPI communicator to run on
+   also returns the pointer through the last argument if it is not NULL
 ------------------------------------------------------------------------- */
 
-void sparta_open(int argc, char **argv, MPI_Comm communicator, void **ptr)
+void *sparta_open(int argc, char **argv, MPI_Comm communicator, void **ptr)
 {
-  SPARTA *sparta = new SPARTA(argc,argv,communicator);
-  *ptr = (void *) sparta;
+  SPARTA *sparta = NULL;
+
+  try {
+    sparta = new SPARTA(argc,argv,communicator);
+  } catch (SpartaException &) {
+    // error message was already printed by the Error class
+    sparta = NULL;
+  }
+
+  if (ptr) *ptr = (void *) sparta;
+  return (void *) sparta;
 }
 
 /* ----------------------------------------------------------------------
@@ -47,7 +224,7 @@ void sparta_open(int argc, char **argv, MPI_Comm communicator, void **ptr)
    intialize MPI if needed
 ------------------------------------------------------------------------- */
 
-void sparta_open_no_mpi(int argc, char **argv, void **ptr)
+void *sparta_open_no_mpi(int argc, char **argv, void **ptr)
 {
   int flag;
   MPI_Initialized(&flag);
@@ -59,9 +236,7 @@ void sparta_open_no_mpi(int argc, char **argv, void **ptr)
   }
 
   MPI_Comm communicator = MPI_COMM_WORLD;
-
-  SPARTA *sparta = new SPARTA(argc,argv,communicator);
-  *ptr = (void *) sparta;
+  return sparta_open(argc,argv,communicator,ptr);
 }
 
 /* ----------------------------------------------------------------------
@@ -74,24 +249,95 @@ void sparta_close(void *ptr)
   delete sparta;
 }
 
+// ----------------------------------------------------------------------
+// executing commands
+// ----------------------------------------------------------------------
+
 /* ----------------------------------------------------------------------
    process an input script in filename str
 ------------------------------------------------------------------------- */
 
-void sparta_file(void *ptr, char *str)
+void sparta_file(void *ptr, const char *str)
 {
   SPARTA *sparta = (SPARTA *) ptr;
-  sparta->input->file(str);
+
+  BEGIN_CAPTURE {
+    sparta->input->file(str);
+  }
+  END_CAPTURE(sparta)
 }
 
 /* ----------------------------------------------------------------------
    process a single input command in str
 ------------------------------------------------------------------------- */
 
-char *sparta_command(void *ptr, char *str)
+char *sparta_command(void *ptr, const char *str)
 {
   SPARTA *sparta = (SPARTA *) ptr;
-  return sparta->input->one(str);
+  char *result = NULL;
+
+  BEGIN_CAPTURE {
+    result = sparta->input->one(str);
+  }
+  END_CAPTURE(sparta)
+
+  return result;
+}
+
+/* ----------------------------------------------------------------------
+   process multiple input commands in str, separated by newlines
+   a line ending in "&" is concatenated with the following line
+   Input::line_num tracks the line number of the executing command
+------------------------------------------------------------------------- */
+
+void sparta_commands_string(void *ptr, const char *str)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  if (!str) return;
+
+  BEGIN_CAPTURE {
+    sparta->input->line_num = 0;
+
+    int nline = 0;
+    std::string buffer;
+    const char *p = str;
+
+    while (1) {
+      const char *nl = strchr(p,'\n');
+      std::string oneline;
+      if (nl) oneline.assign(p,nl-p);
+      else oneline.assign(p);
+      nline++;
+
+      // strip trailing carriage return and whitespace
+
+      while (!oneline.empty() &&
+             (oneline.back() == '\r' || oneline.back() == ' ' ||
+              oneline.back() == '\t')) oneline.pop_back();
+
+      // line continuation: strip '&' and append the next line
+
+      if (!oneline.empty() && oneline.back() == '&') {
+        oneline.pop_back();
+        if (buffer.empty()) sparta->input->line_num = nline;
+        buffer += oneline;
+      } else {
+        if (buffer.empty()) sparta->input->line_num = nline;
+        buffer += oneline;
+        if (!buffer.empty()) sparta->input->one(buffer.c_str());
+        buffer.clear();
+      }
+
+      if (!nl) break;
+      p = nl + 1;
+      if (*p == '\0') break;
+    }
+
+    // process any trailing continuation line
+
+    if (!buffer.empty()) sparta->input->one(buffer.c_str());
+  }
+  END_CAPTURE(sparta)
 }
 
 /* ----------------------------------------------------------------------
@@ -103,11 +349,9 @@ void sparta_free(void *ptr)
   free(ptr);
 }
 
-/* ----------------------------------------------------------------------
-   add SPARTA-specific library functions
-   all must receive SPARTA pointer as argument
-   customize by adding a function here and in library.h header file
-------------------------------------------------------------------------- */
+// ----------------------------------------------------------------------
+// data extraction
+// ----------------------------------------------------------------------
 
 /* ----------------------------------------------------------------------
    extract a pointer to an internal SPARTA global entity
@@ -118,14 +362,37 @@ void sparta_free(void *ptr)
    customize by adding names
 ------------------------------------------------------------------------- */
 
-void *sparta_extract_global(void *ptr, char *name)
+void *sparta_extract_global(void *ptr, const char *name)
 {
   SPARTA *sparta = (SPARTA *) ptr;
+
+  // these entries do not require an instance,
+  // e.g. so a version check can be done before calling sparta_open()
+
+  // optional build-time git provenance (guarded; absence is harmless so a
+  // plain non-git build still returns an empty/"(unknown)" string)
+#ifndef SPARTA_GIT_COMMIT
+#define SPARTA_GIT_COMMIT ""
+#endif
+#ifndef SPARTA_GIT_BRANCH
+#define SPARTA_GIT_BRANCH ""
+#endif
+
+  if (strcmp(name,"sparta_version") == 0) return (void *) SPARTA_VERSION;
+  if (strcmp(name,"git_branch") == 0) return (void *) SPARTA_GIT_BRANCH;
+  if (strcmp(name,"git_commit") == 0) return (void *) SPARTA_GIT_COMMIT;
+
+  if (!sparta) return NULL;
 
   if (strcmp(name,"dt") == 0) return (void *) &sparta->update->dt;
   if (strcmp(name,"fnum") == 0) return (void *) &sparta->update->fnum;
   if (strcmp(name,"nrho") == 0) return (void *) &sparta->update->nrho;
   if (strcmp(name,"nplocal") == 0) return (void *) &sparta->particle->nlocal;
+  if (strcmp(name,"ntimestep") == 0)
+    return (void *) &sparta->update->ntimestep;
+  if (strcmp(name,"boxlo") == 0) return (void *) sparta->domain->boxlo;
+  if (strcmp(name,"boxhi") == 0) return (void *) sparta->domain->boxhi;
+  if (strcmp(name,"units") == 0) return (void *) sparta->update->unit_style;
   return NULL;
 }
 
@@ -157,9 +424,12 @@ void *sparta_extract_global(void *ptr, char *name)
      so caller must insure that it is OK
 ------------------------------------------------------------------------- */
 
-void *sparta_extract_compute(void *ptr, char *id, int style, int type)
+void *sparta_extract_compute(void *ptr, const char *id, int style, int type)
 {
   SPARTA *sparta = (SPARTA *) ptr;
+  void *result = NULL;
+
+  BEGIN_CAPTURE {
 
   int icompute = sparta->modify->find_compute(id);
   if (icompute < 0) return NULL;
@@ -170,19 +440,19 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
       if (!compute->scalar_flag) return NULL;
       if (compute->invoked_scalar != sparta->update->ntimestep)
         compute->compute_scalar();
-      return (void *) &compute->scalar;
+      result = (void *) &compute->scalar;
     }
     if (type == 1) {
       if (!compute->vector_flag) return NULL;
       if (compute->invoked_vector != sparta->update->ntimestep)
         compute->compute_vector();
-      return (void *) compute->vector;
+      result = (void *) compute->vector;
     }
     if (type == 2) {
       if (!compute->array_flag) return NULL;
       if (compute->invoked_array != sparta->update->ntimestep)
         compute->compute_array();
-      return (void *) compute->array;
+      result = (void *) compute->array;
     }
   }
 
@@ -191,12 +461,12 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
     if (type == 1) {
       if (compute->invoked_per_particle != sparta->update->ntimestep)
         compute->compute_per_particle();
-      return (void *) compute->vector_particle;
+      result = (void *) compute->vector_particle;
     }
     if (type > 1) {
       if (compute->invoked_per_particle != sparta->update->ntimestep)
         compute->compute_per_particle();
-      return (void *) compute->array_particle;
+      result = (void *) compute->array_particle;
     }
   }
 
@@ -209,20 +479,18 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
         compute->post_process_grid(0,1,NULL,NULL,NULL,1);
       else if (compute->post_process_isurf_grid_flag)
         compute->post_process_isurf_grid();
-      return (void *) compute->vector_grid;
+      result = (void *) compute->vector_grid;
     }
     if (type > 1) {
       if (compute->invoked_per_grid != sparta->update->ntimestep)
         compute->compute_per_grid();
       if (compute->post_process_grid_flag) {
         compute->post_process_grid(type,1,NULL,NULL,NULL,1);
-        return (void *) compute->vector_grid;
-      }
-      if (compute->post_process_isurf_grid_flag) {
+        result = (void *) compute->vector_grid;
+      } else if (compute->post_process_isurf_grid_flag) {
         compute->post_process_isurf_grid();
-        return (void *) compute->array_grid;
-      }
-      return (void *) compute->array_grid;
+        result = (void *) compute->array_grid;
+      } else result = (void *) compute->array_grid;
     }
   }
 
@@ -232,13 +500,13 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
       if (compute->invoked_per_surf != sparta->update->ntimestep)
         compute->compute_per_surf();
       compute->post_process_surf();
-      return (void *) compute->vector_surf;
+      result = (void *) compute->vector_surf;
     }
     if (type > 1) {
       if (compute->invoked_per_surf != sparta->update->ntimestep)
         compute->compute_per_surf();
       compute->post_process_surf();
-      return (void *) compute->array_surf;
+      result = (void *) compute->array_surf;
     }
   }
 
@@ -247,16 +515,89 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
     if (type == 1) {
       if (compute->invoked_per_tally != sparta->update->ntimestep)
         compute->compute_per_tally();
-      return (void *) compute->vector_tally;
+      result = (void *) compute->vector_tally;
     }
     if (type > 1) {
       if (compute->invoked_per_tally != sparta->update->ntimestep)
         compute->compute_per_tally();
-      return (void *) compute->array_tally;
+      result = (void *) compute->array_tally;
     }
   }
 
-  return NULL;
+  }
+  END_CAPTURE(sparta)
+
+  return result;
+}
+
+/* ----------------------------------------------------------------------
+   extract a pointer to an internal SPARTA fix-based entity
+   id = fix ID
+   style = 0 for global data, 1 for per particle data,
+     2 for per grid data, 3 for per surf data
+   type
+     for style global: 0 for scalar, 1 for vector
+       returns a pointer to allocated memory holding the value(s)
+       which the caller must free via sparta_free() to avoid a leak
+       for a vector the length is the size_vector member of the fix
+     for style = particle, grid, surf:
+       type = 0 if fix produces a vector
+       type = 1 to N if fix produces an array, type = which column of array
+       returns a pointer to the fix's internal data structure
+   returns a NULL if id is not recognized or style/type not supported
+   IMPORTANT: SPARTA cannot easily check here if the fix data is current,
+     so caller must insure that it is OK to access it
+------------------------------------------------------------------------- */
+
+void *sparta_extract_fix(void *ptr, const char *id, int style, int type)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  void *result = NULL;
+
+  BEGIN_CAPTURE {
+
+  int ifix = sparta->modify->find_fix(id);
+  if (ifix < 0) return NULL;
+  Fix *fix = sparta->modify->fix[ifix];
+
+  if (style == 0) {
+    if (type == 0) {
+      if (!fix->scalar_flag) return NULL;
+      double *dptr = (double *) malloc(sizeof(double));
+      *dptr = fix->compute_scalar();
+      result = (void *) dptr;
+    }
+    if (type == 1) {
+      if (!fix->vector_flag) return NULL;
+      double *vector = (double *) malloc(fix->size_vector*sizeof(double));
+      for (int i = 0; i < fix->size_vector; i++)
+        vector[i] = fix->compute_vector(i);
+      result = (void *) vector;
+    }
+  }
+
+  if (style == 1) {
+    if (!fix->per_particle_flag) return NULL;
+    if (type == 0 || type == 1) result = (void *) fix->vector_particle;
+    if (type > 1) result = (void *) fix->array_particle;
+  }
+
+  if (style == 2) {
+    if (!fix->per_grid_flag) return NULL;
+    if (type == 0 || type == 1) result = (void *) fix->vector_grid;
+    if (type > 1) result = (void *) fix->array_grid;
+  }
+
+  if (style == 3) {
+    if (!fix->per_surf_flag) return NULL;
+    if (type == 0 || type == 1) result = (void *) fix->vector_surf;
+    if (type > 1) result = (void *) fix->array_surf;
+  }
+
+  }
+  END_CAPTURE(sparta)
+
+  return result;
 }
 
 /* ----------------------------------------------------------------------
@@ -285,25 +626,513 @@ void *sparta_extract_compute(void *ptr, char *id, int style, int type)
      so caller must insure that it is OK
 ------------------------------------------------------------------------- */
 
-void *sparta_extract_variable(void *ptr, char *name)
+void *sparta_extract_variable(void *ptr, const char *name)
 {
   SPARTA *sparta = (SPARTA *) ptr;
+  void *result = NULL;
 
-  int ivar = sparta->input->variable->find(name);
+  BEGIN_CAPTURE {
+
+  int ivar = sparta->input->variable->find((char *) name);
   if (ivar < 0) return NULL;
 
   if (sparta->input->variable->equal_style(ivar)) {
     double *dptr = (double *) malloc(sizeof(double));
     *dptr = sparta->input->variable->compute_equal(ivar);
-    return (void *) dptr;
-  }
-
-  if (sparta->input->variable->particle_style(ivar)) {
+    result = (void *) dptr;
+  } else if (sparta->input->variable->particle_style(ivar)) {
     int nlocal = sparta->particle->nlocal;
     double *vector = (double *) malloc(nlocal*sizeof(double));
     sparta->input->variable->compute_particle(ivar,vector,1,0);
-    return (void *) vector;
+    result = (void *) vector;
   }
 
-  return NULL;
+  }
+  END_CAPTURE(sparta)
+
+  return result;
+}
+
+/* ----------------------------------------------------------------------
+   return the style of a variable as a SPARTA_VAR_ constant
+   returns -1 if name is not a defined variable
+------------------------------------------------------------------------- */
+
+int sparta_extract_variable_datatype(void *ptr, const char *name)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  Variable *variable = sparta->input->variable;
+
+  int ivar = variable->find((char *) name);
+  if (ivar < 0) return -1;
+
+  if (variable->internal_style(ivar)) return SPARTA_VAR_INTERNAL;
+  if (variable->equal_style(ivar)) return SPARTA_VAR_EQUAL;
+  if (variable->particle_style(ivar)) return SPARTA_VAR_PARTICLE;
+  if (variable->grid_style(ivar)) return SPARTA_VAR_GRID;
+  if (variable->surf_style(ivar)) return SPARTA_VAR_SURF;
+  return SPARTA_VAR_STRING;
+}
+
+/* ----------------------------------------------------------------------
+   extract simulation settings and configuration as an integer
+   returns -1 if name is not recognized
+------------------------------------------------------------------------- */
+
+int sparta_extract_setting(void *ptr, const char *name)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+
+  if (strcmp(name,"bigint") == 0) return sizeof(bigint);
+
+  if (strcmp(name,"dimension") == 0) return sparta->domain->dimension;
+  if (strcmp(name,"box_exist") == 0) return sparta->domain->box_exist;
+  if (strcmp(name,"grid_exist") == 0) return sparta->grid->exist;
+  if (strcmp(name,"surf_exist") == 0) return sparta->surf->exist;
+
+  if (strcmp(name,"world_size") == 0) {
+    int nprocs;
+    MPI_Comm_size(sparta->world,&nprocs);
+    return nprocs;
+  }
+  if (strcmp(name,"world_rank") == 0) {
+    int me;
+    MPI_Comm_rank(sparta->world,&me);
+    return me;
+  }
+
+  if (strcmp(name,"nplocal") == 0) return sparta->particle->nlocal;
+  if (strcmp(name,"nspecies") == 0) return sparta->particle->nspecies;
+  if (strcmp(name,"nmixture") == 0) return sparta->particle->nmixture;
+  if (strcmp(name,"ncompute") == 0) return sparta->modify->ncompute;
+  if (strcmp(name,"nfix") == 0) return sparta->modify->nfix;
+  if (strcmp(name,"ndump") == 0) return sparta->output->ndump;
+  if (strcmp(name,"nregion") == 0) return sparta->domain->nregion;
+  if (strcmp(name,"nvariable") == 0)
+    return sparta->input->variable->nvar_active();
+  if (strcmp(name,"ngroup_grid") == 0) return sparta->grid->ngroup;
+  if (strcmp(name,"ngroup_surf") == 0) return sparta->surf->ngroup;
+  if (strcmp(name,"nsurf") == 0) return (int) sparta->surf->nsurf;
+  if (strcmp(name,"nlocal_surf") == 0) return sparta->surf->nlocal;
+
+  if (strcmp(name,"stats_every") == 0) return sparta->output->stats_every;
+
+  return -1;
+}
+
+/* ----------------------------------------------------------------------
+   evaluate a stats keyword and return its value as a double
+   step, np and cpu-related keywords are always available,
+   other stats keywords only while a run is in progress
+   returns 0.0 if keyword cannot be evaluated
+------------------------------------------------------------------------- */
+
+double sparta_get_thermo(void *ptr, const char *name)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  double dvalue = 0.0;
+
+  BEGIN_CAPTURE {
+
+  if (strcmp(name,"step") == 0) {
+    dvalue = (double) sparta->update->ntimestep;
+  } else if (strcmp(name,"np") == 0) {
+    dvalue = (double) sparta->particle->nglobal;
+  } else if (strcmp(name,"dt") == 0) {
+    dvalue = sparta->update->dt;
+  } else if (strcmp(name,"cpu") == 0) {
+    if (sparta->update->runflag)
+      dvalue = sparta->timer->elapsed(TIME_LOOP);
+  } else if (strcmp(name,"cpuremain") == 0) {
+    if (sparta->update->runflag &&
+        sparta->update->ntimestep > sparta->update->firststep) {
+      double cpu = sparta->timer->elapsed(TIME_LOOP);
+      bigint done = sparta->update->ntimestep - sparta->update->firststep;
+      bigint todo = sparta->update->laststep - sparta->update->ntimestep;
+      dvalue = cpu*todo/done;
+    }
+  } else if (strcmp(name,"cpuuse") == 0) {
+    dvalue = sparta->timer->cpu_usage();
+  } else if (sparta->update->runflag) {
+    sparta->output->stats->evaluate_keyword((char *) name,&dvalue);
+  }
+
+  }
+  END_CAPTURE(sparta)
+
+  return dvalue;
+}
+
+/* ----------------------------------------------------------------------
+   access the cached data of the last computed stats output
+   this cache can be read safely, e.g. from a GUI thread,
+   while a simulation is running on another thread
+   what = "lock"    acquire the cache mutex, returns NULL
+   what = "unlock"  release the cache mutex, returns NULL
+   what = "step"    pointer to bigint with timestep of the cached data
+   what = "num"     pointer to int with # of cached columns
+   what = "setup"   pointer to int, 1 if in setup phase (data invalid)
+   what = "line"    pointer to int with input script line of run command
+   what = "imagename"  most recently written dump image filename (char *)
+   what = "keyword" name of stats column with given index (char *)
+   what = "type"    pointer to int with data type of column (SPARTA_INT,
+                    SPARTA_DOUBLE, or SPARTA_INT64)
+   what = "data"    pointer to value of column with given index
+   returns NULL if what is not recognized or index out of range
+------------------------------------------------------------------------- */
+
+void *sparta_last_thermo(void *ptr, const char *what, int index)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  return sparta->output->stats->last_thermo(what,index);
+}
+
+// ----------------------------------------------------------------------
+// introspection
+// ----------------------------------------------------------------------
+
+/* ----------------------------------------------------------------------
+   return SPARTA version as an integer in YYYYMMDD format
+------------------------------------------------------------------------- */
+
+int sparta_version(void *)
+{
+  return version2num(SPARTA_VERSION);
+}
+
+/* ----------------------------------------------------------------------
+   return the number of styles available in a style category
+   category = command, compute, fix, dump, region, collide, react,
+     surf_collide, or surf_react
+   returns 0 for an unknown category
+------------------------------------------------------------------------- */
+
+int sparta_style_count(void *, const char *category)
+{
+  const std::map<std::string,std::vector<std::string> > &smap = style_map();
+  std::map<std::string,std::vector<std::string> >::const_iterator entry =
+    smap.find(category);
+  if (entry == smap.end()) return 0;
+  return (int) entry->second.size();
+}
+
+/* ----------------------------------------------------------------------
+   copy the name of style number idx in a style category into buffer
+   returns 1 if successful, 0 if not
+------------------------------------------------------------------------- */
+
+int sparta_style_name(void *, const char *category, int idx,
+                      char *buffer, int buf_size)
+{
+  const std::map<std::string,std::vector<std::string> > &smap = style_map();
+  std::map<std::string,std::vector<std::string> >::const_iterator entry =
+    smap.find(category);
+  if (entry == smap.end()) return 0;
+  if (idx < 0 || idx >= (int) entry->second.size()) return 0;
+  return copy_string(entry->second[idx].c_str(),buffer,buf_size);
+}
+
+/* ----------------------------------------------------------------------
+   return the number of defined instances in an ID category
+   category = compute, dump, fix, mixture, region, species,
+     surf_collide, surf_react, variable, group_grid, or group_surf
+   returns -1 for an unknown category
+------------------------------------------------------------------------- */
+
+int sparta_id_count(void *ptr, const char *category)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+
+  if (strcmp(category,"compute") == 0) return sparta->modify->ncompute;
+  if (strcmp(category,"dump") == 0) return sparta->output->ndump;
+  if (strcmp(category,"fix") == 0) return sparta->modify->nfix;
+  if (strcmp(category,"mixture") == 0) return sparta->particle->nmixture;
+  if (strcmp(category,"region") == 0) return sparta->domain->nregion;
+  if (strcmp(category,"species") == 0) return sparta->particle->nspecies;
+  if (strcmp(category,"surf_collide") == 0) return sparta->surf->nsc;
+  if (strcmp(category,"surf_react") == 0) return sparta->surf->nsr;
+  if (strcmp(category,"variable") == 0)
+    return sparta->input->variable->nvar_active();
+  if (strcmp(category,"group_grid") == 0) return sparta->grid->ngroup;
+  if (strcmp(category,"group_surf") == 0) return sparta->surf->ngroup;
+  return -1;
+}
+
+/* ----------------------------------------------------------------------
+   copy the name of instance idx in an ID category into buffer
+   returns 1 if successful, 0 if not
+------------------------------------------------------------------------- */
+
+int sparta_id_name(void *ptr, const char *category, int idx,
+                   char *buffer, int buf_size)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+
+  if (idx < 0) return 0;
+
+  if (strcmp(category,"compute") == 0) {
+    if (idx >= sparta->modify->ncompute) return 0;
+    return copy_string(sparta->modify->compute[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"dump") == 0) {
+    if (idx >= sparta->output->ndump) return 0;
+    return copy_string(sparta->output->dump[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"fix") == 0) {
+    if (idx >= sparta->modify->nfix) return 0;
+    return copy_string(sparta->modify->fix[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"mixture") == 0) {
+    if (idx >= sparta->particle->nmixture) return 0;
+    return copy_string(sparta->particle->mixture[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"region") == 0) {
+    if (idx >= sparta->domain->nregion) return 0;
+    return copy_string(sparta->domain->regions[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"species") == 0) {
+    if (idx >= sparta->particle->nspecies) return 0;
+    return copy_string(sparta->particle->species[idx].id,buffer,buf_size);
+  }
+  if (strcmp(category,"surf_collide") == 0) {
+    if (idx >= sparta->surf->nsc) return 0;
+    return copy_string(sparta->surf->sc[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"surf_react") == 0) {
+    if (idx >= sparta->surf->nsr) return 0;
+    return copy_string(sparta->surf->sr[idx]->id,buffer,buf_size);
+  }
+  if (strcmp(category,"variable") == 0) {
+    if (idx >= sparta->input->variable->nvar_active()) return 0;
+    return copy_string(sparta->input->variable->name(idx),buffer,buf_size);
+  }
+  if (strcmp(category,"group_grid") == 0) {
+    if (idx >= sparta->grid->ngroup) return 0;
+    return copy_string(sparta->grid->gnames[idx],buffer,buf_size);
+  }
+  if (strcmp(category,"group_surf") == 0) {
+    if (idx >= sparta->surf->ngroup) return 0;
+    return copy_string(sparta->surf->gnames[idx],buffer,buf_size);
+  }
+  return 0;
+}
+
+/* ----------------------------------------------------------------------
+   return 1 if a specific ID exists in an ID category, 0 if not
+   returns -1 for an unknown category
+------------------------------------------------------------------------- */
+
+int sparta_has_id(void *ptr, const char *category, const char *name)
+{
+  int count = sparta_id_count(ptr,category);
+  if (count < 0) return -1;
+
+  char buffer[256];
+  for (int i = 0; i < count; i++) {
+    if (sparta_id_name(ptr,category,i,buffer,256) &&
+        strcmp(buffer,name) == 0) return 1;
+  }
+  return 0;
+}
+
+/* ----------------------------------------------------------------------
+   copy a human-readable description of variable number idx into buffer
+   (name, style, and definition), matching the LAMMPS lammps_variable_info
+   contract so the GUI can display one variable per line
+   returns 1 if successful, 0 if not
+------------------------------------------------------------------------- */
+
+int sparta_variable_info(void *ptr, int idx, char *buffer, int buf_size)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+
+  if (idx < 0 || idx >= sparta->input->variable->nvar_active()) return 0;
+  std::string info = sparta->input->variable->get_info(idx);
+  return copy_string(info.c_str(),buffer,buf_size);
+}
+
+// ----------------------------------------------------------------------
+// run control
+// ----------------------------------------------------------------------
+
+/* ----------------------------------------------------------------------
+   return 1 if a run is in progress, 0 if not
+------------------------------------------------------------------------- */
+
+int sparta_is_running(void *ptr)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  return sparta->update->runflag;
+}
+
+/* ----------------------------------------------------------------------
+   trigger a timeout, so that a run stops cleanly at the next timestep
+   the timeout setting is restored at the beginning of the next run
+------------------------------------------------------------------------- */
+
+void sparta_force_timeout(void *ptr)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  sparta->timer->force_timeout();
+}
+
+// ----------------------------------------------------------------------
+// error handling
+// ----------------------------------------------------------------------
+
+/* ----------------------------------------------------------------------
+   return 1 if an error occurred in a previous library call, 0 if not
+------------------------------------------------------------------------- */
+
+int sparta_has_error(void *ptr)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  return (sparta->error->get_last_error_type() != Error::ERROR_NONE) ? 1 : 0;
+}
+
+/* ----------------------------------------------------------------------
+   copy the last error message into buffer and clear the error status
+   returns 1 if the error was recoverable (Error::all),
+   2 if it was not (Error::one in a parallel run), 0 if there was no error
+------------------------------------------------------------------------- */
+
+int sparta_get_last_error_message(void *ptr, char *buffer, int buf_size)
+{
+  SPARTA *sparta = (SPARTA *) ptr;
+  Error *error = sparta->error;
+
+  if (error->get_last_error_type() == Error::ERROR_NONE) {
+    if (buffer && buf_size > 0) buffer[0] = '\0';
+    return 0;
+  }
+
+  int type = error->get_last_error_type();
+  copy_string(error->get_last_error(),buffer,buf_size);
+  error->set_last_error(NULL,Error::ERROR_NONE);
+  return type;
+}
+
+// ----------------------------------------------------------------------
+// compile time configuration
+// ----------------------------------------------------------------------
+
+/* return 1 if SPARTA was compiled with a real MPI library, 0 if not */
+
+int sparta_config_has_mpi_support()
+{
+#ifdef MPI_STUBS
+  return 0;
+#else
+  return 1;
+#endif
+}
+
+/* return 1 if SPARTA was compiled with PNG support, 0 if not */
+
+int sparta_config_has_png_support()
+{
+#ifdef SPARTA_PNG
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+/* return 1 if SPARTA was compiled with JPEG support, 0 if not */
+
+int sparta_config_has_jpeg_support()
+{
+#ifdef SPARTA_JPEG
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+/* return 1 if SPARTA was compiled with FFmpeg support, 0 if not */
+
+int sparta_config_has_ffmpeg_support()
+{
+#ifdef SPARTA_FFMPEG
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+/* return 1 if SPARTA was compiled with gzip support, 0 if not */
+
+int sparta_config_has_gzip_support()
+{
+#ifdef SPARTA_GZIP
+  return 1;
+#else
+  return 0;
+#endif
+}
+
+/* return 1 if errors are recoverable via C++ exceptions
+   always true since exceptions are unconditionally enabled */
+
+int sparta_config_has_exceptions()
+{
+  return 1;
+}
+
+/* return 1 if SPARTA was compiled with the named package, 0 if not */
+
+int sparta_config_has_package(const char *name)
+{
+  if (strcmp(name,"KOKKOS") == 0) {
+#ifdef SPARTA_KOKKOS
+    return 1;
+#else
+    return 0;
+#endif
+  }
+  if (strcmp(name,"FFT") == 0) {
+    // FFT package presence is detected via its compute style
+    const std::vector<std::string> &v = style_map().at("compute");
+    for (size_t i = 0; i < v.size(); i++)
+      if (v[i] == "fft/grid") return 1;
+    return 0;
+  }
+  return 0;
+}
+
+/* return availability of an accelerator package setting
+   package = accelerator package name (only KOKKOS)
+   category/setting = api:serial/openmp/cuda etc.
+   simplified relative to LAMMPS: returns 1 if the package is available
+   and the category/setting combination is plausible, 0 if not */
+
+int sparta_config_accelerator(const char *package, const char *category,
+                              const char *setting)
+{
+#ifdef SPARTA_KOKKOS
+  if (strcmp(package,"KOKKOS") == 0) {
+    if (strcmp(category,"api") == 0) {
+      if (strcmp(setting,"serial") == 0) return 1;
+#ifdef KOKKOS_ENABLE_OPENMP
+      if (strcmp(setting,"openmp") == 0) return 1;
+#endif
+#ifdef KOKKOS_ENABLE_CUDA
+      if (strcmp(setting,"cuda") == 0) return 1;
+#endif
+#ifdef KOKKOS_ENABLE_HIP
+      if (strcmp(setting,"hip") == 0) return 1;
+#endif
+      return 0;
+    }
+    if (strcmp(category,"precision") == 0) {
+      if (strcmp(setting,"double") == 0) return 1;
+      return 0;
+    }
+    return 0;
+  }
+#endif
+  (void) package;
+  (void) category;
+  (void) setting;
+  return 0;
 }

--- a/src/library.h
+++ b/src/library.h
@@ -15,9 +15,38 @@
 /*
    C or Fortran style library interface to SPARTA
    new SPARTA-specific functions can be added
+
+   the function names and semantics mirror the LAMMPS C library
+   interface (lammps_* -> sparta_*) where a LAMMPS equivalent exists,
+   so that tools written for liblammps (e.g. LAMMPS-GUI) can be
+   adapted to SPARTA with minimal changes
 */
 
 #include "mpi.h"
+
+/* data type constants for extracted or returned data */
+
+enum _SPARTA_DATATYPE {
+  SPARTA_NONE = -1,     /* no data type assigned (yet) */
+  SPARTA_INT = 0,       /* 32-bit integer (array) */
+  SPARTA_INT_2D = 1,    /* two-dimensional 32-bit integer array */
+  SPARTA_DOUBLE = 2,    /* 64-bit double (array) */
+  SPARTA_DOUBLE_2D = 3, /* two-dimensional 64-bit double array */
+  SPARTA_INT64 = 4,     /* 64-bit integer (array) */
+  SPARTA_INT64_2D = 5,  /* two-dimensional 64-bit integer array */
+  SPARTA_STRING = 6     /* C-String */
+};
+
+/* style constants for variable data */
+
+enum _SPARTA_VAR_STYLE {
+  SPARTA_VAR_EQUAL = 0,    /* equal-style (and compatible) variables */
+  SPARTA_VAR_PARTICLE = 1, /* particle-style variables */
+  SPARTA_VAR_GRID = 2,     /* grid-style variables */
+  SPARTA_VAR_SURF = 3,     /* surf-style variables */
+  SPARTA_VAR_STRING = 4,   /* string-valued variables, e.g. index or loop */
+  SPARTA_VAR_INTERNAL = 5  /* internal variables */
+};
 
 /* ifdefs allow this file to be included in a C program */
 
@@ -25,16 +54,74 @@
 extern "C" {
 #endif
 
-void sparta_open(int, char **, MPI_Comm, void **);
-void sparta_open_no_mpi(int, char **, void **);
+/* ----------------------------------------------------------------------
+ * library initialization and finalization
+ * ---------------------------------------------------------------------- */
+
+void *sparta_open(int, char **, MPI_Comm, void **);
+void *sparta_open_no_mpi(int, char **, void **);
 void sparta_close(void *);
-void sparta_file(void *, char *);
-char *sparta_command(void *, char *);
+
+/* ----------------------------------------------------------------------
+ * executing commands
+ * ---------------------------------------------------------------------- */
+
+void sparta_file(void *, const char *);
+char *sparta_command(void *, const char *);
+void sparta_commands_string(void *, const char *);
+
+/* ----------------------------------------------------------------------
+ * data extraction
+ * ---------------------------------------------------------------------- */
+
+void *sparta_extract_global(void *, const char *);
+void *sparta_extract_compute(void *, const char *, int, int);
+void *sparta_extract_fix(void *, const char *, int, int);
+void *sparta_extract_variable(void *, const char *);
+int sparta_extract_variable_datatype(void *, const char *);
+int sparta_extract_setting(void *, const char *);
+double sparta_get_thermo(void *, const char *);
+void *sparta_last_thermo(void *, const char *, int);
 void sparta_free(void *);
 
-void *sparta_extract_global(void *, char *);
-void *sparta_extract_compute(void *, char *, int, int);
-void *sparta_extract_variable(void *, char *);
+/* ----------------------------------------------------------------------
+ * introspection
+ * ---------------------------------------------------------------------- */
+
+int sparta_version(void *);
+int sparta_style_count(void *, const char *);
+int sparta_style_name(void *, const char *, int, char *, int);
+int sparta_id_count(void *, const char *);
+int sparta_id_name(void *, const char *, int, char *, int);
+int sparta_has_id(void *, const char *, const char *);
+int sparta_variable_info(void *, int, char *, int);
+
+/* ----------------------------------------------------------------------
+ * run control
+ * ---------------------------------------------------------------------- */
+
+int sparta_is_running(void *);
+void sparta_force_timeout(void *);
+
+/* ----------------------------------------------------------------------
+ * error handling
+ * ---------------------------------------------------------------------- */
+
+int sparta_has_error(void *);
+int sparta_get_last_error_message(void *, char *, int);
+
+/* ----------------------------------------------------------------------
+ * compile time configuration
+ * ---------------------------------------------------------------------- */
+
+int sparta_config_has_mpi_support();
+int sparta_config_has_png_support();
+int sparta_config_has_jpeg_support();
+int sparta_config_has_ffmpeg_support();
+int sparta_config_has_gzip_support();
+int sparta_config_has_exceptions();
+int sparta_config_has_package(const char *);
+int sparta_config_accelerator(const char *, const char *, const char *);
 
 #ifdef __cplusplus
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,9 @@
 #include "mpi.h"
 #include "sparta.h"
 #include "input.h"
+#include "spaexception.h"
+
+#include "stdlib.h"
 
 using namespace SPARTA_NS;
 
@@ -26,9 +29,17 @@ int main(int argc, char **argv)
 {
   MPI_Init(&argc,&argv);
 
-  SPARTA *sparta = new SPARTA(argc,argv,MPI_COMM_WORLD);
-  sparta->input->file();
-  delete sparta;
+  try {
+    SPARTA *sparta = new SPARTA(argc,argv,MPI_COMM_WORLD);
+    sparta->input->file();
+    delete sparta;
+  } catch (SpartaAbortException &e) {
+    MPI_Abort(e.get_universe(),1);
+  } catch (SpartaException &) {
+    // error message was already printed by the Error class
+    MPI_Finalize();
+    exit(1);
+  }
 
   MPI_Finalize();
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -42,8 +42,16 @@ void *Memory::smalloc(bigint nbytes, const char *name, int align)
   void *ptr;
 
   if (align) {
+#if defined(_WIN32)
+    // MinGW/MSVCRT has no posix_memalign, and memory from _aligned_malloc()
+    // must be released with _aligned_free() rather than the free() used
+    // throughout SPARTA. Alignment here is only a performance hint, so fall
+    // back to plain malloc() (still safe to free() normally) on Windows.
+    ptr = malloc(nbytes);
+#else
     int retval = posix_memalign(&ptr, align, nbytes);
     if (retval) ptr = NULL;
+#endif
   } else {
     ptr = malloc(nbytes);
   }
@@ -76,6 +84,8 @@ void *Memory::srealloc(void *ptr, bigint nbytes, const char *name, int align)
       ptr = smalloc(nbytes, name, align);
 #if defined(__APPLE__)
       memcpy(ptr, optr, MIN(nbytes,malloc_size(optr)));
+#elif defined(_WIN32)
+      memcpy(ptr, optr, MIN(nbytes,_msize(optr)));
 #else
       memcpy(ptr, optr, MIN(nbytes,malloc_usable_size(optr)));
 #endif

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -23,6 +23,7 @@
 #include "input.h"
 #include "modify.h"
 #include "output.h"
+#include "stats.h"
 #include "finish.h"
 #include "timer.h"
 #include "error.h"
@@ -38,6 +39,13 @@ Run::Run(SPARTA *sparta) : Pointers(sparta) {}
 void Run::command(int narg, char **arg)
 {
   if (narg < 1) error->all(FLERR,"Illegal run command");
+
+  // restore timeout in case a previous run was interrupted
+  // by force_timeout() via the library interface,
+  // and invalidate the stats cache of the previous run
+
+  timer->reset_timeout();
+  output->stats->reset_cache();
 
   if (!grid->exist)
     error->all(FLERR,"Run command before grid is defined");

--- a/src/spaexception.h
+++ b/src/spaexception.h
@@ -1,0 +1,59 @@
+/* ----------------------------------------------------------------------
+   SPARTA - Stochastic PArallel Rarefied-gas Time-accurate Analyzer
+   http://sparta.github.io
+   Steve Plimpton, sjplimp@gmail.com, Michael Gallis, magalli@sandia.gov
+   Sandia National Laboratories
+
+   Copyright (2014) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level SPARTA directory.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_SPAEXCEPTION_H
+#define SPARTA_SPAEXCEPTION_H
+
+#include "mpi.h"
+
+#include <exception>
+#include <string>
+
+namespace SPARTA_NS {
+
+// thrown by Error::all() and Error::universe_all(),
+// i.e. in situations where all MPI ranks fail collectively.
+// callers embedding SPARTA as a library can catch it and recover,
+// since every rank unwinds to the library interface
+
+class SpartaException : public std::exception {
+ public:
+  explicit SpartaException(const char *msg) : message(msg) {}
+  explicit SpartaException(const std::string &msg) : message(msg) {}
+  const char *what() const noexcept override { return message.c_str(); }
+
+ protected:
+  std::string message;
+};
+
+// thrown by Error::one() and Error::universe_one(),
+// i.e. when only one (or a subset of) MPI rank(s) hit the error.
+// in parallel the catch site must call MPI_Abort() on the stored
+// communicator since the other ranks cannot be unwound;
+// on a single rank it can be handled like SpartaException
+
+class SpartaAbortException : public SpartaException {
+ public:
+  SpartaAbortException(const char *msg, MPI_Comm comm) : SpartaException(msg), universe(comm) {}
+  SpartaAbortException(const std::string &msg, MPI_Comm comm) :
+      SpartaException(msg), universe(comm) {}
+  MPI_Comm get_universe() const { return universe; }
+
+ protected:
+  MPI_Comm universe;
+};
+
+}    // namespace SPARTA_NS
+
+#endif

--- a/src/sparta.cpp
+++ b/src/sparta.cpp
@@ -409,7 +409,7 @@ SPARTA::SPARTA(int narg, char **arg, MPI_Comm communicator)
   // if helpflag set, print help and exit
 
   if (helpflag) {
-    if (universe->me == 0) print_styles();
+    if (universe->me == 0) print_help();
     error->done();
   }
 }
@@ -575,6 +575,171 @@ void SPARTA::destroy()
   delete react;
   delete output;
   delete timer;
+}
+
+/* ----------------------------------------------------------------------
+   optional build-time provenance defines (guarded; absence is harmless)
+   the build system may -D these; if it does not, fall back to "(unknown)"
+   so a plain (non-git, e.g. tarball) build still compiles and prints
+   sensibly.  Keeping the fallbacks here makes -help self-contained.
+------------------------------------------------------------------------- */
+
+#ifndef SPARTA_GIT_COMMIT
+#define SPARTA_GIT_COMMIT "(unknown)"
+#endif
+#ifndef SPARTA_GIT_BRANCH
+#define SPARTA_GIT_BRANCH "(unknown)"
+#endif
+
+/* return a short descriptor of the compiler used to build SPARTA */
+
+static const char *compiler_info()
+{
+#if defined(__INTEL_LLVM_COMPILER)
+  return "Intel LLVM C++";
+#elif defined(__clang__)
+  return "Clang C++ " __clang_version__;
+#elif defined(__GNUC__)
+  return "GNU C++ " __VERSION__;
+#elif defined(_MSC_VER)
+  return "Microsoft Visual C++";
+#else
+  return "(unknown compiler)";
+#endif
+}
+
+/* return the C++ language standard the build was compiled against */
+
+static const char *cxx_standard()
+{
+#if __cplusplus >= 202302L
+  return "C++23";
+#elif __cplusplus >= 202002L
+  return "C++20";
+#elif __cplusplus >= 201703L
+  return "C++17";
+#elif __cplusplus >= 201402L
+  return "C++14";
+#elif __cplusplus >= 201103L
+  return "C++11";
+#else
+  return "(pre-C++11)";
+#endif
+}
+
+/* return the operating system SPARTA was built for */
+
+static const char *os_info()
+{
+#if defined(__linux__)
+  return "Linux";
+#elif defined(__APPLE__)
+  return "macOS";
+#elif defined(_WIN32)
+  return "Windows";
+#elif defined(__unix__)
+  return "Unix";
+#else
+  return "(unknown OS)";
+#endif
+}
+
+/* return the CPU architecture SPARTA was built for */
+
+static const char *arch_info()
+{
+#if defined(__x86_64__) || defined(_M_X64)
+  return "x86_64";
+#elif defined(__aarch64__) || defined(_M_ARM64)
+  return "arm64";
+#elif defined(__i386__) || defined(_M_IX86)
+  return "i386";
+#elif defined(__powerpc64__)
+  return "ppc64";
+#else
+  return "(unknown arch)";
+#endif
+}
+
+/* ----------------------------------------------------------------------
+   print a LAMMPS-style -help report: build/version provenance, the
+   configuration (parallelism, accelerators, image/movie I/O support),
+   the command-line switches, and the styles included in this executable.
+   Deliberately self-contained (no dependence on the library API or the
+   GUI) so it can be maintained as a standalone upstream feature.
+------------------------------------------------------------------------- */
+
+void SPARTA::print_help()
+{
+  // build/version provenance banner
+
+  printf("\nSPARTA (%s)\n",universe->version);
+  printf("Git info:     %s / %s\n",SPARTA_GIT_BRANCH,SPARTA_GIT_COMMIT);
+  printf("Compiled:     %s %s\n",__DATE__,__TIME__);
+  printf("Compiler:     %s (%s)\n",compiler_info(),cxx_standard());
+  printf("OS / arch:    %s / %s (%d-bit integers)\n",
+         os_info(),arch_info(),(int)(8*sizeof(bigint)));
+
+  // configuration: parallelism, accelerators, image/movie support
+
+#ifdef SPARTA_PNG
+  const char *have_png = "yes";
+#else
+  const char *have_png = "no";
+#endif
+#ifdef SPARTA_JPEG
+  const char *have_jpeg = "yes";
+#else
+  const char *have_jpeg = "no";
+#endif
+#ifdef SPARTA_FFMPEG
+  const char *have_ffmpeg = "yes";
+#else
+  const char *have_ffmpeg = "no";
+#endif
+#ifdef SPARTA_GZIP
+  const char *have_gzip = "yes";
+#else
+  const char *have_gzip = "no";
+#endif
+
+  printf("\nConfiguration:\n");
+#ifdef MPI_STUBS
+  printf("  Parallelism:  serial (MPI STUBS)\n");
+#else
+  printf("  Parallelism:  MPI\n");
+#endif
+#ifdef SPARTA_KOKKOS
+  printf("  Accelerator:  KOKKOS\n");
+#else
+  printf("  Accelerator:  none\n");
+#endif
+  printf("  PNG images:   %s\n",have_png);
+  printf("  JPEG images:  %s\n",have_jpeg);
+  printf("  FFmpeg movie: %s\n",have_ffmpeg);
+  printf("  gzip files:   %s\n",have_gzip);
+
+  // command-line switches
+
+  printf("\nUsage: sparta [command-line switches] < input_script\n");
+  printf("       sparta [command-line switches] -in input_script\n\n");
+  printf("Command-line switches:\n");
+  printf("  -e  or -echo none/screen/log/both : how to echo the input script\n");
+  printf("  -h  or -help                      : print this help message and exit\n");
+  printf("  -i  or -in <file>                 : read input from <file> (default: stdin)\n");
+  printf("  -k  or -kokkos on/off ...         : enable/configure the KOKKOS package\n");
+  printf("  -l  or -log <file>/none           : write log to <file> (default: log.sparta)\n");
+  printf("  -p  or -partition <n1> <n2> ...   : split procs into multiple partitions\n");
+  printf("  -pk or -package <style> ...       : invoke a package command at startup\n");
+  printf("  -pl or -plog <file>/none          : per-partition log file base name\n");
+  printf("  -ps or -pscreen <file>/none       : per-partition screen file base name\n");
+  printf("  -sc or -screen <file>/none        : write screen output to <file>\n");
+  printf("  -sf or -suffix <style>            : append a style suffix (e.g. kk)\n");
+  printf("  -v  or -var <name> <value> ...    : set an index-style variable\n");
+
+  // styles compiled into this executable
+
+  print_styles();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/sparta.h
+++ b/src/sparta.h
@@ -65,6 +65,7 @@ class SPARTA {
   void destroy();
 
   void print_styles();
+  void print_help();
 };
 
 }

--- a/src/stats.cpp
+++ b/src/stats.cpp
@@ -68,6 +68,11 @@ Stats::Stats(SPARTA *sparta) : Pointers(sparta)
 
   line = new char[MAXLINE];
 
+  cache_step = 0;
+  cache_num = 0;
+  cache_setup = 1;
+  cache_line = 0;
+
   keyword = NULL;
   vfunc = NULL;
   vtype = NULL;
@@ -256,16 +261,37 @@ void Stats::compute(int flag)
     }
 
   // add each stat value to line with its specific format
+  // also store each value in the cache for the library interface,
+  // guarded by the cache mutex since another thread may read it
 
-  int loc = 0;
-  for (ifield = 0; ifield < nfield; ifield++) {
-    (this->*vfunc[ifield])();
-    if (vtype[ifield] == FLOAT)
-      loc += sprintf(&line[loc],format[ifield],dvalue);
-    else if (vtype[ifield] == INT)
-      loc += sprintf(&line[loc],format[ifield],ivalue);
-    else if (vtype[ifield] == BIGINT) {
-      loc += sprintf(&line[loc],format[ifield],bivalue);
+  {
+    std::lock_guard<std::mutex> guard(cache_mutex);
+
+    cache_step = update->ntimestep;
+    cache_num = nfield;
+    cache_setup = (flag == 0);
+    cache_line = input->line_num;
+    cache_keyword.resize(nfield);
+    cache_type.resize(nfield);
+    cache_data.resize(nfield);
+
+    int loc = 0;
+    for (ifield = 0; ifield < nfield; ifield++) {
+      (this->*vfunc[ifield])();
+      cache_keyword[ifield] = keyword[ifield];
+      if (vtype[ifield] == FLOAT) {
+        loc += sprintf(&line[loc],format[ifield],dvalue);
+        cache_type[ifield] = 2;                  // SPARTA_DOUBLE
+        cache_data[ifield].d = dvalue;
+      } else if (vtype[ifield] == INT) {
+        loc += sprintf(&line[loc],format[ifield],ivalue);
+        cache_type[ifield] = 0;                  // SPARTA_INT
+        cache_data[ifield].i = ivalue;
+      } else if (vtype[ifield] == BIGINT) {
+        loc += sprintf(&line[loc],format[ifield],bivalue);
+        cache_type[ifield] = (sizeof(bigint) == 8) ? 4 : 0;  // SPARTA_INT64
+        cache_data[ifield].b = bivalue;
+      }
     }
   }
 
@@ -278,6 +304,83 @@ void Stats::compute(int flag)
       if (flushflag) fflush(logfile);
     }
   }
+}
+
+/* ----------------------------------------------------------------------
+   access the cache of the last computed stats data
+   called by sparta_last_thermo() in the library interface,
+   possibly from a different thread than the one running a simulation
+   what = "lock"/"unlock" acquire/release the cache mutex, so a caller
+     can consistently read multiple entries while a run progresses
+   returns pointer to the requested entry, NULL if unknown
+------------------------------------------------------------------------- */
+
+void *Stats::last_thermo(const char *what, int index)
+{
+  if (strcmp(what,"lock") == 0) {
+    cache_mutex.lock();
+    return NULL;
+  }
+  if (strcmp(what,"unlock") == 0) {
+    cache_mutex.unlock();
+    return NULL;
+  }
+
+  if (strcmp(what,"step") == 0) return (void *) &cache_step;
+  if (strcmp(what,"num") == 0) return (void *) &cache_num;
+  if (strcmp(what,"setup") == 0) return (void *) &cache_setup;
+  // "line" reports the *live* line number of the command currently being
+  // executed by the library command processor (Input::line_num, updated per
+  // command in sparta_commands_string), not the value cached at the last
+  // thermo output.  This is what lets the GUI highlight the exact input line
+  // that triggered an error even when the error happens before any thermo
+  // output has been produced (e.g. a bad "global" command): cache_line would
+  // still be 0 there and wrongly point at the first line.  During a run it is
+  // the line of the executing "run" command, so the progress highlight is
+  // unchanged.
+  if (strcmp(what,"line") == 0) return (void *) &input->line_num;
+  if (strcmp(what,"imagename") == 0) {
+    if (cache_imagename.empty()) return NULL;
+    return (void *) cache_imagename.c_str();
+  }
+
+  if (index < 0 || index >= cache_num) return NULL;
+
+  if (strcmp(what,"keyword") == 0)
+    return (void *) cache_keyword[index].c_str();
+  if (strcmp(what,"type") == 0) return (void *) &cache_type[index];
+  if (strcmp(what,"data") == 0) {
+    if (cache_type[index] == 0) return (void *) &cache_data[index].i;
+    if (cache_type[index] == 2) return (void *) &cache_data[index].d;
+    if (cache_type[index] == 4) return (void *) &cache_data[index].b;
+    return NULL;
+  }
+
+  return NULL;
+}
+
+/* ----------------------------------------------------------------------
+   record name of most recently written dump image file
+   called by DumpImage so a GUI can display images as they are created
+------------------------------------------------------------------------- */
+
+void Stats::set_last_image(const char *fname)
+{
+  std::lock_guard<std::mutex> guard(cache_mutex);
+  if (fname) cache_imagename = fname;
+  else cache_imagename.clear();
+}
+
+/* ----------------------------------------------------------------------
+   invalidate the cache at the beginning of a run
+------------------------------------------------------------------------- */
+
+void Stats::reset_cache()
+{
+  std::lock_guard<std::mutex> guard(cache_mutex);
+  cache_num = 0;
+  cache_setup = 1;
+  cache_imagename.clear();
 }
 
 /* ----------------------------------------------------------------------

--- a/src/stats.h
+++ b/src/stats.h
@@ -17,6 +17,10 @@
 
 #include "pointers.h"
 
+#include <mutex>
+#include <string>
+#include <vector>
+
 namespace SPARTA_NS {
 
 class Stats : protected Pointers {
@@ -30,10 +34,31 @@ class Stats : protected Pointers {
   void compute(int);
   int evaluate_keyword(char *, double *);
 
+  // thread-safe cache of the last computed stats line
+  // accessed by the library interface (sparta_last_thermo),
+  // e.g. from a GUI thread while a run progresses on another thread
+
+  void *last_thermo(const char *, int);
+  void set_last_image(const char *);
+  void reset_cache();
+
  private:
   char *line;
   char **keyword;
   int *vtype;
+
+  // last-stats cache for the library interface
+
+  std::mutex cache_mutex;
+  bigint cache_step;              // timestep of cached data
+  int cache_num;                  // # of cached fields
+  int cache_setup;                // 1 if in setup phase of a run, data invalid
+  int cache_line;                 // input script line # of executing command
+  std::vector<std::string> cache_keyword;   // per-field keyword strings
+  std::vector<int> cache_type;    // per-field datatype (library codes)
+  struct CacheVal { int i; double d; bigint b; };
+  std::vector<CacheVal> cache_data;          // per-field values
+  std::string cache_imagename;    // most recent dump image filename
 
   int nfield;
   int me;

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -31,11 +31,18 @@ using namespace SPARTA_NS;
 Timer::Timer(SPARTA *sparta) : Pointers(sparta)
 {
   memory->create(array,TIME_N,"array");
+  // zero the timers at construction: init() only runs at the start of a run,
+  // but commands such as "balance_grid rcb time" read the array before any run
+  // and would otherwise use uninitialized values (garbage cell weights, and a
+  // missed "no time history" warning) -- benign in a fresh process where the
+  // heap is zeroed, but not when SPARTA is embedded in a long-lived process.
+  for (int i = 0; i < TIME_N; i++) array[i] = 0.0;
   _timeout = -1.0;
   _s_timeout = -1.0;
   _checkfreq = 10;
   _nextcheck = -1;
-
+  last_cpu_secs = -1.0;
+  last_cpu_wall = -1.0;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -139,8 +146,6 @@ bool Timer::_check_timeout()
   // broadcast time to ensure all ranks act the same.
   MPI_Bcast(&walltime, 1, MPI_DOUBLE, 0, world);
 
-  printf("%g %g\n",walltime,_timeout);
-
   if (walltime < _timeout) {
     _nextcheck += _checkfreq;
     return false;
@@ -158,4 +163,40 @@ double Timer::get_timeout_remain()
   // never report a negative remaining time.
   if (remain < 0.0) remain = 0.0;
   return (_timeout < 0.0) ? 0.0 : remain;
+}
+
+/* ----------------------------------------------------------------------
+   return CPU utilization in percent since the previous call
+   first call returns 0.0 and initializes the reference point
+------------------------------------------------------------------------- */
+
+#if defined(_WIN32)
+#include <ctime>
+#else
+#include <sys/resource.h>
+#include <sys/time.h>
+#endif
+
+double Timer::cpu_usage()
+{
+  double cpu_secs;
+
+#if defined(_WIN32)
+  cpu_secs = (double) clock() / CLOCKS_PER_SEC;
+#else
+  struct rusage ru;
+  getrusage(RUSAGE_SELF,&ru);
+  cpu_secs = (double) ru.ru_utime.tv_sec + 1.0e-6*ru.ru_utime.tv_usec +
+    (double) ru.ru_stime.tv_sec + 1.0e-6*ru.ru_stime.tv_usec;
+#endif
+
+  double wall = MPI_Wtime();
+
+  double percent = 0.0;
+  if (last_cpu_wall >= 0.0 && wall > last_cpu_wall)
+    percent = 100.0*(cpu_secs-last_cpu_secs)/(wall-last_cpu_wall);
+
+  last_cpu_secs = cpu_secs;
+  last_cpu_wall = wall;
+  return percent;
 }

--- a/src/timer.h
+++ b/src/timer.h
@@ -46,6 +46,10 @@ class Timer : protected Pointers {
   // get remaining time in seconds. 0.0 if inactive, negative if expired
   double get_timeout_remain();
 
+  // CPU utilization in percent since the previous call
+  // used by the library interface, e.g. for a GUI progress display
+  double cpu_usage();
+
   // print timeout message
   void print_timeout(FILE *);
 
@@ -63,6 +67,8 @@ class Timer : protected Pointers {
  private:
   double previous_time;
   double timeout_start;
+  double last_cpu_secs;     // process CPU time at last cpu_usage() call
+  double last_cpu_wall;     // wall time at last cpu_usage() call
   double _timeout;      // max allowed wall time in seconds. infinity if negative
   double _s_timeout;    // copy of timeout for restoring after a forced timeout
   int _checkfreq;       // frequency of timeout checking

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -74,6 +74,10 @@ Update::Update(SPARTA *sparta) : Pointers(sparta)
   beginstep = endstep = 0;
   first_update = 0;
 
+  rcbflag = 0;
+  rcblo[0] = rcblo[1] = rcblo[2] = 0.0;
+  rcbhi[0] = rcbhi[1] = rcbhi[2] = 0.0;
+
   time = 0.0;
   time_last_update = 0;
 

--- a/src/update.h
+++ b/src/update.h
@@ -90,7 +90,9 @@ class Update : protected Pointers {
 
   class RanMars *ranmaster;   // master random number generator
 
-  double rcblo[3],rcbhi[3];    // debug info from RCB for dump image
+  int rcbflag;                 // 1 if per-proc RCB sub-boxes are valid
+  double rcblo[3],rcbhi[3];    // most recent RCB sub-box of this proc,
+                               // e.g. for the dump image subbox keyword
 
   // hooks to computes doing on-surface collision/reaction tallying
   // public b/c accessed

--- a/src/variable.cpp
+++ b/src/variable.cpp
@@ -994,6 +994,47 @@ int Variable::find(char *name)
 }
 
 /* ----------------------------------------------------------------------
+   return a human-readable one-line description of variable i:
+   its name, style, and definition string(s).
+   used by the library interface (sparta_variable_info) for GUI display;
+   mirrors LAMMPS Info::get_variable_info / Variable::get_info
+------------------------------------------------------------------------- */
+
+std::string Variable::get_info(int i)
+{
+  static const char *varstyles[] = {
+    "index","loop","world","universe","uloop","string","getenv",
+    "file","format","equal","particle","grid","surf","internal","python"};
+  const int nstyles = sizeof(varstyles)/sizeof(varstyles[0]);
+
+  char buf[256];
+
+  if (i < 0 || i >= nvar) {
+    snprintf(buf,sizeof(buf),"Variable[%3d]: (unknown)\n",i);
+    return std::string(buf);
+  }
+
+  const char *vstyle =
+    (style[i] >= 0 && style[i] < nstyles) ? varstyles[style[i]] : "(unknown)";
+  std::string sname = std::string(names[i]) + ",";
+  std::string sstyle = std::string(vstyle) + ",";
+  snprintf(buf,sizeof(buf),"Variable[%3d]: %-16s  style = %-16s  def =",
+           i,sname.c_str(),sstyle.c_str());
+  std::string text(buf);
+
+  if (style[i] == INTERNAL) {
+    snprintf(buf,sizeof(buf)," %.8g\n",dvalue[i]);
+    text += buf;
+    return text;
+  }
+
+  for (int j = 0; j < num[i]; ++j)
+    if (data[i][j]) { text += ' '; text += data[i][j]; }
+  text += "\n";
+  return text;
+}
+
+/* ----------------------------------------------------------------------
    called by python command in input script
    simply pass input script line args to Python class
 ------------------------------------------------------------------------- */

--- a/src/variable.h
+++ b/src/variable.h
@@ -17,6 +17,7 @@
 
 #include "stdio.h"
 #include "pointers.h"
+#include <string>
 
 namespace SPARTA_NS {
 
@@ -51,6 +52,12 @@ class Variable : protected Pointers {
 
   int int_between_brackets(char *&, int, const char * = "variable");
   double evaluate_boolean(char *);
+
+  // accessors for the library interface
+
+  int nvar_active() const { return nvar; }
+  const char *name(int i) const { return names[i]; }
+  std::string get_info(int);
 
  protected:
   int me;


### PR DESCRIPTION
## Purpose

This pull request bundles a set of minimally-invasive core changes that make it practical to embed SPARTA as a shared library in a long-running host process, plus a few self-contained enhancements and a colormap bugfix. The changes are additive and backward compatible; the standalone `spa_*` binary behaves exactly as before.

Highlights:

- **Exception-based error handling for embedded use.** `Error::all()/one()` (and the `universe_*` variants) now throw a `SpartaException` / `SpartaAbortException` after the usual rank-0 message instead of calling `exit()`/`MPI_Abort()` directly. `main.cpp` catches them so the standalone binary still prints `ERROR:` and exits 1, and multi-rank runs still abort. A host embedding SPARTA can now catch an error, recover, and keep issuing commands instead of having the whole process torn down. A last-error buffer is recorded for retrieval through the library.
- **Extended C library interface** (`src/library.{h,cpp}`, ~9 → ~34 functions): run commands from a string with input-line tracking, query the most recent thermodynamic output, poll whether a run is active and request an early, clean stop, retrieve captured error state, enumerate command/compute/fix/dump/region/collide/react/surf styles and defined IDs, introspect variables and settings, and read build/version provenance. Existing functions keep their signatures.
- **Cached thermodynamic output** (`Stats`): the most recent thermo line is cached under a mutex during `Stats::compute()` so a second thread (e.g. a monitor) can read step/keywords/values safely while a run is in progress.
- **`dump image` enhancements:** `fsaa` full-scene antialiasing, a real `subbox`/`subboxcolor` keyword for per-processor RCB sub-domain boxes (promoted from the old `RCB_DEBUG` path), a `backcolor2` gradient background, and a `lights` `dump_modify` option. All default to the previous behavior, so existing renders are unchanged.
- **Colormap bugfix:** discrete color maps set their entry bounds via `.lo`/`.hi` instead of the (unused) `.single` field, matching the numeric-value code path, so `MINVALUE`/`MAXVALUE` bounds now take effect for discrete maps.
- **KOKKOS init/finalize** is made safe across repeated embedded use (never finalize Kokkos on an error/library path, since it cannot be re-initialized in the same process).
- **Build fixes** for native and cross compilation.

## Author(s)

Stan Moore (SNL) and Claude Code (Fable 5, Opus 4.8)

## Backward Compatibility

Yes

## Implementation Notes

- The error path builds the full message (including file:line), stores it in the last-error buffer, then throws; catch sites decide serial-recover vs. `MPI_Abort`, preserving parallel semantics. Kokkos is never finalized in error/library paths.
- The `Stats` cache is filled inside the existing field loop under a single `std::lock_guard`; the library exposes `lock`/`unlock` keys mapping to that mutex so a polling thread reads a consistent snapshot.
- Style enumeration reuses the generated `style_*.h` macro headers (pure macro lists, no linkage cost) to build static name tables in `library.cpp`.
- `dump image` back-ports were validated by rendering `examples/circle` with each new keyword and confirming that the `fsaa`-off / default path is byte-for-byte identical to the pre-change renders, and that old inputs still parse.
- Standalone `stats` output for `examples/circle` and `examples/collide` was compared before/after and is identical (apart from CPU-time columns).

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

Documentation was updated alongside the code: `doc/Section_howto` (library interface), `doc/Section_start` (`-help`), `doc/dump_image` and `doc/dump_modify` (new keywords, plus removal of the phantom `bcolor`/`bdiam` entries). No new example decks are included because the changes are library/infrastructure and additive `dump image` options that the existing examples already exercise.