### PR TITLE
Small bugfixes and other changes

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -77,6 +77,37 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/Modules)
 set(SPARTA_CMAKE_COMMON_DIR ${SPARTA_CMAKE_DIR}/common)
 # ######### END   SET COMMON DIRS ##########
 
+# ######### BEGIN CHECK BUILD DIRECTORY ##########
+# Refuse to generate into the SPARTA source tree.
+#
+# The usual source == binary test is not sufficient here, because the CMake
+# source directory is sparta/cmake rather than the repo root.  Running
+# "cmake /path/to/sparta/cmake" from sparta/src therefore looks like a
+# normal out-of-source build to CMake, and the generated Makefile silently
+# overwrites the hand-written src/Makefile used by the gnumake build.
+# Check the directories that hold files CMake would clobber.
+get_filename_component(SPARTA_REAL_BINARY_DIR ${CMAKE_BINARY_DIR} REALPATH)
+get_filename_component(SPARTA_REAL_CMAKE_DIR ${SPARTA_CMAKE_DIR} REALPATH)
+get_filename_component(SPARTA_REAL_SRC_DIR ${SPARTA_SRC_DIR} REALPATH)
+get_filename_component(SPARTA_REAL_ROOT_DIR ${SPARTA_CMAKE_DIR}/.. REALPATH)
+
+foreach(dir ${SPARTA_REAL_CMAKE_DIR} ${SPARTA_REAL_SRC_DIR}
+             ${SPARTA_REAL_ROOT_DIR})
+  if(SPARTA_REAL_BINARY_DIR STREQUAL dir)
+    message(
+      FATAL_ERROR
+        "Refusing to build in ${SPARTA_REAL_BINARY_DIR}, which is part of the "
+        "SPARTA source tree. Generating here would overwrite files tracked in "
+        "git, such as src/Makefile. Create a separate build directory "
+        "instead:\n"
+        "  mkdir build && cd build\n"
+        "  cmake ${SPARTA_REAL_CMAKE_DIR}\n"
+        "Remove the CMakeCache.txt and CMakeFiles/ that this run left behind, "
+        "and restore any overwritten file with git checkout.")
+  endif()
+endforeach()
+# ######### END   CHECK BUILD DIRECTORY ##########
+
 # ######### BEGIN SET CMAKE DEFAULTS ##########
 include(${SPARTA_CMAKE_COMMON_DIR}/set/sparta_cmake_defaults.cmake)
 # ######### END   SET CMAKE DEFAULTS ##########

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -55,14 +55,6 @@ list(APPEND TARGET_SPARTA_BUILD_TPLS ${TARGET_SPARTA_BUILD_MPI})
 
 # ################### BEGIN PROCESS FFT TPL/PKG ####################
 
-if((NOT PKG_FFT) AND (NOT (FFT_KOKKOS STREQUAL "OFF")))
-  message(FATAL_ERROR  "Setting FFT_KOKKOS library requires PKG_FFT: ON.")
-endif()
-
-if((NOT PKG_FFT) AND (NOT (FFT STREQUAL "OFF")))
-  message(FATAL_ERROR  "Setting FFT library requires PKG_FFT: ON.")
-endif()
-
 if(PKG_FFT)
 
   if(FFT STREQUAL "OFF")

--- a/doc/fix_emit_face.html
+++ b/doc/fix_emit_face.html
@@ -120,10 +120,18 @@ of particles entering the simulation box.
 useful for debugging purposes.  If <I>Np</I> is set to 0, then the number
 of added particles is a function of <I>fnum</I>, <I>nrho</I>, and other mixture
 settings, as described above.  If <I>Np</I> is set to a value > 0, then the
-<I>fnum</I> and <I>nrho</I> settings are ignored, and exactly <I>Np</I> particles are
-added on each insertion timestep.  This is done by dividing <I>Np</I> by
-the total number of grid cells that are adjacent to the specified box
+<I>fnum</I> and <I>nrho</I> settings are ignored, and <I>Np</I> particles are added
+on each insertion timestep.  This is done by dividing <I>Np</I> by the
+total number of grid cells that are adjacent to the specified box
 faces and adding an equal number of particles per grid cell.
+</P>
+<P><I>Np</I> may be set to a non-integer value, e.g. 12.5 or 0.5.  In this
+case the integer part of <I>Np</I> is added exactly each timestep, and the
+fractional part is added stochastically, spread across the eligible
+grid cells, so that <I>Np</I> particles are added on average.  This allows
+for an insertion rate of less than one particle per timestep, which is
+useful when a low inflow rate is desired through a specific set of box
+faces without changing the global <I>fnum</I> setting.
 </P>
 <P>The <I>nevery</I> keyword determines how often particles are added.  If
 <I>Nstep</I> > 1, this may give a non-continuous, clumpy distribution in

--- a/doc/fix_emit_face.txt
+++ b/doc/fix_emit_face.txt
@@ -109,10 +109,18 @@ The {n} keyword can alter how many particles are added, which can be
 useful for debugging purposes.  If {Np} is set to 0, then the number
 of added particles is a function of {fnum}, {nrho}, and other mixture
 settings, as described above.  If {Np} is set to a value > 0, then the
-{fnum} and {nrho} settings are ignored, and exactly {Np} particles are
-added on each insertion timestep.  This is done by dividing {Np} by
-the total number of grid cells that are adjacent to the specified box
+{fnum} and {nrho} settings are ignored, and {Np} particles are added
+on each insertion timestep.  This is done by dividing {Np} by the
+total number of grid cells that are adjacent to the specified box
 faces and adding an equal number of particles per grid cell.
+
+{Np} may be set to a non-integer value, e.g. 12.5 or 0.5.  In this
+case the integer part of {Np} is added exactly each timestep, and the
+fractional part is added stochastically, spread across the eligible
+grid cells, so that {Np} particles are added on average.  This allows
+for an insertion rate of less than one particle per timestep, which is
+useful when a low inflow rate is desired through a specific set of box
+faces without changing the global {fnum} setting.
 
 The {nevery} keyword determines how often particles are added.  If
 {Nstep} > 1, this may give a non-continuous, clumpy distribution in

--- a/doc/fix_emit_surf.html
+++ b/doc/fix_emit_surf.html
@@ -136,6 +136,12 @@ of emitted particles is set to its fraction of the total emission area
 that results in a fractional value, then an extra particle is emitted
 depending on the value of a random number, as explained above.
 </P>
+<P><I>Np</I> may be set to a non-integer value, e.g. 12.5 or 0.5.  Since the
+per-surface-element target is rounded stochastically, this allows for
+an emission rate of less than one particle per timestep, which is
+useful when a low inflow rate is desired through a specific group of
+surface elements without changing the global <I>fnum</I> setting.
+</P>
 <P>The <I>Np</I> value can be also be specified as an equal-style
 <A HREF = "variable.html">variable</A>.  If the value is a variable, it should be
 specified as v_name, where name is the variable name.  In this case,

--- a/doc/fix_emit_surf.txt
+++ b/doc/fix_emit_surf.txt
@@ -126,6 +126,12 @@ of emitted particles is set to its fraction of the total emission area
 that results in a fractional value, then an extra particle is emitted
 depending on the value of a random number, as explained above.
 
+{Np} may be set to a non-integer value, e.g. 12.5 or 0.5.  Since the
+per-surface-element target is rounded stochastically, this allows for
+an emission rate of less than one particle per timestep, which is
+useful when a low inflow rate is desired through a specific group of
+surface elements without changing the global {fnum} setting.
+
 The {Np} value can be also be specified as an equal-style
 "variable"_variable.html.  If the value is a variable, it should be
 specified as v_name, where name is the variable name.  In this case,

--- a/doc/global.html
+++ b/doc/global.html
@@ -381,16 +381,17 @@ store particles because it is performed out-of-place by default. Reading
 and writing restart files also requires temporary buffers to hold grid 
 cells and particles and can double the memory required. 
 </P>
-<P>Specifying the value for <I>mem/limit</I> as <I>grid</I>, will allocate extra 
-memory limited to the size of memory for storing grid cells on each 
-processor. For most simulations this is typically much smaller than the 
-memory used to store particles. Specifying a numeric value for <I>bytes</I> 
-will allocate extra memory limited to that many MBytes on each 
-processor. <I>Bytes</I> can be specified as a floating point value or an 
-integer, e.g. 0.5 if you want to use 1/2 MByte of extra memory or 100 
-for a 100 MByte buffer. Specifying a value of 0 (the default) means no 
-limit is used. The value used for <I>mem/limit</I> must not exceed 2GB or an
-error will occur.
+<P>Specifying the value for <I>mem/limit</I> as <I>grid</I>, will allocate extra
+memory limited to the size of memory for storing grid cells on each
+processor. For most simulations this is typically much smaller than the
+memory used to store particles. If the grid memory exceeds the 2GB limit,
+it is capped at 2GB. Specifying a numeric value for <I>bytes</I>
+will allocate extra memory limited to that many MBytes on each
+processor, where 1 MByte = 1024*1024 bytes. <I>Bytes</I> can be specified as a
+floating point value or an integer, e.g. 0.5 if you want to use 1/2 MByte
+of extra memory or 100 for a 100 MByte buffer. Specifying a value of 0
+(the default) means no limit is used. The numeric value used for
+<I>mem/limit</I> must not exceed 2GB or an error will occur.
 </P>
 <P>For load-balancing, the communication of grid and particle data to new 
 processors will then be performed in multiple passes (if necessary) so 

--- a/doc/global.txt
+++ b/doc/global.txt
@@ -375,16 +375,17 @@ store particles because it is performed out-of-place by default. Reading
 and writing restart files also requires temporary buffers to hold grid 
 cells and particles and can double the memory required. 
 
-Specifying the value for {mem/limit} as {grid}, will allocate extra 
-memory limited to the size of memory for storing grid cells on each 
-processor. For most simulations this is typically much smaller than the 
-memory used to store particles. Specifying a numeric value for {bytes} 
-will allocate extra memory limited to that many MBytes on each 
-processor. {Bytes} can be specified as a floating point value or an 
-integer, e.g. 0.5 if you want to use 1/2 MByte of extra memory or 100 
-for a 100 MByte buffer. Specifying a value of 0 (the default) means no 
-limit is used. The value used for {mem/limit} must not exceed 2GB or an
-error will occur.
+Specifying the value for {mem/limit} as {grid}, will allocate extra
+memory limited to the size of memory for storing grid cells on each
+processor. For most simulations this is typically much smaller than the
+memory used to store particles. If the grid memory exceeds the 2GB limit,
+it is capped at 2GB. Specifying a numeric value for {bytes}
+will allocate extra memory limited to that many MBytes on each
+processor, where 1 MByte = 1024*1024 bytes. {Bytes} can be specified as a
+floating point value or an integer, e.g. 0.5 if you want to use 1/2 MByte
+of extra memory or 100 for a 100 MByte buffer. Specifying a value of 0
+(the default) means no limit is used. The numeric value used for
+{mem/limit} must not exceed 2GB or an error will occur.
 
 For load-balancing, the communication of grid and particle data to new 
 processors will then be performed in multiple passes (if necessary) so 

--- a/doc/read_isurf.html
+++ b/doc/read_isurf.html
@@ -304,6 +304,17 @@ created by the marching cubes or marching squares algorithms.
 </P>
 <P>The default for the <I>push</I> keyword is <I>yes</I>.
 </P>
+<P>Note that <I>push yes</I> re-normalizes the corner point values as they are
+read, snapping fully interior/exterior corners to 0 or 255.  This is
+appropriate for a freshly generated geometry file, but it means a
+read_isurf is not an exact inverse of a <A HREF = "write_isurf.html">write_isurf</A>.
+When you use the write_isurf then read_isurf sequence to save and
+restore a partially ablated (mid-run) surface state, as described on
+the <A HREF = "write_isurf.html">write_isurf</A> doc page, use <I>push no</I> so the
+corner point values are restored exactly as written.  Also use
+<I>precision double</I> in that case (see below), so partially decremented
+corner point values are not truncated to integers.
+</P>
 <P>The <I>read</I> keyword specifies how the input file of grid corner point
 values is read.  If the value is <I>serial</I>, which is the default, then
 only a single proc reads the file, a chunk of values at at time.  They

--- a/doc/read_isurf.txt
+++ b/doc/read_isurf.txt
@@ -293,6 +293,17 @@ created by the marching cubes or marching squares algorithms.
 
 The default for the {push} keyword is {yes}.
 
+Note that {push yes} re-normalizes the corner point values as they are
+read, snapping fully interior/exterior corners to 0 or 255.  This is
+appropriate for a freshly generated geometry file, but it means a
+read_isurf is not an exact inverse of a "write_isurf"_write_isurf.html.
+When you use the write_isurf then read_isurf sequence to save and
+restore a partially ablated (mid-run) surface state, as described on
+the "write_isurf"_write_isurf.html doc page, use {push no} so the
+corner point values are restored exactly as written.  Also use
+{precision double} in that case (see below), so partially decremented
+corner point values are not truncated to integers.
+
 The {read} keyword specifies how the input file of grid corner point
 values is read.  If the value is {serial}, which is the default, then
 only a single proc reads the file, a chunk of values at at time.  They

--- a/doc/write_isurf.html
+++ b/doc/write_isurf.html
@@ -69,6 +69,17 @@ the grid corner point values for each grid cell.
 <P>The output file is written in the same binary format as the
 <A HREF = "read_isurf.html">read_isurf</A> command reads in.
 </P>
+<P>Because implicit-surface corner point values are not stored in restart
+files, a write_isurf followed by a later <A HREF = "read_isurf.html">read_isurf</A>
+is the way to save and restore the state of an ablating surface.  To
+reproduce the saved state exactly, write the file with <I>precision
+double</I> (the default) so partially decremented corner point values are
+not truncated to integers, and read it back with the read_isurf
+<I>precision double</I> and <I>push no</I> options.  The default read_isurf
+<I>push yes</I> re-normalizes corner point values as they are read and so
+will not reproduce a mid-ablation state exactly; see the <I>push</I> keyword
+discussion on the <A HREF = "read_isurf.html">read_isurf</A> doc page.
+</P>
 <P><B>Restrictions:</B> none
 </P>
 <P><B>Related commands:</B>

--- a/doc/write_isurf.txt
+++ b/doc/write_isurf.txt
@@ -59,6 +59,17 @@ the grid corner point values for each grid cell.
 The output file is written in the same binary format as the
 "read_isurf"_read_isurf.html command reads in.
 
+Because implicit-surface corner point values are not stored in restart
+files, a write_isurf followed by a later "read_isurf"_read_isurf.html
+is the way to save and restore the state of an ablating surface.  To
+reproduce the saved state exactly, write the file with {precision
+double} (the default) so partially decremented corner point values are
+not truncated to integers, and read it back with the read_isurf
+{precision double} and {push no} options.  The default read_isurf
+{push yes} re-normalizes corner point values as they are read and so
+will not reproduce a mid-ablation state exactly; see the {push} keyword
+discussion on the "read_isurf"_read_isurf.html doc page.
+
 [Restrictions:] none
 
 [Related commands:]

--- a/src/KOKKOS/fix_ave_grid_kokkos.cpp
+++ b/src/KOKKOS/fix_ave_grid_kokkos.cpp
@@ -170,6 +170,13 @@ void FixAveGridKokkos::end_of_step()
   // could do this with memset()
 
   copymode = 1;
+
+  // grid cell migration (load balance / grid adaptation) reorders the
+  // per-cell tally and output on the host; pull those changes onto the
+  // device before accumulating so the running tally is not corrupted
+
+  pergrid_sync(Device);
+
   if (ave == ONE && irepeat == 0)
     Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Zero_tally>(0,nglocal),*this);
 
@@ -338,6 +345,12 @@ void FixAveGridKokkos::end_of_step()
     }
   }
 
+  // the tally array was accumulated on the device this step
+  // mark it modified so the host copy is refreshed if grid cells later
+  // migrate (the migration hooks pack/unpack the host tally)
+
+  k_tally.modify_device();
+
   // done if irepeat < nrepeat
   // else reset irepeat and nvalid
 
@@ -400,10 +413,15 @@ void FixAveGridKokkos::end_of_step()
     GridKokkos* grid_kk = (GridKokkos*) grid;
     grid_kk->sync(Device,CINFO_MASK);
     d_cinfo = grid_kk->k_cinfo.view_device();
-    if (nvalues == 1)
+    if (nvalues == 1) {
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Zero_group_vector>(0,nglocal),*this);
-    else
+      k_vector_grid.modify_device();
+      k_vector_grid.sync_host();
+    } else {
       Kokkos::parallel_for(Kokkos::RangePolicy<DeviceType, TagFixAveGrid_Zero_group_array>(0,nglocal),*this);
+      k_array_grid.modify_device();
+      k_array_grid.sync_host();
+    }
   }
 
   // reset nsample if ave = ONE
@@ -496,17 +514,100 @@ void FixAveGridKokkos::grow_percell(int nnew)
   maxgrid += DELTAGRID;
   int n = maxgrid;
 
+  // resize with the device as the source of truth, then refresh the host
+  // so both copies hold valid data and no dangling modify flag remains
+  // (this is called from the grid migration hooks, which then edit the host)
+
+  pergrid_sync(Device);
+
   if (nvalues == 1) {
     memoryKK->grow_kokkos(k_vector_grid,vector_grid,n,"ave/grid:vector_grid");
     d_vector_grid = k_vector_grid.view_device();
-    k_vector_grid.sync_host();
   } else {
     memoryKK->grow_kokkos(k_array_grid,array_grid,n,nvalues,"ave/grid:array_grid");
     d_array_grid = k_array_grid.view_device();
-    k_array_grid.sync_host();
   }
 
   memoryKK->grow_kokkos(k_tally,tally,n,ntotal,"ave/grid:tally");
   d_tally = k_tally.view_device();
+
+  pergrid_sync(Host);
+}
+
+/* ----------------------------------------------------------------------
+   grid cell migration hooks (load balance / grid adaptation)
+   the base class packs/unpacks/copies the per-cell tally and output using
+   the host arrays, so bring the host up to date before it reads and mark
+   the host modified after it writes; the device is refreshed lazily in
+   end_of_step().  Without this the accumulated tally is only correct on the
+   device and grid migration silently corrupts the averaged output when UVM
+   is disabled.
+------------------------------------------------------------------------- */
+
+int FixAveGridKokkos::pack_grid_one(int icell, char *buf, int memflag)
+{
+  pergrid_sync(Host);
+  return FixAveGrid::pack_grid_one(icell,buf,memflag);
+}
+
+/* ---------------------------------------------------------------------- */
+
+int FixAveGridKokkos::unpack_grid_one(int icell, char *buf)
+{
+  pergrid_sync(Host);
+  int n = FixAveGrid::unpack_grid_one(icell,buf);
+  pergrid_modify(Host);
+  return n;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixAveGridKokkos::copy_grid_one(int icell, int jcell)
+{
+  pergrid_sync(Host);
+  FixAveGrid::copy_grid_one(icell,jcell);
+  pergrid_modify(Host);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixAveGridKokkos::add_grid_one()
+{
+  pergrid_sync(Host);
+  FixAveGrid::add_grid_one();
+  pergrid_modify(Host);
+}
+
+/* ----------------------------------------------------------------------
+   sync/modify the per-grid dual views: the tally array plus whichever
+   output array (vector_grid or array_grid) is in use
+------------------------------------------------------------------------- */
+
+void FixAveGridKokkos::pergrid_sync(ExecutionSpace space)
+{
+  if (space == Device) {
+    if (nvalues == 1) k_vector_grid.sync_device();
+    else k_array_grid.sync_device();
+    k_tally.sync_device();
+  } else {
+    if (nvalues == 1) k_vector_grid.sync_host();
+    else k_array_grid.sync_host();
+    k_tally.sync_host();
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixAveGridKokkos::pergrid_modify(ExecutionSpace space)
+{
+  if (space == Device) {
+    if (nvalues == 1) k_vector_grid.modify_device();
+    else k_array_grid.modify_device();
+    k_tally.modify_device();
+  } else {
+    if (nvalues == 1) k_vector_grid.modify_host();
+    else k_array_grid.modify_host();
+    k_tally.modify_host();
+  }
 }
 

--- a/src/KOKKOS/fix_ave_grid_kokkos.h
+++ b/src/KOKKOS/fix_ave_grid_kokkos.h
@@ -46,6 +46,11 @@ class FixAveGridKokkos : public FixAveGrid, public KokkosBase {
   void setup();
   void end_of_step();
 
+  int pack_grid_one(int, char *, int);
+  int unpack_grid_one(int, char *);
+  void copy_grid_one(int, int);
+  void add_grid_one();
+
   KOKKOS_INLINE_FUNCTION
   void operator()(TagFixAveGrid_Zero_group_vector, const int&) const;
 
@@ -103,6 +108,12 @@ class FixAveGridKokkos : public FixAveGrid, public KokkosBase {
   int j,k,kk,jm1,m,ntally;
 
   void grow_percell(int);
+
+  // sync/modify the per-grid dual views (tally + vector/array output)
+  // needed so accumulated tally survives grid cell migration without UVM
+
+  void pergrid_sync(ExecutionSpace);
+  void pergrid_modify(ExecutionSpace);
 };
 
 }

--- a/src/KOKKOS/fix_emit_face_kokkos.cpp
+++ b/src/KOKKOS/fix_emit_face_kokkos.cpp
@@ -406,12 +406,14 @@ void FixEmitFaceKokkos::operator()(TagFixEmitFace_ninsert, const int &i) const
       d_ninsert(i * nspecies + isp) = ninsert;
     }
   } else {
-    if (np == 0) {
+    if (np == 0.0) {
       auto ntarget = prefactor*d_tasks(i).ntarget + rand_gen.drand();
       ninsert = static_cast<int> (ntarget);
     } else {
       ninsert = npertask;
       if (i >= nthresh) ninsert++;
+      if (npremain_pertask > 0.0)
+        ninsert += static_cast<int> (npremain_pertask + rand_gen.drand());
     }
     d_ninsert(i) = ninsert;
   }

--- a/src/KOKKOS/update_kokkos.cpp
+++ b/src/KOKKOS/update_kokkos.cpp
@@ -411,8 +411,10 @@ void UpdateKokkos::run(int nsteps)
       timer->stamp(TIME_OUTPUT);
     }
   }
-  sparta->kokkos->auto_sync = 1;
 
+  modify->post_run();
+
+  sparta->kokkos->auto_sync = 1;
   particle_kk->sync(Host,ALL_MASK);
 }
 

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -113,7 +113,7 @@ FixAblate::FixAblate(SPARTA *sparta, int narg, char **arg) :
     which = VARIABLE;
 
     int n = strlen(arg[5]);
-    char *idsource = new char[n];
+    idsource = new char[n];
     strcpy(idsource,&arg[5][2]);
 
   } else if (strcmp(arg[5],"random") == 0) {

--- a/src/fix_ablate.cpp
+++ b/src/fix_ablate.cpp
@@ -326,6 +326,16 @@ void FixAblate::store_corners(int nx_caller, int ny_caller, int nz_caller,
     mvalues = NULL; // likely not needed
   }
 
+  // a multivalue fix stores corner state in mvalues and leaves array_grid
+  //   (= cvalues) NULL, so it cannot expose the per-grid corner array that
+  //   per_grid_flag advertises.  Turn the flag off so generic per-grid
+  //   consumers (compute reduce, dump grid, fix ave/grid, ...) reject it
+  //   cleanly at setup instead of dereferencing NULL array_grid at run time.
+  //   The scalar output (f_ID) is unaffected.
+
+  if (multi_val_flag) per_grid_flag = 0;
+  else per_grid_flag = 1;
+
   nx = nx_caller;
   ny = ny_caller;
   nz = nz_caller;

--- a/src/fix_emit_face.cpp
+++ b/src/fix_emit_face.cpp
@@ -231,18 +231,26 @@ void FixEmitFace::grid_changed()
   create_tasks();
 
   // if Np > 0, nper = # of insertions per task
-  // set nthresh so as to achieve exactly Np insertions
-  // tasks > tasks_with_no_extra need to insert 1 extra particle
+  // integer part of Np is distributed deterministically:
+  //   set nthresh so as to achieve exactly npint insertions
+  //   tasks > tasks_with_no_extra need to insert 1 extra particle
+  // fractional part of Np is spread stochastically across all tasks:
+  //   each task inserts npremain_pertask + random extra particle on average
   // NOTE: currently setting same # of insertions per task
   //       could instead weight by cell face area
 
-  if (np > 0) {
+  if (np > 0.0) {
     int all,nupto,tasks_with_no_extra;
+    int npint = static_cast<int> (np);
     MPI_Allreduce(&ntask,&all,1,MPI_INT,MPI_SUM,world);
     if (all) {
-      npertask = np / all;
-      tasks_with_no_extra = all - (np % all);
-    } else npertask = tasks_with_no_extra = 0;
+      npertask = npint / all;
+      tasks_with_no_extra = all - (npint % all);
+      npremain_pertask = (np - npint) / all;
+    } else {
+      npertask = tasks_with_no_extra = 0;
+      npremain_pertask = 0.0;
+    }
 
     MPI_Scan(&ntask,&nupto,1,MPI_INT,MPI_SUM,world);
     if (tasks_with_no_extra < nupto-ntask) nthresh = 0;
@@ -590,12 +598,14 @@ void FixEmitFace::perform_task_onepass()
       }
 
     } else {
-      if (np == 0) {
+      if (np == 0.0) {
         ntarget = prefactor*tasks[i].ntarget + random->uniform();
         ninsert = static_cast<int> (ntarget);
       } else {
         ninsert = npertask;
         if (i >= nthresh) ninsert++;
+        if (npremain_pertask > 0.0)
+          ninsert += static_cast<int> (npremain_pertask + random->uniform());
       }
 
       nactual = 0;
@@ -714,12 +724,14 @@ void FixEmitFace::perform_task_twopass()
         ninsert_values[i][isp] = ninsert;
       }
     } else {
-      if (np == 0) {
+      if (np == 0.0) {
         ntarget = prefactor*tasks[i].ntarget + random->uniform();
         ninsert = static_cast<int> (ntarget);
       } else {
         ninsert = npertask;
         if (i >= nthresh) ninsert++;
+        if (npremain_pertask > 0.0)
+          ninsert += static_cast<int> (npremain_pertask + random->uniform());
       }
       ninsert_values[i][0] = ninsert;
     }
@@ -1173,8 +1185,8 @@ int FixEmitFace::option(int narg, char **arg)
 {
   if (strcmp(arg[0],"n") == 0) {
     if (2 > narg) error->all(FLERR,"Illegal fix emit/face command");
-    np = atoi(arg[1]);
-    if (np <= 0) error->all(FLERR,"Illegal fix emit/face command");
+    np = atof(arg[1]);
+    if (np <= 0.0) error->all(FLERR,"Illegal fix emit/face command");
     return 2;
   }
 

--- a/src/fix_emit_face.h
+++ b/src/fix_emit_face.h
@@ -62,9 +62,11 @@ class FixEmitFace : public FixEmit {
   };
 
  protected:
-  int imix,np,subsonic,subsonic_style,subsonic_warning;
+  int imix,subsonic,subsonic_style,subsonic_warning;
   int faces[6];
   int npertask,nthresh,twopass;
+  double np;             // # of particles to insert per step (n option, may be non-integer)
+  double npremain_pertask;  // fractional remainder of np spread stochastically per task
   double psubsonic,tsubsonic,nsubsonic;
   double tprefactor,soundspeed_mixture;
 

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -1569,8 +1569,9 @@ int FixEmitSurf::option(int narg, char **arg)
       npstr = new char[n];
       strcpy(npstr,&arg[1][2]);
     } else {
-      np = atoi(arg[1]);
-      if (np == 0) npmode = FLOW;
+      np = atof(arg[1]);
+      if (np < 0.0) error->all(FLERR,"Illegal fix emit/surf command");
+      if (np == 0.0) npmode = FLOW;
       else npmode = CONSTANT;
     }
     return 2;

--- a/src/fix_emit_surf.h
+++ b/src/fix_emit_surf.h
@@ -67,7 +67,8 @@ class FixEmitSurf : public FixEmit {
   double psubsonic,tsubsonic,nsubsonic;
   double tprefactor,soundspeed_mixture;
 
-  int npmode,np;    // npmode = FLOW,CONSTANT,VARIABLE
+  int npmode;       // npmode = FLOW,CONSTANT,VARIABLE
+  double np;        // # of particles to insert per step (CONSTANT mode)
   int npvar;
   char *npstr;
 

--- a/src/fix_halt.cpp
+++ b/src/fix_halt.cpp
@@ -28,6 +28,7 @@
 #include "update.h"
 #include "utils.h"
 #include "variable.h"
+#include "sparta_masks.h"
 
 #include <cmath>
 #include <cstring>
@@ -125,6 +126,9 @@ FixHalt::FixHalt(SPARTA *sparta, int narg, char **arg) :
     const bigint nfirst = (update->ntimestep / nevery) * nevery + nevery;
     modify->addstep_compute_all(nfirst);
   }
+
+  datamask_read = EMPTY_MASK;
+  datamask_modify = EMPTY_MASK;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/read_isurf.cpp
+++ b/src/read_isurf.cpp
@@ -246,6 +246,40 @@ void ReadISurf::create_hash(int count)
        if it owns the grid cell, makes copy of the corner pt
 ------------------------------------------------------------------------- */
 
+/* ----------------------------------------------------------------------
+   verify an open isurf corner point file matches the requested grid
+     extent and precision, based on its total size
+   fp is positioned just past the dim-int header on entry;
+     restore that position before returning so the caller can keep reading
+   only called by proc 0
+   isurf files store no precision/format marker, so a wrong precision
+     keyword silently reinterprets the byte stream and otherwise fails
+     later with a confusing error; this gives a clear diagnostic instead
+------------------------------------------------------------------------- */
+
+void ReadISurf::check_file_size(FILE *fp, char *gridfile)
+{
+  bigint ncval = (bigint) (nx+1) * (ny+1);
+  if (dim == 3) ncval *= (nz+1);
+  int vbytes = (precision == DOUBLE) ? sizeof(double) : sizeof(uint8_t);
+  bigint expected = (bigint) dim*sizeof(int) + ncval*vbytes;
+
+  fseek(fp,0,SEEK_END);
+  bigint fsize = (bigint) ftell(fp);
+  fseek(fp,(long) dim*sizeof(int),SEEK_SET);
+
+  if (fsize != expected) {
+    char str[256];
+    snprintf(str,256,"Read_isurf file %s size (" BIGINT_FORMAT " bytes) does "
+             "not match grid extent and precision (" BIGINT_FORMAT
+             " bytes expected); check the precision keyword",
+             gridfile,fsize,expected);
+    error->one(FLERR,str);
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
 void ReadISurf::read_corners_serial(char *gridfile)
 {
   int nchunk,tmp;
@@ -270,6 +304,13 @@ void ReadISurf::read_corners_serial(char *gridfile)
       error->one(FLERR,str);
     }
     tmp = fread(nxyz,sizeof(int),dim,fp);
+
+    // sanity check the file size against the grid extent and precision
+    // isurf files carry no precision marker, so a wrong precision keyword
+    // would otherwise reinterpret the byte stream and fail later with a
+    // misleading error (e.g. "Grid boundary value != 0")
+
+    check_file_size(fp,gridfile);
   }
 
   MPI_Bcast(nxyz,dim,MPI_INT,0,world);
@@ -512,6 +553,11 @@ void ReadISurf::read_corners_parallel(char *gridfile)
       error->one(FLERR,str);
     }
     tmp = fread(nxyz,sizeof(int),dim,fp);
+
+    // sanity check the file size against the grid extent and precision
+    // (see note in read_corners_serial)
+
+    check_file_size(fp,gridfile);
   }
 
   MPI_Bcast(nxyz,dim,MPI_INT,0,world);

--- a/src/read_isurf.h
+++ b/src/read_isurf.h
@@ -85,6 +85,7 @@ class ReadISurf : protected Pointers {
   void process_args(int, char **);
 
   void create_hash(int);
+  void check_file_size(FILE *, char *);
   void read_corners_serial(char *);
   void assign_corners(int, bigint, uint8_t *, double *);
   void read_types_serial(char *);

--- a/src/surf_react_adsorb.cpp
+++ b/src/surf_react_adsorb.cpp
@@ -555,7 +555,7 @@ void SurfReactAdsorb::init()
       int m = 0;
       for (int isurf = me; isurf < nslocal; isurf += nprocs) {
 	isr = lines[isurf].isr;
-	if (surf->sr[isr] == this) {
+	if (isr >= 0 && surf->sr[isr] == this) {
 	  area[m] = surf->line_size(&lines[isurf]);
 	  weight[m] = 1.0;
 	}
@@ -566,7 +566,7 @@ void SurfReactAdsorb::init()
       int m = 0;
       for (int isurf = me; isurf < nslocal; isurf += nprocs) {
 	isr = tris[isurf].isr;
-	if (surf->sr[isr] == this) {
+	if (isr >= 0 && surf->sr[isr] == this) {
 	  area[m] = surf->tri_size(&tris[isurf],tmp);
 	  weight[m] = 1.0;
 	}
@@ -578,7 +578,7 @@ void SurfReactAdsorb::init()
     if (domain->dimension == 2) {
       for (int isurf = 0; isurf < nsown; isurf++) {
 	isr = mylines[isurf].isr;
-	if (surf->sr[isr] != this) continue;
+	if (isr < 0 || surf->sr[isr] != this) continue;
 	area[isurf] = surf->line_size(&mylines[isurf]);
 	weight[isurf] = 1.0;
       }
@@ -586,7 +586,7 @@ void SurfReactAdsorb::init()
       double tmp;
       for (int isurf = 0; isurf < nsown; isurf++) {
 	isr = mytris[isurf].isr;
-	if (surf->sr[isr] != this) continue;
+	if (isr < 0 || surf->sr[isr] != this) continue;
 	area[isurf] = surf->tri_size(&mytris[isurf],tmp);
 	weight[isurf] = 1.0;
       }

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1703,7 +1703,7 @@ void Update::global(int narg, char **arg)
       iarg += 2;
 
     } else if (strcmp(arg[iarg],"field") == 0) {
-      if (iarg+1 > narg) error->all(FLERR,"Illegal global command");
+      if (iarg+2 > narg) error->all(FLERR,"Illegal global command");
       if (strcmp(arg[iarg+1],"none") == 0) {
         fstyle = NOFIELD;
         iarg += 2;

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -53,6 +53,12 @@ enum{NOFIELD,CFIELD,PFIELD,GFIELD};             // several files
 #define MAXSTUCK 20
 #define EPSPARAM 1.0e-7
 
+// max value (bytes) for global_mem_limit = 2000 MiB = 2097152000
+// kept safely below MAXSMALLINT (INT_MAX = 2147483647) so that the buffer-size
+// arithmetic in restart I/O (e.g. "max_size += 128") cannot overflow a 32-bit int
+
+#define MEMLIMIT_MAX (2000*1024*1024)
+
 // either set ID or PROC/INDEX, set other to -1
 
 //#define MOVE_DEBUG 1              // un-comment to debug one particle
@@ -1814,7 +1820,7 @@ void Update::global(int narg, char **arg)
         double factor = input->numeric(FLERR,arg[iarg+1]);
         bigint global_mem_limit_big = static_cast<bigint> (factor * 1024*1024);
         if (global_mem_limit_big < 0) error->all(FLERR,"Illegal global command");
-        if (global_mem_limit_big > MAXSMALLINT)
+        if (global_mem_limit_big > MEMLIMIT_MAX)
           error->all(FLERR,"Global mem/limit setting cannot exceed 2GB");
         global_mem_limit = global_mem_limit_big;
       }
@@ -1885,8 +1891,10 @@ void Update::set_mem_limit_grid(int gnlocal)
 
   bigint global_mem_limit_big = static_cast<bigint> (gnlocal*sizeof(Grid::ChildCell));
 
-  if (global_mem_limit_big > MAXSMALLINT)
-    error->one(FLERR,"Global mem/limit setting cannot exceed 2GB");
+  // cap at 2 GB rather than erroring out so large grids can still be handled
+
+  if (global_mem_limit_big > MEMLIMIT_MAX)
+    global_mem_limit_big = MEMLIMIT_MAX;
 
   global_mem_limit = global_mem_limit_big;
 }

--- a/src/write_isurf.cpp
+++ b/src/write_isurf.cpp
@@ -188,6 +188,15 @@ void WriteISurf::collect_values()
   int ix,iy,iz,index;
   double **array_grid = ablate->array_grid;
 
+  // a multivalue fix ablate (multiple yes / create_isurf multi) stores its
+  // corner state in mvalues, not cvalues, so array_grid is NULL.  isurf files
+  // are single-valued, so error cleanly instead of dereferencing NULL below.
+
+  if (array_grid == NULL)
+    error->all(FLERR,"Write_isurf does not support a multivalue fix ablate "
+               "(multiple yes); its corner state cannot be written to an "
+               "isurf file");
+
   for (int icell = 0; icell < nglocal; icell++) {
     if (!(cinfo[icell].mask & groupbit)) continue;
     if (cells[icell].nsplit <= 0) continue;


### PR DESCRIPTION
## Purpose

Small bugfixes and other changes:

- Fix segfault in fix ablate with variable (v_) decrement source, fixes #657
- Fix NULL array_grid crashes for a multivalue fix ablate, fixes #658
- Guard out-of-bounds surf->sr[isr] reads in SurfReactAdsorb::init, fixes #659
- Validate isurf file size vs grid extent and precision in read_isurf, fixes #660
- Document `push no` for exact write_isurf/read_isurf ablation restarts, fixes #661 
- KOKKOS: fix missing host/device sync in fix ave/grid across grid migration, fixes #662 
- Cap global mem/limit at 2GB via a hard byte constant
- Fix out-of-bounds arg read for "global field" with no fstyle
- cmake: refuse to generate into the SPARTA source tree
- Allow non-integer n in fix emit/surf and fix emit/face, fixes #153
- Ignore FFT_KOKKOS if FFT package is not enabled
- Add missing modify call to Kokkos version
- Disable unneeded data movement in fix halt

## Author(s)

Stan Moore (SNL), Claude Code (Opus 4.8, Opus 5, Fable 5), Upendra Yadav (University of California, Irvine)

## Backward Compatibility

Yes

